### PR TITLE
Fix azure and openstack external providers

### DIFF
--- a/contrib/providers.d/azure/cloudconfig/install_runner.tpl
+++ b/contrib/providers.d/azure/cloudconfig/install_runner.tpl
@@ -59,7 +59,7 @@ sendStatus "starting service"
 ./svc.sh start || fail "failed to start service"
 
 set +e
-AGENT_ID=$(grep "agentId" /home/{{ .RunnerUsername }}/actions-runner/.runner |  tr -d -c 0-9)
+AGENT_ID=$(grep "agentId" /home/runner/actions-runner/.runner |  tr -d -c 0-9)
 if [ $? -ne 0 ];then
 	fail "failed to get agent ID"
 fi

--- a/contrib/providers.d/openstack/cloudconfig/install_runner.tpl
+++ b/contrib/providers.d/openstack/cloudconfig/install_runner.tpl
@@ -59,7 +59,7 @@ sendStatus "starting service"
 ./svc.sh start || fail "failed to start service"
 
 set +e
-AGENT_ID=$(grep "agentId" /home/{{ .RunnerUsername }}/actions-runner/.runner |  tr -d -c 0-9)
+AGENT_ID=$(grep "agentId" /home/runner/actions-runner/.runner |  tr -d -c 0-9)
 if [ $? -ne 0 ];then
 	fail "failed to get agent ID"
 fi

--- a/contrib/providers.d/openstack/garm-external-provider
+++ b/contrib/providers.d/openstack/garm-external-provider
@@ -275,7 +275,7 @@ function CreateInstance() {
     checkValNotNull "${VERSION}" "os_version" || return $?
     ARCH=$(echo "${IMAGE_DETAILS}" | jq -c -r '.properties.architecture')
     checkValNotNull "${ARCH}" "architecture" || return $?
-    GH_ARCH=OS_TO_GH_ARCH_MAP[${ARCH}]
+    GH_ARCH=${OS_TO_GH_ARCH_MAP[${ARCH}]}
 
     if [ -z "${GH_ARCH}" ];then
         GH_ARCH=${ARCH}


### PR DESCRIPTION
* The `{{ .RunnerUsername }}` is not replaced in any external providers' scripts.
   However, we can safely assume that the username is properly created by cloud-init before the userdata is executed.
* Correctly use the `OS_TO_GH_ARCH_MAP` bash map.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>