### PR TITLE
fix: shortid generates correctly now

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -32,6 +32,7 @@ import (
 	providerCommon "garm/runner/providers/common"
 
 	"github.com/google/go-github/v48/github"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/teris-io/shortid"
 )
@@ -388,9 +389,6 @@ func (r *basePoolManager) acquireNewInstance(job params.WorkflowJob) error {
 	return nil
 }
 
-// use own alphabet to avoid '-' and '_' in the shortid
-const shortidABC = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
 func (r *basePoolManager) AddRunner(ctx context.Context, poolID string) error {
 	pool, err := r.helper.GetPoolByID(poolID)
 	if err != nil {
@@ -401,7 +399,11 @@ func (r *basePoolManager) AddRunner(ctx context.Context, poolID string) error {
 	if prefix == "" {
 		prefix = params.DefaultRunnerPrefix
 	}
-	name := fmt.Sprintf("%s-%s", prefix, shortid.MustNew(0, shortidABC, 42).String())
+	suffix, err := shortid.Generate()
+	if err != nil {
+		suffix = uuid.New().String()
+	}
+	name := fmt.Sprintf("%s-%s", prefix, suffix)
 
 	createParams := params.CreateInstanceParams{
 		Name:          name,


### PR DESCRIPTION
Sorry...

I committed some un-tested idea where I wanted to remove the ugly '-' and '_' in the shortid.
It doesn't work like that, and currently the runner name generation is broken!

<sub>Michael Kuhnt <michael.kuhnt@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))
</sub>