### PR TITLE
Allow installing additional packages in lxd container

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -222,7 +222,8 @@ type BootstrapInstance struct {
 }
 
 type UserDataOptions struct {
-	DisableUpdatesOnBoot bool `json:"disable_updates_on_boot"`
+	DisableUpdatesOnBoot bool     `json:"disable_updates_on_boot"`
+	ExtraPackages        []string `json:"extra_packages"`
 }
 
 type Tag struct {

--- a/runner/providers/lxd/lxd.go
+++ b/runner/providers/lxd/lxd.go
@@ -236,6 +236,7 @@ func (l *LXD) getCreateInstanceArgs(bootstrapParams params.BootstrapInstance, sp
 	}
 
 	bootstrapParams.UserDataOptions.DisableUpdatesOnBoot = specs.DisableUpdates
+	bootstrapParams.UserDataOptions.ExtraPackages = specs.ExtraPackages
 	cloudCfg, err := util.GetCloudConfig(bootstrapParams, tools, bootstrapParams.Name)
 	if err != nil {
 		return api.InstancesPost{}, errors.Wrap(err, "generating cloud-config")

--- a/runner/providers/lxd/specs.go
+++ b/runner/providers/lxd/specs.go
@@ -22,7 +22,8 @@ import (
 )
 
 type extraSpecs struct {
-	DisableUpdates bool `json:"disable_updates"`
+	DisableUpdates bool     `json:"disable_updates"`
+	ExtraPackages  []string `json:"extra_packages"`
 }
 
 func parseExtraSpecsFromBootstrapParams(bootstrapParams params.BootstrapInstance) (extraSpecs, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -271,6 +271,9 @@ func GetCloudConfig(bootstrapParams params.BootstrapInstance, tools github.Runne
 			cloudCfg.PackageUpgrade = false
 			cloudCfg.Packages = []string{}
 		}
+		for _, pkg := range bootstrapParams.UserDataOptions.ExtraPackages {
+			cloudCfg.AddPackage(pkg)
+		}
 
 		cloudCfg.AddSSHKey(bootstrapParams.SSHKeys...)
 		cloudCfg.AddFile(installScript, "/install_runner.sh", "root:root", "755")


### PR DESCRIPTION
Dear maintainers,

This proposed change extends the `UserDataOptions` introduced in #87 and #95 so that the user can configure additional packages to be installed into the runner of each pool. 

This can be very useful when GitHub Actions workflows require Docker to be installed in the runner. This can be configured via
```bash
garm-cli pool update \
    --extra-specs='{"extra_packages": ["docker.io"]}' \
        <pool id>
```