### PR TITLE
Move some defaults and types from config

### DIFF
--- a/cloudconfig/cloudconfig.go
+++ b/cloudconfig/cloudconfig.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/cloudbase/garm/config"
+	"github.com/cloudbase/garm/util/appdefaults"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -36,10 +36,10 @@ func NewDefaultCloudInitConfig() *CloudInit {
 		},
 		SystemInfo: &SystemInfo{
 			DefaultUser: DefaultUser{
-				Name:   config.DefaultUser,
-				Home:   fmt.Sprintf("/home/%s", config.DefaultUser),
-				Shell:  config.DefaultUserShell,
-				Groups: config.DefaultUserGroups,
+				Name:   appdefaults.DefaultUser,
+				Home:   fmt.Sprintf("/home/%s", appdefaults.DefaultUser),
+				Shell:  appdefaults.DefaultUserShell,
+				Groups: appdefaults.DefaultUserGroups,
 				Sudo:   "ALL=(ALL) NOPASSWD:ALL",
 			},
 		},

--- a/cmd/garm-cli/cmd/pool.go
+++ b/cmd/garm-cli/cmd/pool.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cloudbase/garm/config"
 	"github.com/cloudbase/garm/params"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -192,8 +191,8 @@ var poolAddCmd = &cobra.Command{
 			MinIdleRunners:         poolMinIdleRunners,
 			Image:                  poolImage,
 			Flavor:                 poolFlavor,
-			OSType:                 config.OSType(poolOSType),
-			OSArch:                 config.OSArch(poolOSArch),
+			OSType:                 params.OSType(poolOSType),
+			OSArch:                 params.OSArch(poolOSArch),
 			Tags:                   tags,
 			Enabled:                poolEnabled,
 			RunnerBootstrapTimeout: poolRunnerBootstrapTimeout,
@@ -279,11 +278,11 @@ explicitly remove them using the runner delete command.
 		}
 
 		if cmd.Flags().Changed("os-type") {
-			poolUpdateParams.OSType = config.OSType(poolOSType)
+			poolUpdateParams.OSType = params.OSType(poolOSType)
 		}
 
 		if cmd.Flags().Changed("os-arch") {
-			poolUpdateParams.OSArch = config.OSArch(poolOSArch)
+			poolUpdateParams.OSArch = params.OSArch(poolOSArch)
 		}
 
 		if cmd.Flags().Changed("max-runners") {

--- a/cmd/garm/main.go
+++ b/cmd/garm/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cloudbase/garm/metrics"
 	"github.com/cloudbase/garm/runner"
 	"github.com/cloudbase/garm/util"
+	"github.com/cloudbase/garm/util/appdefaults"
 	"github.com/cloudbase/garm/websocket"
 
 	"github.com/gorilla/handlers"
@@ -43,7 +44,7 @@ import (
 )
 
 var (
-	conf    = flag.String("config", config.DefaultConfigFilePath, "garm config file")
+	conf    = flag.String("config", appdefaults.DefaultConfigFilePath, "garm config file")
 	version = flag.Bool("version", false, "prints version")
 )
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudbase/garm/params"
+	"github.com/cloudbase/garm/util/appdefaults"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,7 +81,7 @@ func getDefaultProvidersConfig() []Provider {
 	return []Provider{
 		{
 			Name:         "test_lxd",
-			ProviderType: LXDProvider,
+			ProviderType: params.LXDProvider,
 			Description:  "test LXD provider",
 			LXD:          lxdConfig,
 		},
@@ -542,7 +544,7 @@ func TestTimeToLiveDuration(t *testing.T) {
 	require.Equal(t, cfg.TimeToLive.Duration(), 48*time.Hour)
 
 	cfg.TimeToLive = "1h"
-	require.Equal(t, cfg.TimeToLive.Duration(), DefaultJWTTTL)
+	require.Equal(t, cfg.TimeToLive.Duration(), appdefaults.DefaultJWTTTL)
 
 	cfg.TimeToLive = "72h"
 	require.Equal(t, cfg.TimeToLive.Duration(), 72*time.Hour)
@@ -578,7 +580,7 @@ func TestNewConfigEmptyConfigDir(t *testing.T) {
 		t.Fatalf("failed to create temporary directory: %s", err)
 	}
 	defer os.RemoveAll(dirPath)
-	DefaultConfigDir = dirPath
+	appdefaults.DefaultConfigDir = dirPath
 
 	cfg, err := NewConfig("testdata/test-empty-config-dir.toml")
 	require.Nil(t, err)

--- a/database/sql/models.go
+++ b/database/sql/models.go
@@ -17,7 +17,6 @@ package sql
 import (
 	"time"
 
-	"github.com/cloudbase/garm/config"
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/providers/common"
 
@@ -64,8 +63,8 @@ type Pool struct {
 	RunnerBootstrapTimeout uint
 	Image                  string `gorm:"index:idx_pool_type"`
 	Flavor                 string `gorm:"index:idx_pool_type"`
-	OSType                 config.OSType
-	OSArch                 config.OSArch
+	OSType                 params.OSType
+	OSArch                 params.OSArch
 	Tags                   []*Tag `gorm:"many2many:pool_tags;"`
 	Enabled                bool
 	// ExtraSpecs is an opaque json that gets sent to the provider
@@ -140,8 +139,8 @@ type Instance struct {
 	ProviderID    *string `gorm:"uniqueIndex"`
 	Name          string  `gorm:"uniqueIndex"`
 	AgentID       int64
-	OSType        config.OSType
-	OSArch        config.OSArch
+	OSType        params.OSType
+	OSArch        params.OSArch
 	OSName        string
 	OSVersion     string
 	Addresses     []Address `gorm:"foreignKey:InstanceID"`

--- a/params/params.go
+++ b/params/params.go
@@ -18,8 +18,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/cloudbase/garm/config"
 	"github.com/cloudbase/garm/runner/providers/common"
+	"github.com/cloudbase/garm/util/appdefaults"
 
 	"github.com/google/go-github/v48/github"
 	uuid "github.com/satori/go.uuid"
@@ -29,6 +29,16 @@ type PoolType string
 type AddressType string
 type EventType string
 type EventLevel string
+type OSType string
+type OSArch string
+type ProviderType string
+
+const (
+	// LXDProvider represents the LXD provider.
+	LXDProvider ProviderType = "lxd"
+	// ExternalProvider represents an external provider.
+	ExternalProvider ProviderType = "external"
+)
 
 const (
 	RepositoryPool   PoolType = "repository"
@@ -50,6 +60,19 @@ const (
 	EventInfo    EventLevel = "info"
 	EventWarning EventLevel = "warning"
 	EventError   EventLevel = "error"
+)
+
+const (
+	Windows OSType = "windows"
+	Linux   OSType = "linux"
+	Unknown OSType = "unknown"
+)
+
+const (
+	Amd64 OSArch = "amd64"
+	I386  OSArch = "i386"
+	Arm64 OSArch = "arm64"
+	Arm   OSArch = "arm"
 )
 
 type Address struct {
@@ -80,13 +103,13 @@ type Instance struct {
 	Name string `json:"name,omitempty"`
 	// OSType is the operating system type. For now, only Linux and
 	// Windows are supported.
-	OSType config.OSType `json:"os_type,omitempty"`
+	OSType OSType `json:"os_type,omitempty"`
 	// OSName is the name of the OS. Eg: ubuntu, centos, etc.
 	OSName string `json:"os_name,omitempty"`
 	// OSVersion is the version of the operating system.
 	OSVersion string `json:"os_version,omitempty"`
 	// OSArch is the operating system architecture.
-	OSArch config.OSArch `json:"os_arch,omitempty"`
+	OSArch OSArch `json:"os_arch,omitempty"`
 	// Addresses is a list of IP addresses the provider reports
 	// for this instance.
 	Addresses []Address `json:"addresses,omitempty"`
@@ -139,11 +162,11 @@ type BootstrapInstance struct {
 
 	CACertBundle []byte `json:"ca-cert-bundle"`
 
-	OSArch config.OSArch `json:"arch"`
-	Flavor string        `json:"flavor"`
-	Image  string        `json:"image"`
-	Labels []string      `json:"labels"`
-	PoolID string        `json:"pool_id"`
+	OSArch OSArch   `json:"arch"`
+	Flavor string   `json:"flavor"`
+	Image  string   `json:"image"`
+	Labels []string `json:"labels"`
+	PoolID string   `json:"pool_id"`
 }
 
 type Tag struct {
@@ -154,24 +177,24 @@ type Tag struct {
 type Pool struct {
 	RunnerPrefix
 
-	ID                     string        `json:"id"`
-	ProviderName           string        `json:"provider_name"`
-	MaxRunners             uint          `json:"max_runners"`
-	MinIdleRunners         uint          `json:"min_idle_runners"`
-	Image                  string        `json:"image"`
-	Flavor                 string        `json:"flavor"`
-	OSType                 config.OSType `json:"os_type"`
-	OSArch                 config.OSArch `json:"os_arch"`
-	Tags                   []Tag         `json:"tags"`
-	Enabled                bool          `json:"enabled"`
-	Instances              []Instance    `json:"instances"`
-	RepoID                 string        `json:"repo_id,omitempty"`
-	RepoName               string        `json:"repo_name,omitempty"`
-	OrgID                  string        `json:"org_id,omitempty"`
-	OrgName                string        `json:"org_name,omitempty"`
-	EnterpriseID           string        `json:"enterprise_id,omitempty"`
-	EnterpriseName         string        `json:"enterprise_name,omitempty"`
-	RunnerBootstrapTimeout uint          `json:"runner_bootstrap_timeout"`
+	ID                     string     `json:"id"`
+	ProviderName           string     `json:"provider_name"`
+	MaxRunners             uint       `json:"max_runners"`
+	MinIdleRunners         uint       `json:"min_idle_runners"`
+	Image                  string     `json:"image"`
+	Flavor                 string     `json:"flavor"`
+	OSType                 OSType     `json:"os_type"`
+	OSArch                 OSArch     `json:"os_arch"`
+	Tags                   []Tag      `json:"tags"`
+	Enabled                bool       `json:"enabled"`
+	Instances              []Instance `json:"instances"`
+	RepoID                 string     `json:"repo_id,omitempty"`
+	RepoName               string     `json:"repo_name,omitempty"`
+	OrgID                  string     `json:"org_id,omitempty"`
+	OrgName                string     `json:"org_name,omitempty"`
+	EnterpriseID           string     `json:"enterprise_id,omitempty"`
+	EnterpriseName         string     `json:"enterprise_name,omitempty"`
+	RunnerBootstrapTimeout uint       `json:"runner_bootstrap_timeout"`
 	// ExtraSpecs is an opaque raw json that gets sent to the provider
 	// as part of the bootstrap params for instances. It can contain
 	// any kind of data needed by providers. The contents of this field means
@@ -186,7 +209,7 @@ func (p Pool) GetID() string {
 
 func (p *Pool) RunnerTimeout() uint {
 	if p.RunnerBootstrapTimeout == 0 {
-		return config.DefaultRunnerBootstrapTimeout
+		return appdefaults.DefaultRunnerBootstrapTimeout
 	}
 	return p.RunnerBootstrapTimeout
 }
@@ -302,9 +325,9 @@ type GithubCredentials struct {
 }
 
 type Provider struct {
-	Name         string              `json:"name"`
-	ProviderType config.ProviderType `json:"type"`
-	Description  string              `json:"description"`
+	Name         string       `json:"name"`
+	ProviderType ProviderType `json:"type"`
+	Description  string       `json:"description"`
 }
 
 type UpdatePoolStateParams struct {

--- a/params/requests.go
+++ b/params/requests.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/cloudbase/garm/config"
 	"github.com/cloudbase/garm/errors"
 	"github.com/cloudbase/garm/runner/providers/common"
 )
@@ -26,9 +25,9 @@ import (
 const DefaultRunnerPrefix = "garm"
 
 type InstanceRequest struct {
-	Name      string        `json:"name"`
-	OSType    config.OSType `json:"os_type"`
-	OSVersion string        `json:"os_version"`
+	Name      string `json:"name"`
+	OSType    OSType `json:"os_type"`
+	OSVersion string `json:"os_version"`
 }
 
 type CreateRepoParams struct {
@@ -116,15 +115,15 @@ type UpdatePoolParams struct {
 	RunnerBootstrapTimeout *uint           `json:"runner_bootstrap_timeout,omitempty"`
 	Image                  string          `json:"image"`
 	Flavor                 string          `json:"flavor"`
-	OSType                 config.OSType   `json:"os_type"`
-	OSArch                 config.OSArch   `json:"os_arch"`
+	OSType                 OSType          `json:"os_type"`
+	OSArch                 OSArch          `json:"os_arch"`
 	ExtraSpecs             json.RawMessage `json:"extra_specs,omitempty"`
 }
 
 type CreateInstanceParams struct {
 	Name          string
-	OSType        config.OSType
-	OSArch        config.OSArch
+	OSType        OSType
+	OSArch        OSArch
 	Status        common.InstanceStatus
 	RunnerStatus  common.RunnerStatus
 	CallbackURL   string
@@ -140,8 +139,8 @@ type CreatePoolParams struct {
 	MinIdleRunners         uint            `json:"min_idle_runners"`
 	Image                  string          `json:"image"`
 	Flavor                 string          `json:"flavor"`
-	OSType                 config.OSType   `json:"os_type"`
-	OSArch                 config.OSArch   `json:"os_arch"`
+	OSType                 OSType          `json:"os_type"`
+	OSArch                 OSArch          `json:"os_arch"`
 	Tags                   []string        `json:"tags"`
 	Enabled                bool            `json:"enabled"`
 	RunnerBootstrapTimeout uint            `json:"runner_bootstrap_timeout"`

--- a/runner/enterprises.go
+++ b/runner/enterprises.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 
 	"github.com/cloudbase/garm/auth"
-	"github.com/cloudbase/garm/config"
 	runnerErrors "github.com/cloudbase/garm/errors"
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
+	"github.com/cloudbase/garm/util/appdefaults"
 
 	"github.com/pkg/errors"
 )
@@ -210,7 +210,7 @@ func (r *Runner) CreateEnterprisePool(ctx context.Context, enterpriseID string, 
 	}
 
 	if param.RunnerBootstrapTimeout == 0 {
-		param.RunnerBootstrapTimeout = config.DefaultRunnerBootstrapTimeout
+		param.RunnerBootstrapTimeout = appdefaults.DefaultRunnerBootstrapTimeout
 	}
 
 	pool, err := r.store.CreateEnterprisePool(ctx, enterpriseID, createPoolParams)

--- a/runner/organizations.go
+++ b/runner/organizations.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 
 	"github.com/cloudbase/garm/auth"
-	"github.com/cloudbase/garm/config"
 	runnerErrors "github.com/cloudbase/garm/errors"
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
+	"github.com/cloudbase/garm/util/appdefaults"
 
 	"github.com/pkg/errors"
 )
@@ -224,7 +224,7 @@ func (r *Runner) CreateOrgPool(ctx context.Context, orgID string, param params.C
 	}
 
 	if param.RunnerBootstrapTimeout == 0 {
-		param.RunnerBootstrapTimeout = config.DefaultRunnerBootstrapTimeout
+		param.RunnerBootstrapTimeout = appdefaults.DefaultRunnerBootstrapTimeout
 	}
 
 	pool, err := r.store.CreateOrganizationPool(ctx, orgID, createPoolParams)

--- a/runner/providers/external/external.go
+++ b/runner/providers/external/external.go
@@ -19,7 +19,7 @@ import (
 var _ common.Provider = (*external)(nil)
 
 func NewProvider(ctx context.Context, cfg *config.Provider, controllerID string) (common.Provider, error) {
-	if cfg.ProviderType != config.ExternalProvider {
+	if cfg.ProviderType != params.ExternalProvider {
 		return nil, garmErrors.NewBadRequestError("invalid provider config")
 	}
 

--- a/runner/providers/lxd/lxd.go
+++ b/runner/providers/lxd/lxd.go
@@ -54,16 +54,16 @@ var (
 		"arm64":   "arm64",
 	}
 
-	configToLXDArchMap map[config.OSArch]string = map[config.OSArch]string{
-		config.Amd64: "x86_64",
-		config.Arm64: "aarch64",
-		config.Arm:   "armv7l",
+	configToLXDArchMap map[params.OSArch]string = map[params.OSArch]string{
+		params.Amd64: "x86_64",
+		params.Arm64: "aarch64",
+		params.Arm:   "armv7l",
 	}
 
-	lxdToConfigArch map[string]config.OSArch = map[string]config.OSArch{
-		"x86_64":  config.Amd64,
-		"aarch64": config.Arm64,
-		"armv7l":  config.Arm,
+	lxdToConfigArch map[string]params.OSArch = map[string]params.OSArch{
+		"x86_64":  params.Amd64,
+		"aarch64": params.Arm64,
+		"armv7l":  params.Arm,
 	}
 )
 
@@ -77,8 +77,8 @@ func NewProvider(ctx context.Context, cfg *config.Provider, controllerID string)
 		return nil, errors.Wrap(err, "validating provider config")
 	}
 
-	if cfg.ProviderType != config.LXDProvider {
-		return nil, fmt.Errorf("invalid provider type %s, expected %s", cfg.ProviderType, config.LXDProvider)
+	if cfg.ProviderType != params.LXDProvider {
+		return nil, fmt.Errorf("invalid provider type %s, expected %s", cfg.ProviderType, params.LXDProvider)
 	}
 
 	provider := &LXD{
@@ -175,7 +175,7 @@ func (l *LXD) getTools(image *api.Image, tools []*github.RunnerApplicationDownlo
 
 	// Validate image OS. Linux only for now.
 	switch osType {
-	case config.Linux:
+	case params.Linux:
 	default:
 		return github.RunnerApplicationDownload{}, fmt.Errorf("this provider does not support OS type: %s", osType)
 	}

--- a/runner/providers/lxd/util.go
+++ b/runner/providers/lxd/util.go
@@ -176,9 +176,9 @@ func projectName(cfg config.LXD) string {
 	return DefaultProjectName
 }
 
-func resolveArchitecture(osArch config.OSArch) (string, error) {
+func resolveArchitecture(osArch params.OSArch) (string, error) {
 	if string(osArch) == "" {
-		return configToLXDArchMap[config.Amd64], nil
+		return configToLXDArchMap[params.Amd64], nil
 	}
 	arch, ok := configToLXDArchMap[osArch]
 	if !ok {

--- a/runner/providers/providers.go
+++ b/runner/providers/providers.go
@@ -19,6 +19,7 @@ import (
 	"log"
 
 	"github.com/cloudbase/garm/config"
+	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
 	"github.com/cloudbase/garm/runner/providers/external"
 	"github.com/cloudbase/garm/runner/providers/lxd"
@@ -33,14 +34,14 @@ func LoadProvidersFromConfig(ctx context.Context, cfg config.Config, controllerI
 	for _, providerCfg := range cfg.Providers {
 		log.Printf("Loading provider %s", providerCfg.Name)
 		switch providerCfg.ProviderType {
-		case config.LXDProvider:
+		case params.LXDProvider:
 			conf := providerCfg
 			provider, err := lxd.NewProvider(ctx, &conf, controllerID)
 			if err != nil {
 				return nil, errors.Wrap(err, "creating provider")
 			}
 			providers[providerCfg.Name] = provider
-		case config.ExternalProvider:
+		case params.ExternalProvider:
 			conf := providerCfg
 			provider, err := external.NewProvider(ctx, &conf, controllerID)
 			if err != nil {

--- a/runner/repositories.go
+++ b/runner/repositories.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 
 	"github.com/cloudbase/garm/auth"
-	"github.com/cloudbase/garm/config"
 	runnerErrors "github.com/cloudbase/garm/errors"
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
+	"github.com/cloudbase/garm/util/appdefaults"
 
 	"github.com/pkg/errors"
 )
@@ -223,7 +223,7 @@ func (r *Runner) CreateRepoPool(ctx context.Context, repoID string, param params
 	}
 
 	if createPoolParams.RunnerBootstrapTimeout == 0 {
-		createPoolParams.RunnerBootstrapTimeout = config.DefaultRunnerBootstrapTimeout
+		createPoolParams.RunnerBootstrapTimeout = appdefaults.DefaultRunnerBootstrapTimeout
 	}
 
 	pool, err := r.store.CreateRepositoryPool(ctx, repoID, createPoolParams)

--- a/runner/types.go
+++ b/runner/types.go
@@ -14,7 +14,7 @@
 
 package runner
 
-import "github.com/cloudbase/garm/config"
+import "github.com/cloudbase/garm/params"
 
 type HookTargetType string
 
@@ -26,24 +26,24 @@ const (
 
 var (
 	// Linux only for now. Will add Windows soon. (famous last words?)
-	supportedOSType map[config.OSType]struct{} = map[config.OSType]struct{}{
-		config.Linux: {},
+	supportedOSType map[params.OSType]struct{} = map[params.OSType]struct{}{
+		params.Linux: {},
 	}
 
 	// These are the architectures that Github supports.
-	supportedOSArch map[config.OSArch]struct{} = map[config.OSArch]struct{}{
-		config.Amd64: {},
-		config.Arm:   {},
-		config.Arm64: {},
+	supportedOSArch map[params.OSArch]struct{} = map[params.OSArch]struct{}{
+		params.Amd64: {},
+		params.Arm:   {},
+		params.Arm64: {},
 	}
 )
 
-func IsSupportedOSType(osType config.OSType) bool {
+func IsSupportedOSType(osType params.OSType) bool {
 	_, ok := supportedOSType[osType]
 	return ok
 }
 
-func IsSupportedArch(arch config.OSArch) bool {
+func IsSupportedArch(arch params.OSArch) bool {
 	_, ok := supportedOSArch[arch]
 	return ok
 }

--- a/util/appdefaults/appdefaults.go
+++ b/util/appdefaults/appdefaults.go
@@ -1,0 +1,48 @@
+package appdefaults
+
+import "time"
+
+const (
+	// DefaultJWTTTL is the default duration in seconds a JWT token
+	// will be valid.
+	DefaultJWTTTL time.Duration = 24 * time.Hour
+
+	// DefaultRunnerBootstrapTimeout is the default timeout in minutes a runner is
+	// considered to be defunct. If a runner does not join github in the alloted amount
+	// of time and no new updates have been made to it's state, it will be removed.
+	DefaultRunnerBootstrapTimeout = 20
+
+	// DefaultGithubURL is the default URL where Github or Github Enterprise can be accessed.
+	DefaultGithubURL = "https://github.com"
+
+	// DefaultConfigFilePath is the default path on disk to the garm
+	// configuration file.
+	DefaultConfigFilePath = "/etc/garm/config.toml"
+
+	// DefaultUser is the default username that should exist on the instances.
+	DefaultUser = "runner"
+	// DefaultUserShell is the shell for the default user.
+	DefaultUserShell = "/bin/bash"
+
+	// DefaultPoolQueueSize is the default size for a pool queue.
+	DefaultPoolQueueSize = 10
+
+	// GithubDefaultBaseURL is the default URL for the github API.
+	GithubDefaultBaseURL = "https://api.github.com/"
+
+	// uploadBaseURL is the default URL for guthub uploads.
+	GithubDefaultUploadBaseURL = "https://uploads.github.com/"
+)
+
+var (
+	// DefaultConfigDir is the default path on disk to the config dir. The config
+	// file will probably be in the same folder, but it is not mandatory.
+	DefaultConfigDir = "/etc/garm"
+
+	// DefaultUserGroups are the groups the default user will be part of.
+	DefaultUserGroups = []string{
+		"sudo", "adm", "cdrom", "dialout",
+		"dip", "video", "plugdev", "netdev",
+		"docker", "lxd",
+	}
+)

--- a/util/util.go
+++ b/util/util.go
@@ -37,6 +37,7 @@ import (
 	runnerErrors "github.com/cloudbase/garm/errors"
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
+	"github.com/cloudbase/garm/util/appdefaults"
 
 	"github.com/google/go-github/v48/github"
 	"github.com/google/uuid"
@@ -54,24 +55,24 @@ const alphanumeric = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv
 var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 
 var (
-	OSToOSTypeMap map[string]config.OSType = map[string]config.OSType{
-		"almalinux":  config.Linux,
-		"alma":       config.Linux,
-		"alpine":     config.Linux,
-		"archlinux":  config.Linux,
-		"arch":       config.Linux,
-		"centos":     config.Linux,
-		"ubuntu":     config.Linux,
-		"rhel":       config.Linux,
-		"suse":       config.Linux,
-		"opensuse":   config.Linux,
-		"fedora":     config.Linux,
-		"debian":     config.Linux,
-		"flatcar":    config.Linux,
-		"gentoo":     config.Linux,
-		"rockylinux": config.Linux,
-		"rocky":      config.Linux,
-		"windows":    config.Windows,
+	OSToOSTypeMap map[string]params.OSType = map[string]params.OSType{
+		"almalinux":  params.Linux,
+		"alma":       params.Linux,
+		"alpine":     params.Linux,
+		"archlinux":  params.Linux,
+		"arch":       params.Linux,
+		"centos":     params.Linux,
+		"ubuntu":     params.Linux,
+		"rhel":       params.Linux,
+		"suse":       params.Linux,
+		"opensuse":   params.Linux,
+		"fedora":     params.Linux,
+		"debian":     params.Linux,
+		"flatcar":    params.Linux,
+		"gentoo":     params.Linux,
+		"rockylinux": params.Linux,
+		"rocky":      params.Linux,
+		"windows":    params.Windows,
 	}
 
 	githubArchMapping map[string]string = map[string]string{
@@ -158,10 +159,10 @@ func ConvertFileToBase64(file string) (string, error) {
 	return base64.StdEncoding.EncodeToString(bytes), nil
 }
 
-func OSToOSType(os string) (config.OSType, error) {
+func OSToOSType(os string) (params.OSType, error) {
 	osType, ok := OSToOSTypeMap[strings.ToLower(os)]
 	if !ok {
-		return config.Unknown, fmt.Errorf("no OS to OS type mapping for %s", os)
+		return params.Unknown, fmt.Errorf("no OS to OS type mapping for %s", os)
 	}
 	return osType, nil
 }
@@ -217,8 +218,8 @@ func GetCloudConfig(bootstrapParams params.BootstrapInstance, tools github.Runne
 		DownloadURL:       *tools.DownloadURL,
 		TempDownloadToken: tempToken,
 		MetadataURL:       bootstrapParams.MetadataURL,
-		RunnerUsername:    config.DefaultUser,
-		RunnerGroup:       config.DefaultUser,
+		RunnerUsername:    appdefaults.DefaultUser,
+		RunnerGroup:       appdefaults.DefaultUser,
 		RepoURL:           bootstrapParams.RepoURL,
 		RunnerName:        runnerName,
 		RunnerLabels:      strings.Join(bootstrapParams.Labels, ","),


### PR DESCRIPTION
The params package should not depend on config. The params packages should be consumable by external applications that wish to interact with garm, and it makes no sense to pull in the config package just for some constants. As such, the following changes have been made:

  * Moved some types from config to params
  * Moved defaults in a new leaf package called appdefaults