### PR TITLE
Small fixes to the GARM api server

### DIFF
--- a/apiserver/routers/routers.go
+++ b/apiserver/routers/routers.go
@@ -98,6 +98,7 @@ func NewAPIRouter(han *controllers.APIController, logWriter io.Writer, authMiddl
 	// FirstRunHandler
 	firstRunRouter := apiSubRouter.PathPrefix("/first-run").Subrouter()
 	firstRunRouter.Handle("/", http.HandlerFunc(han.FirstRunHandler)).Methods("POST", "OPTIONS")
+	firstRunRouter.Handle("", http.HandlerFunc(han.FirstRunHandler)).Methods("POST", "OPTIONS")
 
 	// Instance URLs
 	callbackRouter := apiSubRouter.PathPrefix("/callbacks").Subrouter()

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -74,8 +74,8 @@ func (amw *jwtMiddleware) claimsToContext(ctx context.Context, claims *JWTClaims
 }
 
 func invalidAuthResponse(w http.ResponseWriter) {
-	w.WriteHeader(http.StatusUnauthorized)
 	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
 	if err := json.NewEncoder(w).Encode(
 		apiParams.APIErrorResponse{
 			Error: "Authentication failed",


### PR DESCRIPTION
* Fix `Content-Type` not being set on `invalidAuthResponse`
  * Fixes https://github.com/cloudbase/garm/issues/137
* Fix calling `/api/v1/first-run` API endpoint without ending `/`