### PR TITLE
Small fixes for the docs

### DIFF
--- a/doc/database.md
+++ b/doc/database.md
@@ -12,8 +12,8 @@ GARM currently supports SQLite3. Support for other stores will be added in the f
   # the passphrase option is a temporary measure by which we encrypt the webhook
   # secret that gets saved to the database, using AES256. In the future, secrets
   # will be saved to something like Barbican or Vault, eliminating the need for
-  # this.
-  passphrase = "n<$n&P#L*TWqOh95_bN5J1r4mhxY7R84HZ%pvM#1vxJ<7~q%YVsCwU@Z60;7~Djo"
+  # this. This string needs to be 32 characters in size.
+  passphrase = "shreotsinWadquidAitNefayctowUrph"
   [database.sqlite3]
     # Path on disk to the sqlite3 database file.
     db_file = "/home/runner/garm.db"

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -71,7 +71,7 @@ time_to_live = "8760h"
     db_file = "/etc/garm/garm.db"
 ```
 
-This is a minimal config, with no providers or credentials defined. In this example we have the [default](./config_default.md), [metrics](./config_metrics.md), [jwt_auth](./config_jwt_auth.md), [apiserver](./config_api_server.md) and [database](./config_database.md) sections. Each are documented separately. Feel free to read through the available docs if, for example you need to enable TLS without using an nginx reverse proxy or if you want to enable the debug server, the log streamer or a log file.
+This is a minimal config, with no providers or credentials defined. In this example we have the [default](./config_default.md), [metrics](./config_metrics.md), [jwt_auth](./config_jwt_auth.md), [apiserver](./config_api_server.md) and [database](./database.md) sections. Each are documented separately. Feel free to read through the available docs if, for example you need to enable TLS without using an nginx reverse proxy or if you want to enable the debug server, the log streamer or a log file.
 
 In this sample config we:
 


### PR DESCRIPTION
* This PR update the following in the GARM docs:

  * `doc/database.md` --> The `passphrase` needs to have 32 characters.
  * `doc/quickstart.md` --> Correct the incorrect URL for `database.md`.