### PR TITLE
Update to latest version of garm-provider-common and update docs

### DIFF
--- a/doc/config_default.md
+++ b/doc/config_default.md
@@ -10,7 +10,7 @@ The `default` config section holds configuration options that don't need a categ
 # Note: If you're using a reverse proxy in front of your garm installation,
 # this URL needs to point to the address of the reverse proxy. Using TLS is
 # highly encouraged.
-callback_url = "https://garm.example.com/api/v1/callbacks/status"
+callback_url = "https://garm.example.com/api/v1/callbacks"
 
 # This URL is used by instances to retrieve information they need to set themselves
 # up. Access to this URL is granted using the same JWT token used to send back
@@ -73,7 +73,7 @@ This URL must be set and must be accessible by the instance. If you wish to rest
 For example, in a scenario where you expose the API endpoint directly, this setting could look like the following:
 
   ```toml
-  callback_url = "https://garm.example.com/api/v1/callbacks/status"
+  callback_url = "https://garm.example.com/api/v1/callbacks"
   ```
 
 Authentication is done using a short-lived JWT token, that gets generated for a particular instance that we are spinning up. That JWT token grants access to the instance to only update it's own status and to fetch metadata for itself. No other API endpoints will work with that JWT token. The validity of the token is equal to the pool bootstrap timeout value (default 20 minutes) plus the garm polling interval (5 minutes).

--- a/doc/external_provider.md
+++ b/doc/external_provider.md
@@ -174,7 +174,7 @@ Here is a sample of that:
       }
     ],
     "repo_url": "https://github.com/gabriel-samfira/scripts",
-    "callback-url": "https://garm.example.com/api/v1/callbacks/status",
+    "callback-url": "https://garm.example.com/api/v1/callbacks",
     "metadata-url": "https://garm.example.com/api/v1/metadata",
     "instance-token": "super secret JWT token",
     "extra_specs": {

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -46,7 +46,7 @@ Open `/etc/garm/config.toml` in your favorite editor and paste the following:
 
 ```toml
 [default]
-callback_url = "https://garm.example.com/api/v1/callbacks/status"
+callback_url = "https://garm.example.com/api/v1/callbacks"
 metadata_url = "https://garm.example.com/api/v1/metadata"
 
 [metrics]
@@ -154,7 +154,7 @@ docker run -d \
   -p 80:80 \
   -v /etc/garm:/etc/garm:rw \
   -v /var/snap/lxd/common/lxd/unix.socket:/var/snap/lxd/common/lxd/unix.socket:rw \
-  ghcr.io/cloudbase/garm:v0.1.2
+  ghcr.io/cloudbase/garm:v0.1.3
 ```
 
 You will notice we also mounted the LXD unix socket from the host inside the container where the config you pasted expects to find it. If you plan to use an external provider that does not need to connect to LXD over a unix socket, feel free to remove that mount.
@@ -187,7 +187,7 @@ Adding the `garm` user to the LXD group will allow it to connect to the LXD unix
 Next, download the latest release from the [releases page](https://github.com/cloudbase/garm/releases).
 
 ```bash
-wget -q -O - https://github.com/cloudbase/garm/releases/download/v0.1.2/garm-linux-amd64.tgz |  tar xzf - -C /usr/local/bin/
+wget -q -O - https://github.com/cloudbase/garm/releases/download/v0.1.3/garm-linux-amd64.tgz |  tar xzf - -C /usr/local/bin/
 ```
 
 We'll be running under an unprivileged user. If we want to be able to listen on any port under `1024`, we'll have to set some capabilities on the binary:
@@ -206,7 +206,7 @@ Copy the sample `systemd` service file:
 
 ```bash
 wget -O /etc/systemd/system/garm.service \
-  https://raw.githubusercontent.com/cloudbase/garm/v0.1.2/contrib/garm.service
+  https://raw.githubusercontent.com/cloudbase/garm/v0.1.3/contrib/garm.service
 ```
 
 Reload the `systemd` daemon and start the service:
@@ -256,7 +256,7 @@ Before we can start using GARM, we need initialize it. This will create the `adm
 To initialize GARM, we'll use the `garm-cli` tool. You can download the latest release from the [releases page](https://github.com/cloudbase/garm/releases):
 
 ```bash
-wget -q -O - https://github.com/cloudbase/garm/releases/download/v0.1.2/garm-cli-linux-amd64.tgz |  tar xzf - -C /usr/local/bin/
+wget -q -O - https://github.com/cloudbase/garm/releases/download/v0.1.3/garm-cli-linux-amd64.tgz |  tar xzf - -C /usr/local/bin/
 ```
 
 Now we can initialize GARM:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/BurntSushi/toml v1.2.1
-	github.com/cloudbase/garm-provider-common v0.0.0-20230724114054-7aa0a3dfbce0
+	github.com/cloudbase/garm-provider-common v0.0.0-20230726155746-1e24ecc05fcc
 	github.com/go-openapi/errors v0.20.4
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudbase/garm-provider-common v0.0.0-20230724114054-7aa0a3dfbce0 h1:5ScMXea/ZIcUbw1aXAgN8xTqSG84AOf5Maf5hBC82wQ=
-github.com/cloudbase/garm-provider-common v0.0.0-20230724114054-7aa0a3dfbce0/go.mod h1:RKzgL0MXkNeGfloQpE2swz/y4LWJr5+2Wd45bSXPB0k=
+github.com/cloudbase/garm-provider-common v0.0.0-20230726155746-1e24ecc05fcc h1:LnSj5+iakacm98afpOgSmjcQOMf45Nk/2YHhlWlqXOM=
+github.com/cloudbase/garm-provider-common v0.0.0-20230726155746-1e24ecc05fcc/go.mod h1:RKzgL0MXkNeGfloQpE2swz/y4LWJr5+2Wd45bSXPB0k=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=

--- a/runner/providers/lxd/lxd.go
+++ b/runner/providers/lxd/lxd.go
@@ -239,6 +239,7 @@ func (l *LXD) getCreateInstanceArgs(bootstrapParams commonParams.BootstrapInstan
 
 	bootstrapParams.UserDataOptions.DisableUpdatesOnBoot = specs.DisableUpdates
 	bootstrapParams.UserDataOptions.ExtraPackages = specs.ExtraPackages
+	bootstrapParams.UserDataOptions.EnableBootDebug = specs.EnableBootDebug
 	cloudCfg, err := cloudconfig.GetCloudConfig(bootstrapParams, tools, bootstrapParams.Name)
 	if err != nil {
 		return api.InstancesPost{}, errors.Wrap(err, "generating cloud-config")

--- a/runner/providers/lxd/specs.go
+++ b/runner/providers/lxd/specs.go
@@ -22,8 +22,9 @@ import (
 )
 
 type extraSpecs struct {
-	DisableUpdates bool     `json:"disable_updates"`
-	ExtraPackages  []string `json:"extra_packages"`
+	DisableUpdates  bool     `json:"disable_updates"`
+	ExtraPackages   []string `json:"extra_packages"`
+	EnableBootDebug bool     `json:"enable_boot_debug"`
 }
 
 func parseExtraSpecsFromBootstrapParams(bootstrapParams commonParams.BootstrapInstance) (extraSpecs, error) {

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -6,7 +6,7 @@
 # Note: If you're using a reverse proxy in front of your garm installation,
 # this URL needs to point to the address of the reverse proxy. Using TLS is
 # highly encouraged.
-callback_url = "https://garm.example.com/api/v1/callbacks/status"
+callback_url = "https://garm.example.com/api/v1/callbacks"
 
 # This URL is used by instances to retrieve information they need to set themselves
 # up. Access to this URL is granted using the same JWT token used to send back

--- a/vendor/github.com/cloudbase/garm-provider-common/cloudconfig/templates.go
+++ b/vendor/github.com/cloudbase/garm-provider-common/cloudconfig/templates.go
@@ -44,10 +44,7 @@ GITHUB_TOKEN=$(curl --retry 5 --retry-delay 5 --retry-connrefused --fail -s -X G
 
 function call() {
 	PAYLOAD="$1"
-	[[ $CALLBACK_URL =~ ^(.*)/status$ ]]
-	if [ -z "$BASH_REMATCH" ];then
-		CALLBACK_URL="${CALLBACK_URL}/status"
-	fi
+	[[ $CALLBACK_URL =~ ^(.*)/status$ ]] || CALLBACK_URL="${CALLBACK_URL}/status"
 	curl --retry 5 --retry-delay 5 --retry-connrefused --fail -s -X POST -d "${PAYLOAD}" -H 'Accept: application/json' -H "Authorization: Bearer ${BEARER_TOKEN}" "${CALLBACK_URL}" || echo "failed to call home: exit code ($?)"
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/cespare/xxhash/v2
 # github.com/chzyer/readline v1.5.1
 ## explicit; go 1.15
 github.com/chzyer/readline
-# github.com/cloudbase/garm-provider-common v0.0.0-20230724114054-7aa0a3dfbce0
+# github.com/cloudbase/garm-provider-common v0.0.0-20230726155746-1e24ecc05fcc
 ## explicit; go 1.20
 github.com/cloudbase/garm-provider-common/cloudconfig
 github.com/cloudbase/garm-provider-common/defaults


### PR DESCRIPTION
Using the latest version of `garm-provider-common` we can finally consolidate the way we define the `callback_url` with the `metadata_url`. Also updated the docs to point to the latest release.

Using the old callback_url that points to the URL ending in `/status` will continue to work.

Fixes: #88 