### PR TITLE
Fix webhook signature validation

### DIFF
--- a/database/sql/enterprise_test.go
+++ b/database/sql/enterprise_test.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"testing"
 
 	dbCommon "garm/database/common"
 	runnerErrors "garm/errors"
 	garmTesting "garm/internal/testing"
 	"garm/params"
-	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -194,7 +194,7 @@ func (s *EnterpriseTestSuite) TestCreateEnterpriseInvalidDBPassphrase() {
 		s.Fixtures.CreateEnterpriseParams.WebhookSecret)
 
 	s.Require().NotNil(err)
-	s.Require().Equal("failed to encrypt string", err.Error())
+	s.Require().Equal("encoding secret: invalid passphrase length (expected length 32 characters)", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestCreateEnterpriseDBCreateErr() {
@@ -238,16 +238,16 @@ func (s *EnterpriseTestSuite) TestGetEnterpriseNotFound() {
 }
 
 func (s *EnterpriseTestSuite) TestGetEnterpriseDBDecryptingErr() {
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE name = ? COLLATE NOCASE AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
-		WithArgs(s.Fixtures.Enterprises[0].Name).
-		WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow(s.Fixtures.Enterprises[0].Name))
+	// s.Fixtures.SQLMock.
+	//	ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE name = ? COLLATE NOCASE AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
+	//	WithArgs(s.Fixtures.Enterprises[0].Name).
+	//	WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow(s.Fixtures.Enterprises[0].Name))
 
-	_, err := s.StoreSQLMocked.GetEnterprise(context.Background(), s.Fixtures.Enterprises[0].Name)
+	//_, err := s.StoreSQLMocked.GetEnterprise(context.Background(), s.Fixtures.Enterprises[0].Name)
 
-	s.assertSQLMockExpectations()
-	s.Require().NotNil(err)
-	s.Require().Equal("decrypting secret: failed to decrypt text", err.Error())
+	// s.assertSQLMockExpectations()
+	// s.Require().NotNil(err)
+	// s.Require().Equal("decrypting secret: failed to decrypt text", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestListEnterprises() {
@@ -266,7 +266,7 @@ func (s *EnterpriseTestSuite) TestListEnterprisesDBFetchErr() {
 
 	s.assertSQLMockExpectations()
 	s.Require().NotNil(err)
-	s.Require().Equal("fetching enterprise from database: fetching user from database mock error", err.Error())
+	s.Require().Equal("fetching enterprises: fetching user from database mock error", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestDeleteEnterprise() {
@@ -331,7 +331,7 @@ func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBEncryptErr() {
 
 	s.assertSQLMockExpectations()
 	s.Require().NotNil(err)
-	s.Require().Equal("failed to encrypt string", err.Error())
+	s.Require().Equal("encoding secret: invalid passphrase length (expected length 32 characters)", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBSaveErr() {
@@ -353,24 +353,24 @@ func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBSaveErr() {
 }
 
 func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBDecryptingErr() {
-	s.StoreSQLMocked.cfg.Passphrase = "wrong-passphrase"
-	s.Fixtures.UpdateRepoParams.WebhookSecret = ""
+	// s.StoreSQLMocked.cfg.Passphrase = "wrong-passphrase"
+	// s.Fixtures.UpdateRepoParams.WebhookSecret = ""
 
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
-		WithArgs(s.Fixtures.Enterprises[0].ID).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
-	s.Fixtures.SQLMock.ExpectBegin()
-	s.Fixtures.SQLMock.
-		ExpectExec(("UPDATE `enterprises` SET")).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	s.Fixtures.SQLMock.ExpectCommit()
+	// s.Fixtures.SQLMock.
+	// 	ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
+	// 	WithArgs(s.Fixtures.Enterprises[0].ID).
+	// 	WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
+	// s.Fixtures.SQLMock.ExpectBegin()
+	// s.Fixtures.SQLMock.
+	// 	ExpectExec(("UPDATE `enterprises` SET")).
+	// 	WillReturnResult(sqlmock.NewResult(1, 1))
+	// s.Fixtures.SQLMock.ExpectCommit()
 
-	_, err := s.StoreSQLMocked.UpdateEnterprise(context.Background(), s.Fixtures.Enterprises[0].ID, s.Fixtures.UpdateRepoParams)
+	// _, err := s.StoreSQLMocked.UpdateEnterprise(context.Background(), s.Fixtures.Enterprises[0].ID, s.Fixtures.UpdateRepoParams)
 
-	s.assertSQLMockExpectations()
-	s.Require().NotNil(err)
-	s.Require().Equal("decrypting secret: invalid passphrase length (expected length 32 characters)", err.Error())
+	// s.assertSQLMockExpectations()
+	// s.Require().NotNil(err)
+	// s.Require().Equal("decrypting secret: invalid passphrase length (expected length 32 characters)", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestGetEnterpriseByID() {
@@ -388,20 +388,20 @@ func (s *EnterpriseTestSuite) TestGetEnterpriseByIDInvalidEnterpriseID() {
 }
 
 func (s *EnterpriseTestSuite) TestGetEnterpriseByIDDBDecryptingErr() {
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
-		WithArgs(s.Fixtures.Enterprises[0].ID).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE `pools`.`enterprise_id` = ? AND `pools`.`deleted_at` IS NULL")).
-		WithArgs(s.Fixtures.Enterprises[0].ID).
-		WillReturnRows(sqlmock.NewRows([]string{"enterprise_id"}).AddRow(s.Fixtures.Enterprises[0].ID))
+	// s.Fixtures.SQLMock.
+	// 	ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
+	// 	WithArgs(s.Fixtures.Enterprises[0].ID).
+	// 	WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
+	// s.Fixtures.SQLMock.
+	// 	ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE `pools`.`enterprise_id` = ? AND `pools`.`deleted_at` IS NULL")).
+	// 	WithArgs(s.Fixtures.Enterprises[0].ID).
+	// 	WillReturnRows(sqlmock.NewRows([]string{"enterprise_id"}).AddRow(s.Fixtures.Enterprises[0].ID))
 
-	_, err := s.StoreSQLMocked.GetEnterpriseByID(context.Background(), s.Fixtures.Enterprises[0].ID)
+	// _, err := s.StoreSQLMocked.GetEnterpriseByID(context.Background(), s.Fixtures.Enterprises[0].ID)
 
-	s.assertSQLMockExpectations()
-	s.Require().NotNil(err)
-	s.Require().Equal("decrypting secret: failed to decrypt text", err.Error())
+	// s.assertSQLMockExpectations()
+	// s.Require().NotNil(err)
+	// s.Require().Equal("decrypting secret: failed to decrypt text", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestCreateEnterprisePool() {

--- a/database/sql/enterprise_test.go
+++ b/database/sql/enterprise_test.go
@@ -238,16 +238,16 @@ func (s *EnterpriseTestSuite) TestGetEnterpriseNotFound() {
 }
 
 func (s *EnterpriseTestSuite) TestGetEnterpriseDBDecryptingErr() {
-	// s.Fixtures.SQLMock.
-	//	ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE name = ? COLLATE NOCASE AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
-	//	WithArgs(s.Fixtures.Enterprises[0].Name).
-	//	WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow(s.Fixtures.Enterprises[0].Name))
+	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE name = ? COLLATE NOCASE AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
+		WithArgs(s.Fixtures.Enterprises[0].Name).
+		WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow(s.Fixtures.Enterprises[0].Name))
 
-	//_, err := s.StoreSQLMocked.GetEnterprise(context.Background(), s.Fixtures.Enterprises[0].Name)
+	_, err := s.StoreSQLMocked.GetEnterprise(context.Background(), s.Fixtures.Enterprises[0].Name)
 
-	// s.assertSQLMockExpectations()
-	// s.Require().NotNil(err)
-	// s.Require().Equal("decrypting secret: failed to decrypt text", err.Error())
+	s.assertSQLMockExpectations()
+	s.Require().NotNil(err)
+	s.Require().Equal("fetching enterprise: missing secret", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestListEnterprises() {
@@ -353,24 +353,19 @@ func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBSaveErr() {
 }
 
 func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBDecryptingErr() {
-	// s.StoreSQLMocked.cfg.Passphrase = "wrong-passphrase"
-	// s.Fixtures.UpdateRepoParams.WebhookSecret = ""
+	s.StoreSQLMocked.cfg.Passphrase = "wrong-passphrase"
+	s.Fixtures.UpdateRepoParams.WebhookSecret = "some-webhook-secret"
 
-	// s.Fixtures.SQLMock.
-	// 	ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
-	// 	WithArgs(s.Fixtures.Enterprises[0].ID).
-	// 	WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
-	// s.Fixtures.SQLMock.ExpectBegin()
-	// s.Fixtures.SQLMock.
-	// 	ExpectExec(("UPDATE `enterprises` SET")).
-	// 	WillReturnResult(sqlmock.NewResult(1, 1))
-	// s.Fixtures.SQLMock.ExpectCommit()
+	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
+		WithArgs(s.Fixtures.Enterprises[0].ID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
 
-	// _, err := s.StoreSQLMocked.UpdateEnterprise(context.Background(), s.Fixtures.Enterprises[0].ID, s.Fixtures.UpdateRepoParams)
+	_, err := s.StoreSQLMocked.UpdateEnterprise(context.Background(), s.Fixtures.Enterprises[0].ID, s.Fixtures.UpdateRepoParams)
 
-	// s.assertSQLMockExpectations()
-	// s.Require().NotNil(err)
-	// s.Require().Equal("decrypting secret: invalid passphrase length (expected length 32 characters)", err.Error())
+	s.assertSQLMockExpectations()
+	s.Require().NotNil(err)
+	s.Require().Equal("encoding secret: invalid passphrase length (expected length 32 characters)", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestGetEnterpriseByID() {
@@ -388,20 +383,20 @@ func (s *EnterpriseTestSuite) TestGetEnterpriseByIDInvalidEnterpriseID() {
 }
 
 func (s *EnterpriseTestSuite) TestGetEnterpriseByIDDBDecryptingErr() {
-	// s.Fixtures.SQLMock.
-	// 	ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
-	// 	WithArgs(s.Fixtures.Enterprises[0].ID).
-	// 	WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
-	// s.Fixtures.SQLMock.
-	// 	ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE `pools`.`enterprise_id` = ? AND `pools`.`deleted_at` IS NULL")).
-	// 	WithArgs(s.Fixtures.Enterprises[0].ID).
-	// 	WillReturnRows(sqlmock.NewRows([]string{"enterprise_id"}).AddRow(s.Fixtures.Enterprises[0].ID))
+	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).
+		WithArgs(s.Fixtures.Enterprises[0].ID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
+	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE `pools`.`enterprise_id` = ? AND `pools`.`deleted_at` IS NULL")).
+		WithArgs(s.Fixtures.Enterprises[0].ID).
+		WillReturnRows(sqlmock.NewRows([]string{"enterprise_id"}).AddRow(s.Fixtures.Enterprises[0].ID))
 
-	// _, err := s.StoreSQLMocked.GetEnterpriseByID(context.Background(), s.Fixtures.Enterprises[0].ID)
+	_, err := s.StoreSQLMocked.GetEnterpriseByID(context.Background(), s.Fixtures.Enterprises[0].ID)
 
-	// s.assertSQLMockExpectations()
-	// s.Require().NotNil(err)
-	// s.Require().Equal("decrypting secret: failed to decrypt text", err.Error())
+	s.assertSQLMockExpectations()
+	s.Require().NotNil(err)
+	s.Require().Equal("fetching enterprise: missing secret", err.Error())
 }
 
 func (s *EnterpriseTestSuite) TestCreateEnterprisePool() {

--- a/database/sql/enterprise_test.go
+++ b/database/sql/enterprise_test.go
@@ -354,7 +354,7 @@ func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBSaveErr() {
 
 func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBDecryptingErr() {
 	s.StoreSQLMocked.cfg.Passphrase = "wrong-passphrase"
-	s.Fixtures.UpdateRepoParams.WebhookSecret = "some-webhook-secret"
+	s.Fixtures.UpdateRepoParams.WebhookSecret = "webhook-secret"
 
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE id = ? AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT 1")).

--- a/database/sql/organizations_test.go
+++ b/database/sql/organizations_test.go
@@ -354,7 +354,7 @@ func (s *OrgTestSuite) TestUpdateOrganizationDBSaveErr() {
 
 func (s *OrgTestSuite) TestUpdateOrganizationDBDecryptingErr() {
 	s.StoreSQLMocked.cfg.Passphrase = "wrong-passphrase"
-	s.Fixtures.UpdateRepoParams.WebhookSecret = "some-webhook-secret"
+	s.Fixtures.UpdateRepoParams.WebhookSecret = "webhook-secret"
 
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE id = ? AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT 1")).

--- a/database/sql/organizations_test.go
+++ b/database/sql/organizations_test.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"testing"
 
 	dbCommon "garm/database/common"
 	runnerErrors "garm/errors"
 	garmTesting "garm/internal/testing"
 	"garm/params"
-	"testing"
 
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -247,7 +247,7 @@ func (s *OrgTestSuite) TestGetOrganizationDBDecryptingErr() {
 
 	s.assertSQLMockExpectations()
 	s.Require().NotNil(err)
-	s.Require().Equal("decrypting secret: failed to decrypt text", err.Error())
+	s.Require().Equal("fetching org: missing secret", err.Error())
 }
 
 func (s *OrgTestSuite) TestListOrganizations() {
@@ -331,7 +331,7 @@ func (s *OrgTestSuite) TestUpdateOrganizationDBEncryptErr() {
 
 	s.assertSQLMockExpectations()
 	s.Require().NotNil(err)
-	s.Require().Equal("failed to encrypt string", err.Error())
+	s.Require().Equal("saving org: failed to encrypt string: invalid passphrase length (expected length 32 characters)", err.Error())
 }
 
 func (s *OrgTestSuite) TestUpdateOrganizationDBSaveErr() {
@@ -354,23 +354,18 @@ func (s *OrgTestSuite) TestUpdateOrganizationDBSaveErr() {
 
 func (s *OrgTestSuite) TestUpdateOrganizationDBDecryptingErr() {
 	s.StoreSQLMocked.cfg.Passphrase = "wrong-passphrase"
-	s.Fixtures.UpdateRepoParams.WebhookSecret = ""
+	s.Fixtures.UpdateRepoParams.WebhookSecret = "some-webhook-secret"
 
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE id = ? AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT 1")).
 		WithArgs(s.Fixtures.Orgs[0].ID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
-	s.Fixtures.SQLMock.ExpectBegin()
-	s.Fixtures.SQLMock.
-		ExpectExec(("UPDATE `organizations` SET")).
-		WillReturnResult(sqlmock.NewResult(1, 1))
-	s.Fixtures.SQLMock.ExpectCommit()
 
 	_, err := s.StoreSQLMocked.UpdateOrganization(context.Background(), s.Fixtures.Orgs[0].ID, s.Fixtures.UpdateRepoParams)
 
 	s.assertSQLMockExpectations()
 	s.Require().NotNil(err)
-	s.Require().Equal("decrypting secret: invalid passphrase length (expected length 32 characters)", err.Error())
+	s.Require().Equal("saving org: failed to encrypt string: invalid passphrase length (expected length 32 characters)", err.Error())
 }
 
 func (s *OrgTestSuite) TestGetOrganizationByID() {
@@ -401,7 +396,7 @@ func (s *OrgTestSuite) TestGetOrganizationByIDDBDecryptingErr() {
 
 	s.assertSQLMockExpectations()
 	s.Require().NotNil(err)
-	s.Require().Equal("decrypting secret: failed to decrypt text", err.Error())
+	s.Require().Equal("fetching enterprise: missing secret", err.Error())
 }
 
 func (s *OrgTestSuite) TestCreateOrganizationPool() {

--- a/database/sql/repositories_test.go
+++ b/database/sql/repositories_test.go
@@ -392,7 +392,7 @@ func (s *RepoTestSuite) TestUpdateRepositoryDBSaveErr() {
 
 func (s *RepoTestSuite) TestUpdateRepositoryDBDecryptingErr() {
 	s.StoreSQLMocked.cfg.Passphrase = "wrong-passphrase"
-	s.Fixtures.UpdateRepoParams.WebhookSecret = "some-webhook-secret"
+	s.Fixtures.UpdateRepoParams.WebhookSecret = "webhook-secret"
 
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `repositories` WHERE id = ? AND `repositories`.`deleted_at` IS NULL ORDER BY `repositories`.`id` LIMIT 1")).

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -55,6 +55,20 @@ type ProviderError struct {
 	baseError
 }
 
+// NewMissingSecretError returns a new MissingSecretError
+func NewMissingSecretError(msg string, a ...interface{}) error {
+	return &MissingSecretError{
+		baseError{
+			msg: fmt.Sprintf(msg, a...),
+		},
+	}
+}
+
+// MissingSecretError is returned the secret to validate a webhook is missing
+type MissingSecretError struct {
+	baseError
+}
+
 // NewUnauthorizedError returns a new UnauthorizedError
 func NewUnauthorizedError(msg string) error {
 	return &UnauthorizedError{

--- a/params/requests.go
+++ b/params/requests.go
@@ -16,6 +16,7 @@ package params
 
 import (
 	"fmt"
+
 	"garm/config"
 	"garm/errors"
 	"garm/runner/providers/common"
@@ -48,6 +49,9 @@ func (c *CreateRepoParams) Validate() error {
 	if c.CredentialsName == "" {
 		return errors.NewBadRequestError("missing credentials name")
 	}
+	if c.WebhookSecret == "" {
+		return errors.NewMissingSecretError("missing secret")
+	}
 	return nil
 }
 
@@ -65,6 +69,9 @@ func (c *CreateOrgParams) Validate() error {
 	if c.CredentialsName == "" {
 		return errors.NewBadRequestError("missing credentials name")
 	}
+	if c.WebhookSecret == "" {
+		return errors.NewMissingSecretError("missing secret")
+	}
 	return nil
 }
 
@@ -78,9 +85,11 @@ func (c *CreateEnterpriseParams) Validate() error {
 	if c.Name == "" {
 		return errors.NewBadRequestError("missing enterprise name")
 	}
-
 	if c.CredentialsName == "" {
 		return errors.NewBadRequestError("missing credentials name")
+	}
+	if c.WebhookSecret == "" {
+		return errors.NewMissingSecretError("missing secret")
 	}
 	return nil
 }

--- a/runner/enterprises_test.go
+++ b/runner/enterprises_test.go
@@ -17,6 +17,8 @@ package runner
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"garm/auth"
 	"garm/config"
 	"garm/database"
@@ -27,7 +29,6 @@ import (
 	"garm/runner/common"
 	runnerCommonMocks "garm/runner/common/mocks"
 	runnerMocks "garm/runner/mocks"
-	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -106,6 +107,7 @@ func (s *EnterpriseTestSuite) SetupTest() {
 		CreateEnterpriseParams: params.CreateEnterpriseParams{
 			Name:            "test-enterprise-create",
 			CredentialsName: "test-creds",
+			WebhookSecret:   "test-create-enterprise-webhook-secret",
 		},
 		CreatePoolParams: params.CreatePoolParams{
 			ProviderName:           "test-provider",

--- a/runner/organizations_test.go
+++ b/runner/organizations_test.go
@@ -17,6 +17,8 @@ package runner
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"garm/auth"
 	"garm/config"
 	"garm/database"
@@ -27,7 +29,6 @@ import (
 	"garm/runner/common"
 	runnerCommonMocks "garm/runner/common/mocks"
 	runnerMocks "garm/runner/mocks"
-	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -106,6 +107,7 @@ func (s *OrgTestSuite) SetupTest() {
 		CreateOrgParams: params.CreateOrgParams{
 			Name:            "test-org-create",
 			CredentialsName: "test-creds",
+			WebhookSecret:   "test-create-org-webhook-secret",
 		},
 		CreatePoolParams: params.CreatePoolParams{
 			ProviderName:           "test-provider",

--- a/runner/repositories_test.go
+++ b/runner/repositories_test.go
@@ -17,6 +17,8 @@ package runner
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"garm/auth"
 	"garm/config"
 	"garm/database"
@@ -27,7 +29,6 @@ import (
 	"garm/runner/common"
 	runnerCommonMocks "garm/runner/common/mocks"
 	runnerMocks "garm/runner/mocks"
-	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -106,6 +107,7 @@ func (s *RepoTestSuite) SetupTest() {
 			Owner:           "test-owner-create",
 			Name:            "test-repo-create",
 			CredentialsName: "test-creds",
+			WebhookSecret:   "test-create-repo-webhook-secret",
 		},
 		CreatePoolParams: params.CreatePoolParams{
 			ProviderName:           "test-provider",
@@ -404,6 +406,7 @@ func (s *RepoTestSuite) TestGetRepoPoolByIDErrUnauthorized() {
 
 	s.Require().Equal(runnerErrors.ErrUnauthorized, err)
 }
+
 func (s *RepoTestSuite) TestDeleteRepoPool() {
 	pool, err := s.Fixtures.Store.CreateRepositoryPool(s.Fixtures.AdminContext, s.Fixtures.StoreRepos["test-repo-1"].ID, s.Fixtures.CreatePoolParams)
 	if err != nil {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -381,7 +381,6 @@ func (r *Runner) Start() error {
 		go func(repo common.PoolManager) {
 			err := repo.Start()
 			errChan <- err
-
 		}(repo)
 	}
 
@@ -390,7 +389,6 @@ func (r *Runner) Start() error {
 			err := org.Start()
 			errChan <- err
 		}(org)
-
 	}
 
 	for _, enterprise := range enterprises {
@@ -398,7 +396,6 @@ func (r *Runner) Start() error {
 			err := org.Start()
 			errChan <- err
 		}(enterprise)
-
 	}
 
 	for i := 0; i < expectedReplies; i++ {
@@ -542,8 +539,7 @@ func (r *Runner) Wait() error {
 
 func (r *Runner) validateHookBody(signature, secret string, body []byte) error {
 	if secret == "" {
-		// A secret was not set. Skip validation of body.
-		return nil
+		return runnerErrors.NewMissingSecretError("missing secret to validate webhook signature")
 	}
 
 	if signature == "" {


### PR DESCRIPTION
Webhooks seemed never to be validated (see behaviour for empty secret in [runner.go#L544-547](https://github.com/cloudbase/garm/blob/main/runner/runner.go#L544-547)) as the secret of the enterprises and orgs were not properly set (see [enterprise.go#L73-L86](https://github.com/cloudbase/garm/blob/main/database/sql/enterprise.go#L73-L86), [organizations.go#L71-L84](https://github.com/cloudbase/garm/blob/main/database/sql/organizations.go#L71-L84)). For repos the feature seems to work as expected.

**Essentially we need to decide whether empty secrets can be set to disable the validation or not**. After we decided on that I would update the PR accordingly.

* so far I only fixed the code for enterprises after we decided whether we allow for empty secrets  I will fix the code for organizations, too. Of course I can align the code for enterprises, organizations and repos.
* there have been three failing tests  that I could not fix because they depend on side effects in the current implementation. Do we need these tests? Their implementation would depend on the decision above.

The issue was recognize during the work on #60.

<sub>Mathias Zeller <mathias.zeller@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>
