### PR TITLE
Support building with Podman instead of Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM docker.io/golang:alpine
 
 WORKDIR /root
 USER root

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@ SHELL := bash
 
 IMAGE_TAG = garm-build
 
+USER_ID=$(shell (docker --version | grep -q podman) && echo "0" || shell id -u)
+USER_GROUP=$(shell (docker --version | grep -q podman) && echo "0" || shell id -g)
+
 build-static:
 	@echo Building garm
 	docker build --tag $(IMAGE_TAG) .
-	docker run --rm -e USER_ID="$(shell id -u)" -e USER_GROUP="$(shell id -g)" -v $(PWD):/build/garm $(IMAGE_TAG) /build-static.sh
+	docker run --rm -e USER_ID=$(USER_ID) -e USER_GROUP=$(USER_GROUP) -v $(PWD):/build/garm $(IMAGE_TAG) /build-static.sh
 	@echo Binaries are available in $(PWD)/bin


### PR DESCRIPTION
When /usr/bin/docker is a wrapper for podman (as common no Fedora),
Podman will be used which requires the full image name including the
registry. It does not require the chown step, because this results in
the files being owned by a temporary mapped ID due to the user
namespace in rootless mode (which is the default unless Podman is run
by the root user) - make the chown a no-op by using UID/GID 0.