### PR TITLE
Fix e2e secrets generation

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 0 * * *" 
+    - cron: "0 0 * * *"
 
 jobs:
   integration-tests:
@@ -38,14 +38,14 @@ jobs:
           REPO_WEBHOOK_SECRET=$(randomStringGenerator)
           ORG_WEBHOOK_SECRET=$(randomStringGenerator)
 
-          echo "::add-mask::$GARM_PASSWORD" 
-          echo "::add-mask::$REPO_WEBHOOK_SECRET" 
-          echo "::add-mask::$ORG_WEBHOOK_SECRET" 
+          echo "::add-mask::$GARM_PASSWORD"
+          echo "::add-mask::$REPO_WEBHOOK_SECRET"
+          echo "::add-mask::$ORG_WEBHOOK_SECRET"
 
           echo "GARM_PASSWORD=$GARM_PASSWORD" >> $GITHUB_ENV
           echo "REPO_WEBHOOK_SECRET=$REPO_WEBHOOK_SECRET" >> $GITHUB_ENV
           echo "ORG_WEBHOOK_SECRET=$ORG_WEBHOOK_SECRET" >> $GITHUB_ENV
-      
+
       - name: Set up ngrok
         id: ngrok
         uses: gabriel-samfira/ngrok-tunnel-action@v1.1
@@ -62,7 +62,7 @@ jobs:
         run: |
           set -o pipefail
           set -o errexit
-          go run ./test/integration/e2e.go 2>&1 | tee /artifacts-logs/e2e.log 
+          go run ./test/integration/e2e.go 2>&1 | tee /artifacts-logs/e2e.log
         env:
           GARM_BASE_URL: ${{ steps.ngrok.outputs.tunnel-url }}
           GARM_USERNAME: admin

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Generate secrets
         run: |
           function randomStringGenerator() {
-            tr -dc "a-zA-Z0-9@#$%^&*()_+?><~\`;'" </dev/urandom | head -c 64 ; echo '';
+            tr -dc "a-zA-Z0-9@#%^&*()_+?><~;" </dev/urandom | head -c 64 ; echo '';
           }
 
           GARM_PASSWORD=$(randomStringGenerator)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Generate secrets
         run: |
           function randomStringGenerator() {
-            tr -dc "a-zA-Z0-9@#%^&*()_+?><~;" </dev/urandom | head -c 64 ; echo '';
+            tr -dc "a-zA-Z0-9@#%^&*()_+?><~;" </dev/urandom 2>/dev/null | head -c 64 ; echo '';
           }
 
           GARM_PASSWORD=$(randomStringGenerator)


### PR DESCRIPTION
Some integration tests workflows failed with:
```
Error: Invalid format 'ORG_WEBHOOK_SECRET=***'
```
or
```
Error: Invalid format 'GARM_PASSWORD=***'
```

Workflow runs logs:
* https://github.com/cloudbase/garm/actions/runs/5920389694/job/16051606203#step:7:26
* https://github.com/cloudbase/garm/actions/runs/5908193226/job/16027297143#step:7:26

This is a transient error, as it only happens sometimes.

I suspect that sometimes there is some illegal sequence of characters
in the random generated strings. Thus, the GitHub actions logic to
parse the environment fails.

This change removes the special characters that would have a special
meaning in bash, from the `randomStringGenerator` function, in hopes
to fix the transient issue.

Also, silence `try` stderr messages, and fix spacing in the `integration-tests.yml` file.