### PR TITLE
fix: don't update empty runner prefix

### DIFF
--- a/database/sql/util.go
+++ b/database/sql/util.go
@@ -250,7 +250,9 @@ func (s *sqlDatabase) updatePool(pool Pool, param params.UpdatePoolParams) (para
 		pool.Image = param.Image
 	}
 
-	pool.RunnerPrefix = param.GetRunnerPrefix()
+	if param.Prefix != "" {
+		pool.RunnerPrefix = param.Prefix
+	}
 
 	if param.MaxRunners != nil {
 		pool.MaxRunners = *param.MaxRunners


### PR DESCRIPTION
Bug:
the runner prefix is always overwritten. Even if I only want to update e.g. max-runners. If the runner prefix is not specified the default value will be used

Fix:
Only update runner prefix if a value was set.  

<sub>Michael Kuhnt <michael.kuhnt@mercedes-benz.com> Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))
</sub>