### PR TITLE
Cleanup unused struct field and Fix typo

### DIFF
--- a/database/sql/instances.go
+++ b/database/sql/instances.go
@@ -41,7 +41,7 @@ func (s *sqlDatabase) CreateInstance(ctx context.Context, poolID string, param p
 	}
 	q := s.conn.Create(&newInstance)
 	if q.Error != nil {
-		return params.Instance{}, errors.Wrap(q.Error, "creating repository")
+		return params.Instance{}, errors.Wrap(q.Error, "creating instance")
 	}
 
 	return s.sqlToParamsInstance(newInstance), nil

--- a/database/sql/instances.go
+++ b/database/sql/instances.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (s *sqlDatabase) CreateInstance(ctx context.Context, poolID string, param params.CreateInstanceParams) (params.Instance, error) {
-	pool, err := s.getPoolByID(ctx, param.Pool)
+	pool, err := s.getPoolByID(ctx, poolID)
 	if err != nil {
 		return params.Instance{}, errors.Wrap(err, "fetching pool")
 	}

--- a/database/sql/instances_test.go
+++ b/database/sql/instances_test.go
@@ -77,7 +77,6 @@ func (s *InstancesTestSuite) SetupTest() {
 				OSType:      "linux",
 				OSArch:      "amd64",
 				CallbackURL: "https://garm.example.com/",
-				Pool:        pool.ID,
 			},
 		)
 		if err != nil {
@@ -103,7 +102,6 @@ func (s *InstancesTestSuite) TestCreateInstance() {
 		OSType:      "linux",
 		OSArch:      "amd64",
 		CallbackURL: "https://garm.example.com/",
-		Pool:        s.Fixtures.Pool.ID,
 	}
 
 	// call tested function

--- a/params/requests.go
+++ b/params/requests.go
@@ -97,8 +97,6 @@ type CreateInstanceParams struct {
 	RunnerStatus  common.RunnerStatus
 	CallbackURL   string
 	CreateAttempt int `json:"-"`
-
-	Pool string
 }
 
 type CreatePoolParams struct {

--- a/runner/organizations_test.go
+++ b/runner/organizations_test.go
@@ -465,7 +465,6 @@ func (s *OrgTestSuite) TestDeleteOrgPoolRunnersFailed() {
 	if err != nil {
 		s.FailNow(fmt.Sprintf("cannot create org pool: %v", err))
 	}
-	s.Fixtures.CreateInstanceParams.Pool = pool.ID
 	instance, err := s.Fixtures.Store.CreateInstance(s.Fixtures.AdminContext, pool.ID, s.Fixtures.CreateInstanceParams)
 	if err != nil {
 		s.FailNow(fmt.Sprintf("cannot create instance: %s", err))
@@ -539,7 +538,6 @@ func (s *OrgTestSuite) TestListOrgInstances() {
 		s.FailNow(fmt.Sprintf("cannot create org pool: %v", err))
 	}
 	poolInstances := []params.Instance{}
-	s.Fixtures.CreateInstanceParams.Pool = pool.ID
 	for i := 1; i <= 3; i++ {
 		s.Fixtures.CreateInstanceParams.Name = fmt.Sprintf("test-org-%v", i)
 		instance, err := s.Fixtures.Store.CreateInstance(s.Fixtures.AdminContext, pool.ID, s.Fixtures.CreateInstanceParams)

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -316,7 +316,6 @@ func (r *basePool) AddRunner(ctx context.Context, poolID string) error {
 
 	createParams := params.CreateInstanceParams{
 		Name:          name,
-		Pool:          poolID,
 		Status:        providerCommon.InstancePendingCreate,
 		RunnerStatus:  providerCommon.RunnerPending,
 		OSArch:        pool.OSArch,

--- a/runner/repositories_test.go
+++ b/runner/repositories_test.go
@@ -467,7 +467,6 @@ func (s *RepoTestSuite) TestDeleteRepoPoolRunnersFailed() {
 	if err != nil {
 		s.FailNow(fmt.Sprintf("cannot create repo pool: %s", err))
 	}
-	s.Fixtures.CreateInstanceParams.Pool = pool.ID
 	instance, err := s.Fixtures.Store.CreateInstance(s.Fixtures.AdminContext, pool.ID, s.Fixtures.CreateInstanceParams)
 	if err != nil {
 		s.FailNow(fmt.Sprintf("cannot create instance: %s", err))
@@ -507,7 +506,6 @@ func (s *RepoTestSuite) TestListPoolInstances() {
 		s.FailNow(fmt.Sprintf("cannot create repo pool: %v", err))
 	}
 	poolInstances := []params.Instance{}
-	s.Fixtures.CreateInstanceParams.Pool = pool.ID
 	for i := 1; i <= 3; i++ {
 		s.Fixtures.CreateInstanceParams.Name = fmt.Sprintf("test-repo-%v", i)
 		instance, err := s.Fixtures.Store.CreateInstance(s.Fixtures.AdminContext, pool.ID, s.Fixtures.CreateInstanceParams)
@@ -569,7 +567,6 @@ func (s *RepoTestSuite) TestListRepoInstances() {
 		s.FailNow(fmt.Sprintf("cannot create repo pool: %v", err))
 	}
 	poolInstances := []params.Instance{}
-	s.Fixtures.CreateInstanceParams.Pool = pool.ID
 	for i := 1; i <= 3; i++ {
 		s.Fixtures.CreateInstanceParams.Name = fmt.Sprintf("test-repo-%v", i)
 		instance, err := s.Fixtures.Store.CreateInstance(s.Fixtures.AdminContext, pool.ID, s.Fixtures.CreateInstanceParams)


### PR DESCRIPTION
* Cleanup unused struct field
  * Remove `Pool` field from `CreateInstanceParams` struct, because
this is given as a separate parameter to the `CreateInstance` function.
* Fix typo