### PR TITLE
Properly set runner group when creating a pool

### DIFF
--- a/database/sql/enterprise.go
+++ b/database/sql/enterprise.go
@@ -151,6 +151,7 @@ func (s *sqlDatabase) CreateEnterprisePool(ctx context.Context, enterpriseID str
 		EnterpriseID:           &enterprise.ID,
 		Enabled:                param.Enabled,
 		RunnerBootstrapTimeout: param.RunnerBootstrapTimeout,
+		GitHubRunnerGroup:      param.GitHubRunnerGroup,
 	}
 
 	if len(param.ExtraSpecs) > 0 {

--- a/database/sql/organizations.go
+++ b/database/sql/organizations.go
@@ -168,6 +168,7 @@ func (s *sqlDatabase) CreateOrganizationPool(ctx context.Context, orgId string, 
 		OrgID:                  &org.ID,
 		Enabled:                param.Enabled,
 		RunnerBootstrapTimeout: param.RunnerBootstrapTimeout,
+		GitHubRunnerGroup:      param.GitHubRunnerGroup,
 	}
 
 	if len(param.ExtraSpecs) > 0 {

--- a/database/sql/repositories.go
+++ b/database/sql/repositories.go
@@ -168,6 +168,7 @@ func (s *sqlDatabase) CreateRepositoryPool(ctx context.Context, repoId string, p
 		RepoID:                 &repo.ID,
 		Enabled:                param.Enabled,
 		RunnerBootstrapTimeout: param.RunnerBootstrapTimeout,
+		GitHubRunnerGroup:      param.GitHubRunnerGroup,
 	}
 
 	if len(param.ExtraSpecs) > 0 {


### PR DESCRIPTION
The github runner group was not being set during pool creation. this change fixes that.