### PR TITLE
Set pipefail to the script and log org/repo details on timeout exceeded

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,7 +59,10 @@ jobs:
         run: sudo mkdir -p /artifacts-logs && sudo chmod 777 /artifacts-logs
 
       - name: Run integration tests
-        run: go run ./test/integration/e2e.go 2>&1 | tee /artifacts-logs/e2e.log 
+        run: |
+          set -o pipefail
+          set -o errexit
+          go run ./test/integration/e2e.go 2>&1 | tee /artifacts-logs/e2e.log 
         env:
           GARM_BASE_URL: ${{ steps.ngrok.outputs.tunnel-url }}
           GARM_USERNAME: admin

--- a/test/integration/e2e.go
+++ b/test/integration/e2e.go
@@ -657,6 +657,10 @@ func WaitRepoInstance(timeout time.Duration) {
 		time.Sleep(5 * time.Second)
 		timeWaited += 5
 	}
+	repo, err := getRepo(cli, authToken, repoID)
+	handleError(err)
+	printResponse(repo)
+
 	instanceDetails, err := getInstance(cli, authToken, instance.Name)
 	handleError(err)
 	printResponse(instanceDetails)
@@ -823,6 +827,10 @@ func WaitOrgInstance(timeout time.Duration) {
 		time.Sleep(5 * time.Second)
 		timeWaited += 5
 	}
+	org, err := getOrg(cli, authToken, orgID)
+	handleError(err)
+	printResponse(org)
+
 	instanceDetails, err := getInstance(cli, authToken, instance.Name)
 	handleError(err)
 	printResponse(instanceDetails)


### PR DESCRIPTION
* This PR adds log `org/repo` details on timeout exceeded and `set -o pipefail` option to the script.