### PR TITLE
Fix garm pool manager startup

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -1374,7 +1374,7 @@ func (r *basePoolManager) cleanupOrphanedRunners() error {
 }
 
 func (r *basePoolManager) Start() error {
-	r.updateTools() //nolint
+	go r.updateTools() //nolint
 
 	go r.startLoopForFunction(r.runnerCleanup, common.PoolReapTimeoutInterval, "timeout_reaper", false)
 	go r.startLoopForFunction(r.scaleDown, common.PoolScaleDownInterval, "scale_down", false)


### PR DESCRIPTION
If we fail to get the tools for one pool, garm fails to start due to pool manager startup timeout. Launch the initial tools update function as a goroutine and return from Start(). If it fails, it will retry, and we won't block garm from starting.