### PR TITLE
Rotate log file on SIGHUP

### DIFF
--- a/cmd/garm/main.go
+++ b/cmd/garm/main.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/cloudbase/garm/apiserver/controllers"
@@ -37,6 +38,7 @@ import (
 	"github.com/cloudbase/garm/util"
 	"github.com/cloudbase/garm/util/appdefaults"
 	"github.com/cloudbase/garm/websocket"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -81,6 +83,26 @@ func main() {
 	if err != nil {
 		log.Fatalf("fetching log writer: %+v", err)
 	}
+
+	// rotate log file on SIGHUP
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGHUP)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				// Daemon is exiting.
+				return
+			case <-ch:
+				// we got a SIGHUP. Rotate log file.
+				if logger, ok := logWriter.(*lumberjack.Logger); ok {
+					if err := logger.Rotate(); err != nil {
+						log.Printf("failed to rotate log file: %v", err)
+					}
+				}
+			}
+		}
+	}()
 
 	var writers []io.Writer = []io.Writer{
 		logWriter,

--- a/contrib/garm.service
+++ b/contrib/garm.service
@@ -5,6 +5,7 @@ After=multi-user.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/garm -config /etc/garm/config.toml
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=5s
 User=garm

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -1,0 +1,17 @@
+# Logging
+
+By default, GARM is logging only on standard output.
+
+If you would like GARM to use a logging file instead, you can use the `log_file` configuration option:
+
+```toml
+[default]
+# Use this if you'd like to log to a file instead of standard output.
+log_file = "/tmp/runner-manager.log"
+```
+
+## Rotating log files
+
+If GARM uses a log file, by default it will rotate it when it reaches 500MB or 28 days, whichever comes first.
+
+However, if you want to manually rotate the log file, you can send a `SIGHUP` signal to the GARM process.


### PR DESCRIPTION
Fixes https://github.com/cloudbase/garm/issues/114.

Add functionality to rotate the log file when `SIGHUP` signal is received.

Also, a doc is added with few details about logging.