### PR TITLE
Add Userdata options to disable package update during boot / cloud-init

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -25,13 +25,15 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-type PoolType string
-type AddressType string
-type EventType string
-type EventLevel string
-type OSType string
-type OSArch string
-type ProviderType string
+type (
+	PoolType     string
+	AddressType  string
+	EventType    string
+	EventLevel   string
+	OSType       string
+	OSArch       string
+	ProviderType string
+)
 
 const (
 	// LXDProvider represents the LXD provider.

--- a/params/params.go
+++ b/params/params.go
@@ -216,6 +216,13 @@ type BootstrapInstance struct {
 
 	// PoolID is the ID of the garm pool to which this runner belongs.
 	PoolID string `json:"pool_id"`
+
+	// UserDataOptions are the options for the user data generation.
+	UserDataOptions UserDataOptions `json:"user_data_options"`
+}
+
+type UserDataOptions struct {
+	DisableUpdatesOnBoot bool `json:"disable_updates_on_boot"`
 }
 
 type Tag struct {

--- a/util/util.go
+++ b/util/util.go
@@ -171,7 +171,7 @@ func GetLoggingWriter(cfg *config.Config) (io.Writer, error) {
 			Filename:   cfg.Default.LogFile,
 			MaxSize:    500, // megabytes
 			MaxBackups: 3,
-			MaxAge:     28,   //days
+			MaxAge:     28,   // days
 			Compress:   true, // disabled by default
 		}
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -266,6 +266,12 @@ func GetCloudConfig(bootstrapParams params.BootstrapInstance, tools github.Runne
 	switch bootstrapParams.OSType {
 	case params.Linux:
 		cloudCfg := cloudconfig.NewDefaultCloudInitConfig()
+
+		if bootstrapParams.UserDataOptions.DisableUpdatesOnBoot {
+			cloudCfg.PackageUpgrade = false
+			cloudCfg.Packages = []string{}
+		}
+
 		cloudCfg.AddSSHKey(bootstrapParams.SSHKeys...)
 		cloudCfg.AddFile(installScript, "/install_runner.sh", "root:root", "755")
 		cloudCfg.AddRunCmd("/install_runner.sh")


### PR DESCRIPTION
Allow to disable an package updates during boot / cloud-init by adding a new field `UserDataOptions` to `BootstrapInstance` parameters.

This does not change the signature of func `GetCloudConfig`. The default behavior does not change.