### PR TITLE
Move pool type in params

### DIFF
--- a/auth/instance_middleware.go
+++ b/auth/instance_middleware.go
@@ -38,13 +38,13 @@ type InstanceJWTClaims struct {
 	Name   string `json:"name"`
 	PoolID string `json:"provider_id"`
 	// Scope is either repository or organization
-	Scope common.PoolType `json:"scope"`
+	Scope params.PoolType `json:"scope"`
 	// Entity is the repo or org name
 	Entity string `json:"entity"`
 	jwt.StandardClaims
 }
 
-func NewInstanceJWTToken(instance params.Instance, secret, entity string, poolType common.PoolType, ttlMinutes uint) (string, error) {
+func NewInstanceJWTToken(instance params.Instance, secret, entity string, poolType params.PoolType, ttlMinutes uint) (string, error) {
 	// Token expiration is equal to the bootstrap timeout set on the pool plus the polling
 	// interval garm uses to check for timed out runners. Runners that have not sent their info
 	// by the end of this interval are most likely failed and will be reaped by garm anyway.

--- a/params/params.go
+++ b/params/params.go
@@ -23,9 +23,16 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+type PoolType string
 type AddressType string
 type EventType string
 type EventLevel string
+
+const (
+	RepositoryPool   PoolType = "repository"
+	OrganizationPool PoolType = "organization"
+	EnterprisePool   PoolType = "enterprise"
+)
 
 const (
 	PublicAddress  AddressType = "public"
@@ -168,6 +175,17 @@ func (p *Pool) RunnerTimeout() uint {
 		return config.DefaultRunnerBootstrapTimeout
 	}
 	return p.RunnerBootstrapTimeout
+}
+
+func (p *Pool) PoolType() PoolType {
+	if p.RepoID != "" {
+		return RepositoryPool
+	} else if p.OrgID != "" {
+		return OrganizationPool
+	} else if p.EnterpriseID != "" {
+		return EnterprisePool
+	}
+	return ""
 }
 
 type Internal struct {

--- a/runner/common/pool.go
+++ b/runner/common/pool.go
@@ -19,12 +19,7 @@ import (
 	"time"
 )
 
-type PoolType string
-
 const (
-	RepositoryPool   PoolType = "repository"
-	OrganizationPool PoolType = "organization"
-
 	PoolScaleDownInterval     = 1 * time.Minute
 	PoolConsilitationInterval = 5 * time.Second
 	PoolReapTimeoutInterval   = 5 * time.Minute

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -580,13 +580,9 @@ func (r *basePoolManager) addInstanceToProvider(instance params.Instance) error 
 	labels = append(labels, r.poolLabel(pool.ID))
 
 	jwtValidity := pool.RunnerTimeout()
-	var poolType common.PoolType = common.RepositoryPool
-	if pool.OrgID != "" {
-		poolType = common.OrganizationPool
-	}
 
 	entity := r.helper.String()
-	jwtToken, err := auth.NewInstanceJWTToken(instance, r.helper.JwtToken(), entity, poolType, jwtValidity)
+	jwtToken, err := auth.NewInstanceJWTToken(instance, r.helper.JwtToken(), entity, pool.PoolType(), jwtValidity)
 	if err != nil {
 		return errors.Wrap(err, "fetching instance jwt token")
 	}


### PR DESCRIPTION
The ```Scope``` field is not really used, but we may need it later.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>