### PR TITLE
Add root CA bundle metadata URL

### DIFF
--- a/apiserver/controllers/instances.go
+++ b/apiserver/controllers/instances.go
@@ -316,19 +316,3 @@ func (a *APIController) InstanceStatusMessageHandler(w http.ResponseWriter, r *h
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 }
-
-func (a *APIController) InstanceGithubRegistrationTokenHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	token, err := a.r.GetInstanceGithubRegistrationToken(ctx)
-	if err != nil {
-		handleError(w, err)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(token)); err != nil {
-		log.Printf("failed to encode response: %q", err)
-	}
-}

--- a/apiserver/controllers/metadata.go
+++ b/apiserver/controllers/metadata.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package controllers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+func (a *APIController) InstanceGithubRegistrationTokenHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	token, err := a.r.GetInstanceGithubRegistrationToken(ctx)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(token)); err != nil {
+		log.Printf("failed to encode response: %q", err)
+	}
+}
+
+func (a *APIController) RootCertificateBundleHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	bundle, err := a.r.GetRootCertificateBundle(ctx)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(bundle); err != nil {
+		log.Printf("failed to encode response: %q", err)
+	}
+}

--- a/apiserver/routers/routers.go
+++ b/apiserver/routers/routers.go
@@ -108,10 +108,18 @@ func NewAPIRouter(han *controllers.APIController, logWriter io.Writer, authMiddl
 	callbackRouter.Handle("/status", http.HandlerFunc(han.InstanceStatusMessageHandler)).Methods("POST", "OPTIONS")
 	callbackRouter.Use(instanceMiddleware.Middleware)
 
+	///////////////////
+	// Metadata URLs //
+	///////////////////
 	metadataRouter := apiSubRouter.PathPrefix("/metadata").Subrouter()
+	metadataRouter.Use(instanceMiddleware.Middleware)
+
+	// Registration token
 	metadataRouter.Handle("/runner-registration-token/", http.HandlerFunc(han.InstanceGithubRegistrationTokenHandler)).Methods("GET", "OPTIONS")
 	metadataRouter.Handle("/runner-registration-token", http.HandlerFunc(han.InstanceGithubRegistrationTokenHandler)).Methods("GET", "OPTIONS")
-	metadataRouter.Use(instanceMiddleware.Middleware)
+	metadataRouter.Handle("/system/cert-bundle/", http.HandlerFunc(han.RootCertificateBundleHandler)).Methods("GET", "OPTIONS")
+	metadataRouter.Handle("/system/cert-bundle", http.HandlerFunc(han.RootCertificateBundleHandler)).Methods("GET", "OPTIONS")
+
 	// Login
 	authRouter := apiSubRouter.PathPrefix("/auth").Subrouter()
 	authRouter.Handle("/{login:login\\/?}", http.HandlerFunc(han.LoginHandler)).Methods("POST", "OPTIONS")

--- a/auth/context.go
+++ b/auth/context.go
@@ -17,6 +17,7 @@ package auth
 import (
 	"context"
 
+	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/params"
 )
 
@@ -38,6 +39,7 @@ const (
 	instanceEntityKey    contextFlags = "entity"
 	instanceRunnerStatus contextFlags = "status"
 	instanceTokenFetched contextFlags = "tokenFetched"
+	instanceParams       contextFlags = "instanceParams"
 )
 
 func SetInstanceID(ctx context.Context, id string) context.Context {
@@ -62,6 +64,23 @@ func InstanceTokenFetched(ctx context.Context) bool {
 		return false
 	}
 	return elem.(bool)
+}
+
+func SetInstanceParams(ctx context.Context, instance params.Instance) context.Context {
+	return context.WithValue(ctx, instanceParams, instance)
+}
+
+func InstanceParams(ctx context.Context) (params.Instance, error) {
+	elem := ctx.Value(instanceParams)
+	if elem == nil {
+		return params.Instance{}, runnerErrors.ErrNotFound
+	}
+
+	instanceParams, ok := elem.(params.Instance)
+	if !ok {
+		return params.Instance{}, runnerErrors.ErrNotFound
+	}
+	return instanceParams, nil
 }
 
 func SetInstanceRunnerStatus(ctx context.Context, val params.RunnerStatus) context.Context {
@@ -130,6 +149,7 @@ func PopulateInstanceContext(ctx context.Context, instance params.Instance) cont
 	ctx = SetInstancePoolID(ctx, instance.PoolID)
 	ctx = SetInstanceRunnerStatus(ctx, instance.RunnerStatus)
 	ctx = SetInstanceTokenFetched(ctx, instance.TokenFetched)
+	ctx = SetInstanceParams(ctx, instance)
 	return ctx
 }
 

--- a/runner/common/mocks/PoolManager.go
+++ b/runner/common/mocks/PoolManager.go
@@ -142,6 +142,30 @@ func (_m *PoolManager) RefreshState(param params.UpdatePoolStateParams) error {
 	return r0
 }
 
+// RootCABundle provides a mock function with given fields:
+func (_m *PoolManager) RootCABundle() (params.CertificateBundle, error) {
+	ret := _m.Called()
+
+	var r0 params.CertificateBundle
+	var r1 error
+	if rf, ok := ret.Get(0).(func() (params.CertificateBundle, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() params.CertificateBundle); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(params.CertificateBundle)
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Start provides a mock function with given fields:
 func (_m *PoolManager) Start() error {
 	ret := _m.Called()

--- a/runner/common/pool.go
+++ b/runner/common/pool.go
@@ -49,6 +49,8 @@ type PoolManager interface {
 	GetWebhookInfo(ctx context.Context) (params.HookInfo, error)
 	UninstallWebhook(ctx context.Context) error
 
+	RootCABundle() (params.CertificateBundle, error)
+
 	// PoolManager lifecycle functions. Start/stop pool.
 	Start() error
 	Stop() error

--- a/runner/metadata.go
+++ b/runner/metadata.go
@@ -1,0 +1,34 @@
+package runner
+
+import (
+	"context"
+	"log"
+
+	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
+	"github.com/cloudbase/garm/auth"
+	"github.com/cloudbase/garm/params"
+	"github.com/pkg/errors"
+)
+
+func (r *Runner) GetRootCertificateBundle(ctx context.Context) (params.CertificateBundle, error) {
+	instance, err := auth.InstanceParams(ctx)
+	if err != nil {
+		log.Printf("failed to get instance params: %s", err)
+		return params.CertificateBundle{}, runnerErrors.ErrUnauthorized
+	}
+
+	poolMgr, err := r.getPoolManagerFromInstance(ctx, instance)
+	if err != nil {
+		return params.CertificateBundle{}, errors.Wrap(err, "fetching pool manager for instance")
+	}
+
+	bundle, err := poolMgr.RootCABundle()
+	if err != nil {
+		log.Printf("failed to get root CA bundle: %s", err)
+		// The root CA bundle is invalid. Return an empty bundle to the runner and log the event.
+		return params.CertificateBundle{
+			RootCertificates: make(map[string][]byte),
+		}, nil
+	}
+	return bundle, nil
+}

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -1643,3 +1643,7 @@ func (r *basePoolManager) UninstallWebhook(ctx context.Context) error {
 func (r *basePoolManager) GetWebhookInfo(ctx context.Context) (params.HookInfo, error) {
 	return r.helper.GetHookInfo(ctx)
 }
+
+func (r *basePoolManager) RootCABundle() (params.CertificateBundle, error) {
+	return r.credsDetails.RootCertificateBundle()
+}


### PR DESCRIPTION
Thic change adds a metadata endpoint that returns a list of root CA certificates a runner must install in order to be able to validate all relevant API endpoints it may require. This includes any GHES API that runs on a self signed certificate.