### PR TITLE
Allow disabling updates

### DIFF
--- a/runner/providers/lxd/specs.go
+++ b/runner/providers/lxd/specs.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package lxd
+
+import (
+	"encoding/json"
+
+	"github.com/cloudbase/garm/params"
+	"github.com/pkg/errors"
+)
+
+type extraSpecs struct {
+	DisableUpdates bool `json:"disable_updates"`
+}
+
+func parseExtraSpecsFromBootstrapParams(bootstrapParams params.BootstrapInstance) (extraSpecs, error) {
+	specs := extraSpecs{}
+	if bootstrapParams.ExtraSpecs == nil {
+		return specs, nil
+	}
+
+	if err := json.Unmarshal(bootstrapParams.ExtraSpecs, &specs); err != nil {
+		return specs, errors.Wrap(err, "unmarshaling extra specs")
+	}
+	return specs, nil
+}


### PR DESCRIPTION
This change allows disabling updates via extra specs in the LXD provider.

To disable updates, add the following extra specs

```bash
garm-cli pool update \
    --extra-specs='{"disable_updates": true}' \
    <POOL_ID>
```

Fixes: https://github.com/cloudbase/garm/issues/93