### PR TITLE
Don't merge the second column in the CLI

### DIFF
--- a/cmd/garm-cli/cmd/enterprise.go
+++ b/cmd/garm-cli/cmd/enterprise.go
@@ -184,7 +184,7 @@ func formatOneEnterprise(enterprise params.Enterprise) {
 	}
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, AutoMerge: true},
-		{Number: 2, AutoMerge: true},
+		{Number: 2, AutoMerge: false},
 	})
 
 	fmt.Println(t.Render())

--- a/cmd/garm-cli/cmd/organization.go
+++ b/cmd/garm-cli/cmd/organization.go
@@ -183,7 +183,7 @@ func formatOneOrganization(org params.Organization) {
 	}
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, AutoMerge: true},
-		{Number: 2, AutoMerge: true},
+		{Number: 2, AutoMerge: false},
 	})
 
 	fmt.Println(t.Render())

--- a/cmd/garm-cli/cmd/pool.go
+++ b/cmd/garm-cli/cmd/pool.go
@@ -502,7 +502,7 @@ func formatOnePool(pool params.Pool) {
 
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, AutoMerge: true},
-		{Number: 2, AutoMerge: true, WidthMax: 100},
+		{Number: 2, AutoMerge: false, WidthMax: 100},
 	})
 	fmt.Println(t.Render())
 }

--- a/cmd/garm-cli/cmd/repository.go
+++ b/cmd/garm-cli/cmd/repository.go
@@ -189,7 +189,7 @@ func formatOneRepository(repo params.Repository) {
 	}
 	t.SetColumnConfigs([]table.ColumnConfig{
 		{Number: 1, AutoMerge: true},
-		{Number: 2, AutoMerge: true},
+		{Number: 2, AutoMerge: false},
 	})
 
 	fmt.Println(t.Render())


### PR DESCRIPTION
The second column that is printed when showing a resource, contains values that should not be merged, even if they are similar.

Fixes: https://github.com/cloudbase/garm/issues/100