### PR TITLE
feat: scale down idle runners

### DIFF
--- a/runner/common/pool.go
+++ b/runner/common/pool.go
@@ -25,6 +25,7 @@ const (
 	RepositoryPool   PoolType = "repository"
 	OrganizationPool PoolType = "organization"
 
+	PoolScaleDownInterval     = 1 * time.Minute
 	PoolConsilitationInterval = 5 * time.Second
 	PoolReapTimeoutInterval   = 5 * time.Minute
 	// Temporary tools download token is valid for 1 hour by default.


### PR DESCRIPTION
This automatically scales down superfluous runners.

There are a number of scenarios where we end up with more runners than the idle pool size.
E.g. when you change the min_pool_size ..

This PR is an example of how we could scale down runners that are not needed at the moment.
What do you think? 

The runners are deleted not all at once but each `PoolScaleDownInterval` half of the surplus is deleted until we hit `min_idle_runners`

So far, neither the Iterval (1 Minute) nor the percentage of runners to be removed is configurable.

<sub>Michael Kuhnt <michael.kuhnt@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))
</sub>