### PR TITLE
Let CreateInstance download and cache image

### DIFF
--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -130,8 +130,8 @@ sendStatus "installing runner service"
 ./svc.sh install {{ .RunnerUsername }} || fail "failed to install service"
 
 if [ -e "/sys/fs/selinux" ];then
-    sudo chcon -h user_u:object_r:bin_t /home/runner/
-    sudo chcon -R -h {{ .RunnerUsername }}:object_r:bin_t /home/runner/*
+    sudo chcon -h user_u:object_r:bin_t /home/runner/ || fail "failed to change selinux context"
+    sudo chcon -R -h {{ .RunnerUsername }}:object_r:bin_t /home/runner/* || fail "failed to change selinux context"
 fi
 
 sendStatus "starting service"

--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -130,7 +130,8 @@ sendStatus "installing runner service"
 ./svc.sh install {{ .RunnerUsername }} || fail "failed to install service"
 
 if [ -e "/sys/fs/selinux" ];then
-    sudo chcon -R -t bin_t /home/runner/
+    sudo chcon -h user_u:object_r:bin_t /home/runner/
+    sudo chcon -R -h {{ .RunnerUsername }}:object_r:bin_t /home/runner/*
 fi
 
 sendStatus "starting service"


### PR DESCRIPTION
If we give ```CreateInstance()``` a remote image as a source, it will automatically download the image and cache it locally. If configured, LXD will also auto update the image periodically. Using ```CopyImage()``` gives us none of this.

This change removes the ```CopyImage()``` code and allows ```CreateImage()``` to do the right thing.