### PR TITLE
check if runner needs to be installed

### DIFF
--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -36,11 +36,11 @@ if [ -z "$METADATA_URL" ];then
 	echo "no token is available and METADATA_URL is not set"
 	exit 1
 fi
-GITHUB_TOKEN=$(curl --fail -s -X GET -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${METADATA_URL}/runner-registration-token/")
+GITHUB_TOKEN=$(curl -k --fail -s -X GET -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${METADATA_URL}/runner-registration-token/")
 
 function call() {
 	PAYLOAD="$1"
-	curl --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${CALLBACK_URL}" || echo "failed to call home: exit code ($?)"
+	curl -k --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${CALLBACK_URL}" || echo "failed to call home: exit code ($?)"
 }
 
 function sendStatus() {
@@ -72,22 +72,26 @@ if [ ! -z $GH_RUNNER_GROUP ];then
     RUNNER_GROUP_OPT="--runnergroup=$GH_RUNNER_GROUP"
 fi
 
+# test if runner is already installed
+if [ -d "/home/{{ .RunnerUsername }}/actions-runner/" ]; then
+	cd /home/{{ .RunnerUsername }}/actions-runner
+else
+	mkdir -p /home/runner/actions-runner || fail "failed to create actions-runner folder"
 
-if [ ! -z "{{ .TempDownloadToken }}" ]; then
-	TEMP_TOKEN="Authorization: Bearer {{ .TempDownloadToken }}"
+	if [ ! -z "{{ .TempDownloadToken }}" ]; then
+		TEMP_TOKEN="Authorization: Bearer {{ .TempDownloadToken }}"
+	fi
+
+	curl -k -L -H "${TEMP_TOKEN}" -o "/home/{{ .RunnerUsername }}/{{ .FileName }}" "{{ .DownloadURL }}" || fail "failed to download tools"
+
+	sendStatus "extracting runner"
+	tar xf "/home/{{ .RunnerUsername }}/{{ .FileName }}" -C /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to extract runner"
+	chown {{ .RunnerUsername }}:{{ .RunnerGroup }} -R /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to change owner"
+
+	sendStatus "installing dependencies"
+	cd /home/{{ .RunnerUsername }}/actions-runner
+	sudo ./bin/installdependencies.sh || fail "failed to install dependencies"
 fi
-
-curl -L -H "${TEMP_TOKEN}" -o "/home/{{ .RunnerUsername }}/{{ .FileName }}" "{{ .DownloadURL }}" || fail "failed to download tools"
-
-mkdir -p /home/runner/actions-runner || fail "failed to create actions-runner folder"
-
-sendStatus "extracting runner"
-tar xf "/home/{{ .RunnerUsername }}/{{ .FileName }}" -C /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to extract runner"
-chown {{ .RunnerUsername }}:{{ .RunnerGroup }} -R /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to change owner"
-
-sendStatus "installing dependencies"
-cd /home/{{ .RunnerUsername }}/actions-runner
-sudo ./bin/installdependencies.sh || fail "failed to install dependencies"
 
 sendStatus "configuring runner"
 sudo -u {{ .RunnerUsername }} -- ./config.sh --unattended --url "{{ .RepoURL }}" --token "$GITHUB_TOKEN" $RUNNER_GROUP_OPT --name "{{ .RunnerName }}" --labels "{{ .RunnerLabels }}" --ephemeral || fail "failed to configure runner"

--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -36,11 +36,11 @@ if [ -z "$METADATA_URL" ];then
 	echo "no token is available and METADATA_URL is not set"
 	exit 1
 fi
-GITHUB_TOKEN=$(curl -k --fail -s -X GET -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${METADATA_URL}/runner-registration-token/")
+GITHUB_TOKEN=$(curl --fail -s -X GET -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${METADATA_URL}/runner-registration-token/")
 
 function call() {
 	PAYLOAD="$1"
-	curl -k --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${CALLBACK_URL}" || echo "failed to call home: exit code ($?)"
+	curl --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${CALLBACK_URL}" || echo "failed to call home: exit code ($?)"
 }
 
 function sendStatus() {

--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -60,7 +60,45 @@ function fail() {
 	exit 1
 }
 
-sendStatus "downloading tools from {{ .DownloadURL }}"
+# This will echo the version number in the filename. Given a file name like: actions-runner-osx-x64-2.299.1.tar.gz
+# this will output: 2.299.1
+function getRunnerVersion() {
+    FILENAME="{{ .FileName }}"
+    [[ $FILENAME =~ ([0-9]+\.[0-9]+\.[0-9+]) ]]
+    echo $BASH_REMATCH
+}
+
+function getCachedToolsPath() {
+    CACHED_RUNNER="/opt/cache/actions-runner/latest"
+    if [ -d "$CACHED_RUNNER" ];then
+        echo "$CACHED_RUNNER"
+        return 0
+    fi
+
+    VERSION=$(getRunnerVersion)
+    if [ -z "$VERSION" ]; then
+        return 0
+    fi
+
+    CACHED_RUNNER="/opt/cache/actions-runner/$VERSION"
+    if [ -d "$CACHED_RUNNER" ];then
+        echo "$CACHED_RUNNER"
+        return 0
+    fi
+    return 0
+}
+
+function downloadAndExtractRunner() {
+    sendStatus "downloading tools from {{ .DownloadURL }}"
+    if [ ! -z "{{ .TempDownloadToken }}" ]; then
+	TEMP_TOKEN="Authorization: Bearer {{ .TempDownloadToken }}"
+    fi
+    curl -L -H "${TEMP_TOKEN}" -o "/home/{{ .RunnerUsername }}/{{ .FileName }}" "{{ .DownloadURL }}" || fail "failed to download tools"
+    mkdir -p /home/runner/actions-runner || fail "failed to create actions-runner folder"
+    sendStatus "extracting runner"
+    tar xf "/home/{{ .RunnerUsername }}/{{ .FileName }}" -C /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to extract runner"
+    chown {{ .RunnerUsername }}:{{ .RunnerGroup }} -R /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to change owner"
+}
 
 TEMP_TOKEN=""
 GH_RUNNER_GROUP="{{.GitHubRunnerGroup}}"
@@ -72,26 +110,18 @@ if [ ! -z $GH_RUNNER_GROUP ];then
     RUNNER_GROUP_OPT="--runnergroup=$GH_RUNNER_GROUP"
 fi
 
-# test if runner is already installed
-if [ -d "/home/{{ .RunnerUsername }}/actions-runner/" ]; then
-	cd /home/{{ .RunnerUsername }}/actions-runner
+CACHED_RUNNER=$(getCachedToolsPath)
+if [ -z "$CACHED_RUNNER" ];then
+    downloadAndExtractRunner
+    sendStatus "installing dependencies"
+    cd /home/{{ .RunnerUsername }}/actions-runner
+    sudo ./bin/installdependencies.sh || fail "failed to install dependencies"
 else
-	mkdir -p /home/runner/actions-runner || fail "failed to create actions-runner folder"
-
-	if [ ! -z "{{ .TempDownloadToken }}" ]; then
-		TEMP_TOKEN="Authorization: Bearer {{ .TempDownloadToken }}"
-	fi
-
-	curl -k -L -H "${TEMP_TOKEN}" -o "/home/{{ .RunnerUsername }}/{{ .FileName }}" "{{ .DownloadURL }}" || fail "failed to download tools"
-
-	sendStatus "extracting runner"
-	tar xf "/home/{{ .RunnerUsername }}/{{ .FileName }}" -C /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to extract runner"
-	chown {{ .RunnerUsername }}:{{ .RunnerGroup }} -R /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to change owner"
-
-	sendStatus "installing dependencies"
-	cd /home/{{ .RunnerUsername }}/actions-runner
-	sudo ./bin/installdependencies.sh || fail "failed to install dependencies"
+    sudo cp -a "$CACHED_RUNNER"  "/home/{{ .RunnerUsername }}/actions-runner"
+    cd /home/{{ .RunnerUsername }}/actions-runner
+    chown {{ .RunnerUsername }}:{{ .RunnerGroup }} -R "/home/{{ .RunnerUsername }}/actions-runner" || fail "failed to change owner"
 fi
+
 
 sendStatus "configuring runner"
 sudo -u {{ .RunnerUsername }} -- ./config.sh --unattended --url "{{ .RepoURL }}" --token "$GITHUB_TOKEN" $RUNNER_GROUP_OPT --name "{{ .RunnerName }}" --labels "{{ .RunnerLabels }}" --ephemeral || fail "failed to configure runner"


### PR DESCRIPTION
I'm trying your new garm-provider-openstack. So far it's looking good. But we don't have some long time numbers yet.

I wanted to discuss this little idea that could save us some time.. 

For green IT reasons we've already pre-installed the github runner in our runner images. Hence, no need to install it during boot/cloud-init. This PR shows a quick check if the runner dir is already there. Probably this check should be a little bit more robust.. What do you think?

This saves us thousands of downloads and installs .. 

I also added the `curl -k` as we currently do need this in our test pipeline and I believe in the bash provider you also had the `-k` added to the curl requests.