### PR TITLE
Fix pool ID check when listing instances

### DIFF
--- a/runner/providers/lxd/lxd.go
+++ b/runner/providers/lxd/lxd.go
@@ -417,7 +417,7 @@ func (l *LXD) ListInstances(ctx context.Context, poolID string) ([]params.Instan
 	for _, instance := range instances {
 		if id, ok := instance.ExpandedConfig[controllerIDKeyName]; ok && id == l.controllerID {
 			if poolID != "" {
-				id := instance.ExpandedConfig[poolID]
+				id := instance.ExpandedConfig[poolIDKey]
 				if id != poolID {
 					// Pool ID was specified. Filter out instances belonging to other pools.
 					continue


### PR DESCRIPTION
We should be looking for the poolIDKey in the extended LXD config. This was an unfortunate typo. Unit an integration tests will be added in the medium term.
