### PR TITLE
Refactor code to allow more unit testing

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -150,8 +150,7 @@ type Repository struct {
 	Pools           []Pool `json:"pool,omitempty"`
 	CredentialsName string `json:"credentials_name"`
 	// Do not serialize sensitive info.
-	WebhookSecret string   `json:"-"`
-	Internal      Internal `json:"-"`
+	WebhookSecret string `json:"-"`
 }
 
 type Organization struct {
@@ -160,8 +159,7 @@ type Organization struct {
 	Pools           []Pool `json:"pool,omitempty"`
 	CredentialsName string `json:"credentials_name"`
 	// Do not serialize sensitive info.
-	WebhookSecret string   `json:"-"`
-	Internal      Internal `json:"-"`
+	WebhookSecret string `json:"-"`
 }
 
 // Users holds information about a particular user
@@ -200,5 +198,4 @@ type Provider struct {
 
 type UpdatePoolStateParams struct {
 	WebhookSecret string
-	Internal      Internal
 }

--- a/params/requests.go
+++ b/params/requests.go
@@ -57,7 +57,7 @@ type CreateOrgParams struct {
 
 func (c *CreateOrgParams) Validate() error {
 	if c.Name == "" {
-		return errors.NewBadRequestError("missing repo name")
+		return errors.NewBadRequestError("missing org name")
 	}
 
 	if c.CredentialsName == "" {

--- a/runner/interfaces.go
+++ b/runner/interfaces.go
@@ -1,0 +1,34 @@
+// Copyright 2022 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package runner
+
+import (
+	"context"
+	dbCommon "garm/database/common"
+	"garm/params"
+	"garm/runner/common"
+)
+
+type PoolManagerController interface {
+	CreateRepoPoolManager(ctx context.Context, repo params.Repository, providers map[string]common.Provider, store dbCommon.Store) (common.PoolManager, error)
+	GetRepoPoolManager(repo params.Repository) (common.PoolManager, error)
+	DeleteRepoPoolManager(repo params.Repository) error
+	GetRepoPoolManagers() (map[string]common.PoolManager, error)
+
+	CreateOrgPoolManager(ctx context.Context, org params.Organization, providers map[string]common.Provider, store dbCommon.Store) (common.PoolManager, error)
+	GetOrgPoolManager(org params.Organization) (common.PoolManager, error)
+	DeleteOrgPoolManager(org params.Organization) error
+	GetOrgPoolManagers() (map[string]common.PoolManager, error)
+}


### PR DESCRIPTION
In order to allow mocking for some of the `runner` functions, we created a
separate interface (called `PoolManagerController`) with `Create`, `Get`,
`Delete` operations for the `organization` / `repository` pool managers.

Furthermore, a new runner struct (`poolManagerCtrl`) implements this new
interface. The existing code is refactored to use the `poolManagerCtrl`
whenever the pool managers for `org` / `repo` are handled.

This allows more unit testing for the runner functions since `poolManagerCtrl`
field can be mocked now.

Besides this, there are some typos fixed as well.