### PR TITLE
Fix `waitPoolRunningIdleInstances` function

### DIFF
--- a/test/integration/e2e/instances.go
+++ b/test/integration/e2e/instances.go
@@ -88,9 +88,11 @@ func waitPoolRunningIdleInstances(poolID string, timeout time.Duration) error {
 		poolInstances = make(params.Instances, 0)
 		runningIdleCount := 0
 		for _, instance := range instances {
-			if instance.PoolID == poolID {
-				poolInstances = append(poolInstances, instance)
+			if instance.PoolID != poolID {
+				continue
 			}
+			// current instance belongs to the pool we are waiting for
+			poolInstances = append(poolInstances, instance)
 			if instance.Status == commonParams.InstanceRunning && instance.RunnerStatus == params.RunnerIdle {
 				runningIdleCount++
 			}

--- a/test/integration/e2e/organizations.go
+++ b/test/integration/e2e/organizations.go
@@ -102,9 +102,8 @@ func WaitOrgRunningIdleInstances(orgID string, timeout time.Duration) {
 }
 
 func dumpOrgInstancesDetails(orgID string) error {
-	log.Printf("Dumping org %s instances details", orgID)
-
 	// print org details
+	log.Printf("Dumping org %s details", orgID)
 	org, err := getOrg(cli, authToken, orgID)
 	if err != nil {
 		return err
@@ -114,6 +113,7 @@ func dumpOrgInstancesDetails(orgID string) error {
 	}
 
 	// print org instances details
+	log.Printf("Dumping org %s instances details", orgID)
 	instances, err := listOrgInstances(cli, authToken, orgID)
 	if err != nil {
 		return err

--- a/test/integration/e2e/repositories.go
+++ b/test/integration/e2e/repositories.go
@@ -103,9 +103,8 @@ func WaitRepoRunningIdleInstances(repoID string, timeout time.Duration) {
 }
 
 func dumpRepoInstancesDetails(repoID string) error {
-	log.Printf("Dumping repo %s instances details", repoID)
-
 	// print repo details
+	log.Printf("Dumping repo %s details", repoID)
 	repo, err := getRepo(cli, authToken, repoID)
 	if err != nil {
 		return err
@@ -115,6 +114,7 @@ func dumpRepoInstancesDetails(repoID string) error {
 	}
 
 	// print repo instances details
+	log.Printf("Dumping repo %s instances details", repoID)
 	instances, err := listRepoInstances(cli, authToken, repoID)
 	if err != nil {
 		return err


### PR DESCRIPTION
The variable `runningIdleCount` would get incremented for instances on every pool, instead of only for the pool we are interested in. This change fixes this.

Also, adjust the logging message when error occurs in this timeout exceeded scenario.