### PR TITLE
Disable Windows binary build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,23 @@ IMAGE_TAG = garm-build
 USER_ID=$(shell ((docker --version | grep -q podman) && echo "0" || id -u))
 USER_GROUP=$(shell ((docker --version | grep -q podman) && echo "0" || id -g))
 ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+GOPATH ?= $(shell go env GOPATH)
 GO ?= go
 
 
-default: build-static
+default: install
 
-.PHONY : build-static
+.PHONY : build-static test install-lint-deps lint go-test fmt fmtcheck verify-vendor verify
 build-static:
 	@echo Building garm
 	docker build --tag $(IMAGE_TAG) .
 	docker run --rm -e USER_ID=$(USER_ID) -e USER_GROUP=$(USER_GROUP) -v $(PWD):/build/garm:z $(IMAGE_TAG) /build-static.sh
 	@echo Binaries are available in $(PWD)/bin
 
-.PHONY: test
+install:
+	@$(GO) install ./...
+	@echo Binaries available in ${GOPATH}
+
 test: verify go-test
 
 install-lint-deps:

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -12,10 +12,10 @@ USER_GROUP=${USER_GROUP:-$(id -g)}
 
 cd $GARM_SOURCE/cmd/garm
 go build -mod vendor -o $BIN_DIR/garm -tags osusergo,netgo,sqlite_omit_load_extension -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --always --dirty)" .
-GOOS=windows CC=x86_64-w64-mingw32-cc go build -mod vendor -o $BIN_DIR/garm.exe -tags osusergo,netgo,sqlite_omit_load_extension -ldflags "-s -w -X main.Version=$(git describe --always --dirty)" .
+# GOOS=windows CC=x86_64-w64-mingw32-cc go build -mod vendor -o $BIN_DIR/garm.exe -tags osusergo,netgo,sqlite_omit_load_extension -ldflags "-s -w -X main.Version=$(git describe --always --dirty)" .
 
 cd $GARM_SOURCE/cmd/garm-cli
 go build -mod vendor -o $BIN_DIR/garm-cli -tags osusergo,netgo -ldflags "-linkmode external -extldflags '-static' -s -w -X garm/cmd/garm-cli/cmd.Version=$(git describe --always --dirty)" .
-GOOS=windows CGO_ENABLED=0 go build -mod vendor -o $BIN_DIR/garm-cli.exe -ldflags "-s -w -X garm/cmd/garm-cli/cmd.Version=$(git describe --always --dirty)" .
+# GOOS=windows CGO_ENABLED=0 go build -mod vendor -o $BIN_DIR/garm-cli.exe -ldflags "-s -w -X garm/cmd/garm-cli/cmd.Version=$(git describe --always --dirty)" .
 
 chown $USER_ID:$USER_GROUP -R "$BIN_DIR"


### PR DESCRIPTION
Removes windows as a target to build binaries for.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>