### PR TITLE
Attempt to fetch runner name from API

### DIFF
--- a/runner/common/util.go
+++ b/runner/common/util.go
@@ -9,6 +9,8 @@ import (
 // GithubClient that describes the minimum list of functions we need to interact with github.
 // Allows for easier testing.
 type GithubClient interface {
+	// GetWorkflowJobByID gets details about a single workflow job.
+	GetWorkflowJobByID(ctx context.Context, owner, repo string, jobID int64) (*github.WorkflowJob, *github.Response, error)
 	// ListRunners lists all runners within a repository.
 	ListRunners(ctx context.Context, owner, repo string, opts *github.ListOptions) (*github.Runners, *github.Response, error)
 	// ListRunnerApplicationDownloads returns a list of github runner application downloads for the
@@ -18,6 +20,7 @@ type GithubClient interface {
 	RemoveRunner(ctx context.Context, owner, repo string, runnerID int64) (*github.Response, error)
 	// CreateRegistrationToken creates a runner registration token for one repository.
 	CreateRegistrationToken(ctx context.Context, owner, repo string) (*github.RegistrationToken, *github.Response, error)
+
 	// ListOrganizationRunners lists all runners within an organization.
 	ListOrganizationRunners(ctx context.Context, owner string, opts *github.ListOptions) (*github.Runners, *github.Response, error)
 	// ListOrganizationRunnerApplicationDownloads returns a list of github runner application downloads for the

--- a/runner/pool/interfaces.go
+++ b/runner/pool/interfaces.go
@@ -37,5 +37,6 @@ type poolHelper interface {
 	ValidateOwner(job params.WorkflowJob) error
 	UpdateState(param params.UpdatePoolStateParams) error
 	WebhookSecret() string
+	GetRunnerNameFromWorkflow(job params.WorkflowJob) (string, error)
 	ID() string
 }

--- a/runner/pool/organization.go
+++ b/runner/pool/organization.go
@@ -71,6 +71,17 @@ type organization struct {
 	mux sync.Mutex
 }
 
+func (r *organization) GetRunnerNameFromWorkflow(job params.WorkflowJob) (string, error) {
+	workflow, _, err := r.ghcli.GetWorkflowJobByID(r.ctx, job.Organization.Login, job.Repository.Name, job.WorkflowJob.ID)
+	if err != nil {
+		return "", errors.Wrap(err, "fetching workflow info")
+	}
+	if workflow.RunnerName != nil {
+		return *workflow.RunnerName, nil
+	}
+	return "", fmt.Errorf("failed to find runner name from workflow")
+}
+
 func (r *organization) UpdateState(param params.UpdatePoolStateParams) error {
 	r.mux.Lock()
 	defer r.mux.Unlock()
@@ -143,7 +154,7 @@ func (r *organization) GetGithubRegistrationToken() (string, error) {
 }
 
 func (r *organization) String() string {
-	return fmt.Sprintf("%s", r.cfg.Name)
+	return r.cfg.Name
 }
 
 func (r *organization) WebhookSecret() string {

--- a/runner/pool/repository.go
+++ b/runner/pool/repository.go
@@ -73,6 +73,17 @@ type repository struct {
 	mux sync.Mutex
 }
 
+func (r *repository) GetRunnerNameFromWorkflow(job params.WorkflowJob) (string, error) {
+	workflow, _, err := r.ghcli.GetWorkflowJobByID(r.ctx, job.Repository.Owner.Login, job.Repository.Name, job.WorkflowJob.ID)
+	if err != nil {
+		return "", errors.Wrap(err, "fetching workflow info")
+	}
+	if workflow.RunnerName != nil {
+		return *workflow.RunnerName, nil
+	}
+	return "", fmt.Errorf("failed to find runner name from workflow")
+}
+
 func (r *repository) UpdateState(param params.UpdatePoolStateParams) error {
 	r.mux.Lock()
 	defer r.mux.Unlock()


### PR DESCRIPTION
In some cases, runner information is not sent via webhook by Github when a workflow job transitions to in_progress. We need to know the runner name in order to update the state in the database. Attempt to fetch the runner from the API using the workflow ID.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>