### PR TITLE
Add link to `Go Tests` README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #  GitHub Actions Runners Manager (garm)
 
-![Go Tests](https://github.com/cloudbase/garm/actions/workflows/go-tests.yml/badge.svg)
+[![Go Tests](https://github.com/cloudbase/garm/actions/workflows/go-tests.yml/badge.svg)](https://github.com/cloudbase/garm/actions/workflows/go-tests.yml)
 
 Welcome to garm!
 


### PR DESCRIPTION
Make sure that the README `Go Test` badge has a link to the GitHub page with latest workflow results.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>