### PR TITLE
Add webhooks integration tests for `organization` and `repository`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,11 +22,20 @@ jobs:
       - name: Build GARM
         run: make build
 
+      - name: Set up ngrok
+        id: ngrok
+        uses: gabriel-samfira/ngrok-tunnel-action@v1.1
+        with:
+          ngrok_authtoken: ${{ secrets.NGROK_AUTH_TOKEN }}
+          port: 9997
+          tunnel_type: http
+
       - name: Setup GARM
         run: ./test/integration/scripts/setup-garm.sh
         env:
           GH_OAUTH_TOKEN: ${{ secrets.GH_OAUTH_TOKEN }}
           CREDENTIALS_NAME: test-garm-creds
+          GARM_BASE_URL: ${{ steps.ngrok.outputs.tunnel-url }}
 
       - name: Generate secrets
         run: |
@@ -46,14 +55,6 @@ jobs:
           echo "REPO_WEBHOOK_SECRET=$REPO_WEBHOOK_SECRET" >> $GITHUB_ENV
           echo "ORG_WEBHOOK_SECRET=$ORG_WEBHOOK_SECRET" >> $GITHUB_ENV
 
-      - name: Set up ngrok
-        id: ngrok
-        uses: gabriel-samfira/ngrok-tunnel-action@v1.1
-        with:
-          ngrok_authtoken: ${{ secrets.NGROK_AUTH_TOKEN }}
-          port: 9997
-          tunnel_type: http
-
       - name: Create logs directory
         if: always()
         run: sudo mkdir -p /artifacts-logs && sudo chmod 777 /artifacts-logs
@@ -72,6 +73,7 @@ jobs:
           ORG_NAME: gsamfira
           REPO_NAME: garm-testing
           CREDENTIALS_NAME: test-garm-creds
+          WORKFLOW_FILE_NAME: test.yml
           GH_TOKEN: ${{ secrets.GH_OAUTH_TOKEN }}
 
       - name: Show GARM logs

--- a/test/integration/config/config.toml
+++ b/test/integration/config/config.toml
@@ -1,6 +1,8 @@
 [default]
-callback_url = "http://${GARM_METADATA_IP}:9997/api/v1/callbacks/status"
-metadata_url = "http://${GARM_METADATA_IP}:9997/api/v1/metadata"
+callback_url = "${GARM_BASE_URL}/api/v1/callbacks/status"
+metadata_url = "${GARM_BASE_URL}/api/v1/metadata"
+webhook_url = "${GARM_BASE_URL}/webhooks"
+enable_webhook_management = true
 
 [metrics]
 enable = true

--- a/test/integration/scripts/setup-garm.sh
+++ b/test/integration/scripts/setup-garm.sh
@@ -13,6 +13,7 @@ fi
 
 if [[ -z $GH_OAUTH_TOKEN ]]; then echo "ERROR: The env variable GH_OAUTH_TOKEN is not set"; exit 1; fi
 if [[ -z $CREDENTIALS_NAME ]]; then echo "ERROR: The env variable CREDENTIALS_NAME is not set"; exit 1; fi
+if [[ -z $GARM_BASE_URL ]]; then echo "ERROR: The env variable GARM_BASE_URL is not set"; exit 1; fi
 
 # Generate a random 32-char secret for JWT_AUTH_SECRET and DB_PASSPHRASE.
 function generate_secret() {
@@ -34,9 +35,6 @@ function wait_open_port() {
     done
     echo "Port $PORT at address $ADDRESS is open"
 }
-
-# Use the LXD bridge IP address as the GARM metadata address.
-export GARM_METADATA_IP=$(lxc network ls -f json 2>/dev/null | jq -r '.[] | select(.name=="lxdbr0") | .config."ipv4.address"' | cut -d '/' -f1)
 
 export JWT_AUTH_SECRET="$(generate_secret)"
 export DB_PASSPHRASE="$(generate_secret)"


### PR DESCRIPTION
This PR implements the following changes:

  * Get `controller info`
  * `Install/get` webhooks for `org` and `repo`.
  * Trigger a `workflow test` with a specific `label name`.
  * Validate the job lifecycle with the following steps:
    * ensure the job is recorded in the job list.
    * ensure the job goes through `queued` and `in_progress` stages.
    * ensure the job runner instance is running and active.
    * ensure the job is completed.
    * ensure the runner instance is removed.
    * wait for GARM to rebuild pool running idle instances after the job is done.