### PR TITLE
Fixed error wrap

### DIFF
--- a/database/sql/organizations.go
+++ b/database/sql/organizations.go
@@ -117,7 +117,7 @@ func (s *sqlDatabase) UpdateOrganization(ctx context.Context, orgID string, para
 
 	q := s.conn.Save(&org)
 	if q.Error != nil {
-		return params.Organization{}, errors.Wrap(err, "saving org")
+		return params.Organization{}, errors.Wrap(q.Error, "saving org")
 	}
 
 	newParams := s.sqlToCommonOrganization(org)
@@ -188,7 +188,7 @@ func (s *sqlDatabase) CreateOrganizationPool(ctx context.Context, orgId string, 
 
 	q := s.conn.Create(&newPool)
 	if q.Error != nil {
-		return params.Pool{}, errors.Wrap(err, "adding pool")
+		return params.Pool{}, errors.Wrap(q.Error, "adding pool")
 	}
 
 	for _, tt := range tags {


### PR DESCRIPTION
The error is not wrapped correctly, because instead of using `q.Error`, it uses `err`, which is defined elsewhere.

Also, the `UpdateOrganization` and `CreateOrganizationPool` functions will never fail on update/create org, because it returns a nil error, instead of wrap error.

Signed-off-by: Mihaela Balutoiu <mbalutoiu@cloudbasesolutions.com>