### PR TITLE
Reap failed agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ USER_ID=$(shell ((docker --version | grep -q podman) && echo "0" || id -u))
 USER_GROUP=$(shell ((docker --version | grep -q podman) && echo "0" || id -g))
 ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 GOPATH ?= $(shell go env GOPATH)
+VERSION ?= $(shell git describe --tags --match='v[0-9]*' --dirty --always)
 GO ?= go
 
 
@@ -16,6 +17,13 @@ build-static:
 	@echo Building garm
 	docker build --tag $(IMAGE_TAG) .
 	docker run --rm -e USER_ID=$(USER_ID) -e USER_GROUP=$(USER_GROUP) -v $(PWD):/build/garm:z $(IMAGE_TAG) /build-static.sh
+	@echo Binaries are available in $(PWD)/bin
+
+build:
+	@echo Building garm ${VERSION}
+	$(shell mkdir -p ./bin)
+	@$(GO) build -ldflags "-s -w -X main.Version=${VERSION}" -tags osusergo,netgo,sqlite_omit_load_extension -o bin/garm ./cmd/garm
+	@$(GO) build -ldflags "-s -w -X github.com/cloudbase/garm/cmd/garm-cli/cmd.Version=${VERSION}" -tags osusergo,netgo,sqlite_omit_load_extension -o bin/garm-cli ./cmd/garm-cli
 	@echo Binaries are available in $(PWD)/bin
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ VERSION ?= $(shell git describe --tags --match='v[0-9]*' --dirty --always)
 GO ?= go
 
 
-default: install
+default: build
 
 .PHONY : build-static test install-lint-deps lint go-test fmt fmtcheck verify-vendor verify
 build-static:
@@ -25,10 +25,6 @@ build:
 	@$(GO) build -ldflags "-s -w -X main.Version=${VERSION}" -tags osusergo,netgo,sqlite_omit_load_extension -o bin/garm ./cmd/garm
 	@$(GO) build -ldflags "-s -w -X github.com/cloudbase/garm/cmd/garm-cli/cmd.Version=${VERSION}" -tags osusergo,netgo,sqlite_omit_load_extension -o bin/garm-cli ./cmd/garm-cli
 	@echo Binaries are available in $(PWD)/bin
-
-install:
-	@$(GO) install -tags osusergo,netgo,sqlite_omit_load_extension ./...
-	@echo Binaries available in ${GOPATH}
 
 test: verify go-test
 

--- a/cloudconfig/templates.go
+++ b/cloudconfig/templates.go
@@ -36,11 +36,11 @@ if [ -z "$METADATA_URL" ];then
 	echo "no token is available and METADATA_URL is not set"
 	exit 1
 fi
-GITHUB_TOKEN=$(curl --fail -s -X GET -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${METADATA_URL}/runner-registration-token/")
+GITHUB_TOKEN=$(curl --retry 5 --retry-max-time 5 --fail -s -X GET -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${METADATA_URL}/runner-registration-token/")
 
 function call() {
 	PAYLOAD="$1"
-	curl --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${CALLBACK_URL}" || echo "failed to call home: exit code ($?)"
+	curl --retry 5 --retry-max-time 5 --retry-all-errors --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${CALLBACK_URL}" || echo "failed to call home: exit code ($?)"
 }
 
 function sendStatus() {
@@ -93,7 +93,7 @@ function downloadAndExtractRunner() {
 	if [ ! -z "{{ .TempDownloadToken }}" ]; then
 	TEMP_TOKEN="Authorization: Bearer {{ .TempDownloadToken }}"
 	fi
-	curl -L -H "${TEMP_TOKEN}" -o "/home/{{ .RunnerUsername }}/{{ .FileName }}" "{{ .DownloadURL }}" || fail "failed to download tools"
+	curl --retry 5 --retry-max-time 5 --retry-all-errors --fail -L -H "${TEMP_TOKEN}" -o "/home/{{ .RunnerUsername }}/{{ .FileName }}" "{{ .DownloadURL }}" || fail "failed to download tools"
 	mkdir -p /home/runner/actions-runner || fail "failed to create actions-runner folder"
 	sendStatus "extracting runner"
 	tar xf "/home/{{ .RunnerUsername }}/{{ .FileName }}" -C /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to extract runner"


### PR DESCRIPTION
This change reaps runners that appear as `offline` in github and have their `RUNNER STATUS` set to `failed`. Runners that are in this state have registered themselves in GutHub, but failed at a later stage in the setup process. We reap them if no new updates have been made to the instance after the configured pool timeout.

This change also adds a retry when running `config.sh` via userdata. Hopefully in future releases we can switch to using [jit runners](https://github.blog/changelog/2023-06-02-github-actions-just-in-time-self-hosted-runners/) but for the time being, this is not available for GHE.

Fixes: https://github.com/cloudbase/garm/issues/104