### PR TITLE
Add relation to jobs

### DIFF
--- a/database/sql/instances_test.go
+++ b/database/sql/instances_test.go
@@ -295,6 +295,10 @@ func (s *InstancesTestSuite) TestDeleteInstanceDBRecordNotFoundErr() {
 		WithArgs(instance.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"address", "type", "instance_id"}).AddRow("10.10.1.10", "private", instance.ID))
 	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `workflow_jobs` WHERE `workflow_jobs`.`instance_id` = ? AND `workflow_jobs`.`deleted_at` IS NULL")).
+		WithArgs(instance.ID).
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `instance_status_updates` WHERE `instance_status_updates`.`instance_id` = ? AND `instance_status_updates`.`deleted_at` IS NULL")).
 		WithArgs(instance.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"message", "instance_id"}).AddRow("instance sample message", instance.ID))
@@ -327,6 +331,10 @@ func (s *InstancesTestSuite) TestDeleteInstanceDBDeleteErr() {
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `addresses` WHERE `addresses`.`instance_id` = ? AND `addresses`.`deleted_at` IS NULL")).
 		WithArgs(instance.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"address", "type", "instance_id"}).AddRow("12.10.12.13", "public", instance.ID))
+	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `workflow_jobs` WHERE `workflow_jobs`.`instance_id` = ? AND `workflow_jobs`.`deleted_at` IS NULL")).
+		WithArgs(instance.ID).
+		WillReturnRows(sqlmock.NewRows([]string{}))
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `instance_status_updates` WHERE `instance_status_updates`.`instance_id` = ? AND `instance_status_updates`.`deleted_at` IS NULL")).
 		WithArgs(instance.ID).
@@ -379,6 +387,10 @@ func (s *InstancesTestSuite) TestAddInstanceEventDBUpdateErr() {
 		WithArgs(instance.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"address", "type", "instance_id"}).AddRow("10.10.1.10", "private", instance.ID))
 	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `workflow_jobs` WHERE `workflow_jobs`.`instance_id` = ? AND `workflow_jobs`.`deleted_at` IS NULL")).
+		WithArgs(instance.ID).
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `instance_status_updates` WHERE `instance_status_updates`.`instance_id` = ? AND `instance_status_updates`.`deleted_at` IS NULL")).
 		WithArgs(instance.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"message", "instance_id"}).AddRow("instance sample message", instance.ID))
@@ -430,6 +442,10 @@ func (s *InstancesTestSuite) TestUpdateInstanceDBUpdateInstanceErr() {
 		WithArgs(instance.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"address", "type", "instance_id"}).AddRow("10.10.1.10", "private", instance.ID))
 	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `workflow_jobs` WHERE `workflow_jobs`.`instance_id` = ? AND `workflow_jobs`.`deleted_at` IS NULL")).
+		WithArgs(instance.ID).
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `instance_status_updates` WHERE `instance_status_updates`.`instance_id` = ? AND `instance_status_updates`.`deleted_at` IS NULL")).
 		WithArgs(instance.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"message", "instance_id"}).AddRow("instance sample message", instance.ID))
@@ -457,6 +473,10 @@ func (s *InstancesTestSuite) TestUpdateInstanceDBUpdateAddressErr() {
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `addresses` WHERE `addresses`.`instance_id` = ? AND `addresses`.`deleted_at` IS NULL")).
 		WithArgs(instance.ID).
 		WillReturnRows(sqlmock.NewRows([]string{"address", "type", "instance_id"}).AddRow("10.10.1.10", "private", instance.ID))
+	s.Fixtures.SQLMock.
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `workflow_jobs` WHERE `workflow_jobs`.`instance_id` = ? AND `workflow_jobs`.`deleted_at` IS NULL")).
+		WithArgs(instance.ID).
+		WillReturnRows(sqlmock.NewRows([]string{}))
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `instance_status_updates` WHERE `instance_status_updates`.`instance_id` = ? AND `instance_status_updates`.`deleted_at` IS NULL")).
 		WithArgs(instance.ID).

--- a/database/sql/models.go
+++ b/database/sql/models.go
@@ -162,6 +162,8 @@ type Instance struct {
 	Pool   Pool `gorm:"foreignKey:PoolID"`
 
 	StatusMessages []InstanceStatusUpdate `gorm:"foreignKey:InstanceID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
+
+	Job *WorkflowJob `gorm:"foreignKey:InstanceID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
 }
 
 type User struct {
@@ -201,8 +203,11 @@ type WorkflowJob struct {
 	StartedAt   time.Time
 	CompletedAt time.Time
 
-	GithubRunnerID  int64
-	RunnerName      string
+	GithubRunnerID int64
+
+	InstanceID *uuid.UUID `gorm:"index:idx_instance_job"`
+	Instance   Instance   `gorm:"foreignKey:InstanceID"`
+
 	RunnerGroupID   int64
 	RunnerGroupName string
 

--- a/runner/common/mocks/GithubClient.go
+++ b/runner/common/mocks/GithubClient.go
@@ -521,6 +521,58 @@ func (_m *GithubClient) ListRunners(ctx context.Context, owner string, repo stri
 	return r0, r1, r2
 }
 
+// PingOrgHook provides a mock function with given fields: ctx, org, id
+func (_m *GithubClient) PingOrgHook(ctx context.Context, org string, id int64) (*github.Response, error) {
+	ret := _m.Called(ctx, org, id)
+
+	var r0 *github.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64) (*github.Response, error)); ok {
+		return rf(ctx, org, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64) *github.Response); ok {
+		r0 = rf(ctx, org, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64) error); ok {
+		r1 = rf(ctx, org, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PingRepoHook provides a mock function with given fields: ctx, owner, repo, id
+func (_m *GithubClient) PingRepoHook(ctx context.Context, owner string, repo string, id int64) (*github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, id)
+
+	var r0 *github.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64) (*github.Response, error)); ok {
+		return rf(ctx, owner, repo, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64) *github.Response); ok {
+		r0 = rf(ctx, owner, repo, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int64) error); ok {
+		r1 = rf(ctx, owner, repo, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RemoveOrganizationRunner provides a mock function with given fields: ctx, owner, runnerID
 func (_m *GithubClient) RemoveOrganizationRunner(ctx context.Context, owner string, runnerID int64) (*github.Response, error) {
 	ret := _m.Called(ctx, owner, runnerID)

--- a/runner/common/mocks/OrganizationHooks.go
+++ b/runner/common/mocks/OrganizationHooks.go
@@ -145,6 +145,32 @@ func (_m *OrganizationHooks) ListOrgHooks(ctx context.Context, org string, opts 
 	return r0, r1, r2
 }
 
+// PingOrgHook provides a mock function with given fields: ctx, org, id
+func (_m *OrganizationHooks) PingOrgHook(ctx context.Context, org string, id int64) (*github.Response, error) {
+	ret := _m.Called(ctx, org, id)
+
+	var r0 *github.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64) (*github.Response, error)); ok {
+		return rf(ctx, org, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, int64) *github.Response); ok {
+		r0 = rf(ctx, org, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, int64) error); ok {
+		r1 = rf(ctx, org, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewOrganizationHooks creates a new instance of OrganizationHooks. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewOrganizationHooks(t interface {

--- a/runner/common/mocks/RepositoryHooks.go
+++ b/runner/common/mocks/RepositoryHooks.go
@@ -145,6 +145,32 @@ func (_m *RepositoryHooks) ListRepoHooks(ctx context.Context, owner string, repo
 	return r0, r1, r2
 }
 
+// PingRepoHook provides a mock function with given fields: ctx, owner, repo, id
+func (_m *RepositoryHooks) PingRepoHook(ctx context.Context, owner string, repo string, id int64) (*github.Response, error) {
+	ret := _m.Called(ctx, owner, repo, id)
+
+	var r0 *github.Response
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64) (*github.Response, error)); ok {
+		return rf(ctx, owner, repo, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64) *github.Response); ok {
+		r0 = rf(ctx, owner, repo, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*github.Response)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int64) error); ok {
+		r1 = rf(ctx, owner, repo, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // NewRepositoryHooks creates a new instance of RepositoryHooks. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewRepositoryHooks(t interface {


### PR DESCRIPTION
GARM relies on a combination of webhook events and polling to function properly. While most times we will successfully receive webhooks, in some cases we may miss some. Be it because we were offline or because GitHub is having an issue.

When it comes to runners, we periodically check for orphaned runners and clean them up. For Jobs on the other hand, we only check those that are in `queued` state, under certain circumstances. Once they transition to any other state (other than `completed` or `queued`), we don't really check them any more.

Jobs that transition to `in_progress` will generally have a runner associated. This change adds a foreign key constraint between the runner (if found) and the job. We also set an `on delete cascade` constraint on that foreign key. 

This will ensure that when we clean up orphaned runners, we also clean up jobs that they are associated with.