### PR TITLE
Fix TLS client bug

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -86,7 +86,7 @@ func GithubClient(ctx context.Context, token string, credsDetails params.GithubC
 	}
 	httpTransport := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			ClientCAs: roots,
+			RootCAs: roots,
 		},
 	}
 	httpClient := &http.Client{Transport: httpTransport}


### PR DESCRIPTION
The CA bundle must be set on RootCAs to properly validate the remote server.