### PR TITLE
Add dockerfile and workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,49 @@
+name: "Build GARM images"
+on:
+  workflow_dispatch:
+    inputs:
+      push_to_project:
+        description: "Project to build images for"
+        required: true
+        default: "ghcr.io/cloudbase"
+      ref:
+        description: "Ref to build"
+        required: true
+        default: "main"
+
+permissions:
+  contents: read
+
+jobs:
+    images:
+      permissions:
+        packages: write
+      name: "Build GARM images"
+      runs-on: ubuntu-22.04
+      steps:
+        - name: "Checkout"
+          uses: actions/checkout@v3
+          with:
+            path: src/github.com/cloudbase/garm
+            fetch-depth: 0
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+
+        - name: Login to GitHub Container Registry
+          uses: docker/login-action@v2
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+        - name: Build and push
+          run: |
+            cd src/github.com/cloudbase/garm
+            VERSION=$(git describe --tags --match='v[0-9]*' --always ${{ github.event.inputs.ref }})
+            docker buildx build \
+              --provenance=false \
+              --platform linux/amd64,linux/arm64 \
+              --build-arg="GARM_REF=${{ github.event.inputs.ref }}" \
+              -t ${{ github.event.inputs.push_to_project }}/garm:"${VERSION}" \
+              --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,6 @@ FROM scratch
 COPY --from=builder /bin/garm /bin/garm
 COPY --from=builder /opt/garm/providers.d/garm-provider-openstack /opt/garm/providers.d/garm-provider-openstack
 COPY --from=builder /opt/garm/providers.d/garm-provider-azure /opt/garm/providers.d/garm-provider-azure
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/bin/garm", "-config", "/etc/garm/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,28 @@
-FROM docker.io/golang:alpine
+FROM docker.io/golang:alpine AS builder
+ARG GARM_REF
 
-WORKDIR /root
-USER root
+LABEL stage=builder
 
-RUN apk add musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers mingw-w64-gcc
+RUN apk add musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers
+RUN git config --global --add safe.directory /build
 
-ADD ./scripts/build-static.sh /build-static.sh
-RUN chmod +x /build-static.sh
+ADD . /build/garm
+RUN cd /build/garm && git checkout ${GARM_REF}
+RUN git clone https://github.com/cloudbase/garm-provider-azure /build/garm-provider-azure
+RUN git clone https://github.com/cloudbase/garm-provider-openstack /build/garm-provider-openstack
 
-CMD ["/bin/sh"]
+RUN cd /build/garm && go build -o /bin/garm \
+    -tags osusergo,netgo,sqlite_omit_load_extension \
+    -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" \
+    /build/garm/cmd/garm
+RUN mkdir -p /opt/garm/providers.d
+RUN cd /build/garm-provider-azure && go build -ldflags="-linkmode external -extldflags '-static' -s -w" -o /opt/garm/providers.d/garm-provider-azure .
+RUN cd /build/garm-provider-openstack && go build -ldflags="-linkmode external -extldflags '-static' -s -w" -o /opt/garm/providers.d/garm-provider-openstack .
+
+FROM scratch
+
+COPY --from=builder /bin/garm /bin/garm
+COPY --from=builder /opt/garm/providers.d/garm-provider-openstack /opt/garm/providers.d/garm-provider-openstack
+COPY --from=builder /opt/garm/providers.d/garm-provider-azure /opt/garm/providers.d/garm-provider-azure
+
+ENTRYPOINT ["/bin/garm", "-config", "/etc/garm/config.toml"]

--- a/Dockerfile.build-static
+++ b/Dockerfile.build-static
@@ -1,0 +1,15 @@
+FROM docker.io/golang:alpine
+
+WORKDIR /root
+USER root
+
+RUN apk add musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers mingw-w64-gcc
+
+RUN wget http://musl.cc/aarch64-linux-musl-cross.tgz -O /tmp/aarch64-linux-musl-cross.tgz && \
+    tar --strip-components=1 -C /usr/local -xzf /tmp/aarch64-linux-musl-cross.tgz && \
+    rm /tmp/aarch64-linux-musl-cross.tgz
+
+ADD ./scripts/build-static.sh /build-static.sh
+RUN chmod +x /build-static.sh
+
+CMD ["/bin/sh"]

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ default: build
 .PHONY : build-static test install-lint-deps lint go-test fmt fmtcheck verify-vendor verify
 build-static:
 	@echo Building garm
-	docker build --tag $(IMAGE_TAG) .
+	docker build --tag $(IMAGE_TAG) -f Dockerfile.build-static .
 	docker run --rm -e USER_ID=$(USER_ID) -e USER_GROUP=$(USER_GROUP) -v $(PWD):/build/garm:z $(IMAGE_TAG) /build-static.sh
 	@echo Binaries are available in $(PWD)/bin
 

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -10,12 +10,34 @@ export CGO_ENABLED=1
 USER_ID=${USER_ID:-$UID}
 USER_GROUP=${USER_GROUP:-$(id -g)}
 
+mkdir -p $BIN_DIR/amd64 $BIN_DIR/arm64
 cd $GARM_SOURCE/cmd/garm
-go build -mod vendor -o $BIN_DIR/garm -tags osusergo,netgo,sqlite_omit_load_extension -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" .
-# GOOS=windows CC=x86_64-w64-mingw32-cc go build -mod vendor -o $BIN_DIR/garm.exe -tags osusergo,netgo,sqlite_omit_load_extension -ldflags "-s -w -X main.Version=$(git describe --always --dirty)" .
+go build -mod vendor \
+    -o $BIN_DIR/amd64/garm \
+    -tags osusergo,netgo,sqlite_omit_load_extension \
+    -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" .
+CC=aarch64-linux-musl-gcc GOARCH=arm64 go build \
+    -mod vendor \
+    -o $BIN_DIR/arm64/garm \
+    -tags osusergo,netgo,sqlite_omit_load_extension \
+    -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" .
+# GOOS=windows CC=x86_64-w64-mingw32-cc go build -mod vendor \
+#     -o $BIN_DIR/amd64/garm.exe \
+#     -tags osusergo,netgo,sqlite_omit_load_extension \
+#     -ldflags "-s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" .
 
 cd $GARM_SOURCE/cmd/garm-cli
-go build -mod vendor -o $BIN_DIR/garm-cli -tags osusergo,netgo -ldflags "-linkmode external -extldflags '-static' -s -w -X garm/cmd/garm-cli/cmd.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" .
-# GOOS=windows CGO_ENABLED=0 go build -mod vendor -o $BIN_DIR/garm-cli.exe -ldflags "-s -w -X garm/cmd/garm-cli/cmd.Version=$(git describe --always --dirty)" .
+go build -mod vendor \
+    -o $BIN_DIR/amd64/garm-cli \
+    -tags osusergo,netgo,sqlite_omit_load_extension \
+    -ldflags "-linkmode external -extldflags '-static' -s -w -X garm/cmd/garm-cli/cmd.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" .
+CC=aarch64-linux-musl-gcc GOARCH=arm64 go build -mod vendor \
+    -o $BIN_DIR/arm64/garm-cli \
+    -tags osusergo,netgo,sqlite_omit_load_extension \
+    -ldflags "-linkmode external -extldflags '-static' -s -w -X garm/cmd/garm-cli/cmd.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" .
+# GOOS=windows CGO_ENABLED=0 go build -mod vendor \
+#     -o $BIN_DIR/amd64/garm-cli.exe \
+#     -tags osusergo,netgo,sqlite_omit_load_extension \
+#     -ldflags "-s -w -X garm/cmd/garm-cli/cmd.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" .
 
 chown $USER_ID:$USER_GROUP -R "$BIN_DIR"


### PR DESCRIPTION
This PR adds:

  * `make build-static` now builds ARM64 binaries as well
  * A Dockerfile was added to build garm and the currently available providers
  * A new workflow was added to build the image and upload it to ghcr.io