### PR TITLE
Cleaning up leftover runners for `org/repo`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,6 +72,7 @@ jobs:
           ORG_NAME: gsamfira
           REPO_NAME: garm-testing
           CREDENTIALS_NAME: test-garm-creds
+          GH_TOKEN: ${{ secrets.GH_OAUTH_TOKEN }}
 
       - name: Show GARM logs
         if: always()


### PR DESCRIPTION
* This PR implements cleanup of the `orphan runners` for `org/repo`.
* I updated the PR with the following changes:
  * I replaced the `log.Fatalf` with `panic` to prevent the `exit 1` from interrupting the defer statement.
  * I put `graceful cleanup functions` in a function called `GracefulCleanup` and deferred it first.
  * Make sure that the `graceful cleanup functions` are idempotent.
  * I also added two functions: (`GhOrgRunnersCleanup` and `GhRepoRunnersCleanup`) to forcefully delete the runners via  `GitHub API` and deferred them after the `GracefulCleanup` function.