### PR TITLE
Add option to disable JIT config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -219,8 +219,12 @@ type Provider struct {
 	Name         string              `toml:"name" json:"name"`
 	ProviderType params.ProviderType `toml:"provider_type" json:"provider-type"`
 	Description  string              `toml:"description" json:"description"`
-	LXD          LXD                 `toml:"lxd" json:"lxd"`
-	External     External            `toml:"external" json:"external"`
+	// DisableJITConfig explicitly disables JIT configuration and forces runner registration
+	// tokens to be used. This may happen if a provider has not yet been updated to support
+	// JIT configuration.
+	DisableJITConfig bool     `toml:"disable_jit_config" json:"disable-jit-config"`
+	LXD              LXD      `toml:"lxd" json:"lxd"`
+	External         External `toml:"external" json:"external"`
 }
 
 func (p *Provider) Validate() error {

--- a/runner/common/mocks/Provider.go
+++ b/runner/common/mocks/Provider.go
@@ -68,6 +68,20 @@ func (_m *Provider) DeleteInstance(ctx context.Context, instance string) error {
 	return r0
 }
 
+// DisableJITConfig provides a mock function with given fields:
+func (_m *Provider) DisableJITConfig() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // GetInstance provides a mock function with given fields: ctx, instance
 func (_m *Provider) GetInstance(ctx context.Context, instance string) (garm_provider_commonparams.ProviderInstance, error) {
 	ret := _m.Called(ctx, instance)

--- a/runner/common/provider.go
+++ b/runner/common/provider.go
@@ -37,6 +37,10 @@ type Provider interface {
 	Stop(ctx context.Context, instance string, force bool) error
 	// Start boots up an instance.
 	Start(ctx context.Context, instance string) error
+	// DisableJITConfig tells us if the provider explicitly disables JIT configuration and
+	// forces runner registration tokens to be used. This may happen if a provider has not yet
+	// been updated to support JIT configuration.
+	DisableJITConfig() bool
 
 	AsParams() params.Provider
 }

--- a/runner/providers/external/external.go
+++ b/runner/providers/external/external.go
@@ -242,3 +242,13 @@ func (e *external) AsParams() params.Provider {
 		ProviderType: e.cfg.ProviderType,
 	}
 }
+
+// DisableJITConfig tells us if the provider explicitly disables JIT configuration and
+// forces runner registration tokens to be used. This may happen if a provider has not yet
+// been updated to support JIT configuration.
+func (e *external) DisableJITConfig() bool {
+	if e.cfg == nil {
+		return false
+	}
+	return e.cfg.DisableJITConfig
+}

--- a/runner/providers/lxd/lxd.go
+++ b/runner/providers/lxd/lxd.go
@@ -518,3 +518,13 @@ func (l *LXD) Stop(ctx context.Context, instance string, force bool) error {
 func (l *LXD) Start(ctx context.Context, instance string) error {
 	return l.setState(instance, "start", false)
 }
+
+// DisableJITConfig tells us if the provider explicitly disables JIT configuration and
+// forces runner registration tokens to be used. This may happen if a provider has not yet
+// been updated to support JIT configuration.
+func (l *LXD) DisableJITConfig() bool {
+	if l.cfg == nil {
+		return false
+	}
+	return l.cfg.DisableJITConfig
+}

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -112,15 +112,21 @@ time_to_live = "8760h"
 # provider must not be changed, or the pool will no longer work. Make sure you remove any
 # pools before removing or changing a provider.
 [[provider]]
-  # An arbitrary string describing this provider.
-  name = "lxd_local"
-  # Provider type. Garm is designed to allow creating providers which are used to spin
-  # up compute resources, which in turn will run the github runner software.
-  # Currently, LXD is the only supprted provider, but more will be written in the future.
-  provider_type = "lxd"
-  # A short description of this provider. The name, description and provider types will
-  # be included in the information returned by the API when listing available providers.
-  description = "Local LXD installation"
+# An arbitrary string describing this provider.
+name = "lxd_local"
+# Provider type. Garm is designed to allow creating providers which are used to spin
+# up compute resources, which in turn will run the github runner software.
+# Currently, LXD is the only supprted provider, but more will be written in the future.
+provider_type = "lxd"
+# A short description of this provider. The name, description and provider types will
+# be included in the information returned by the API when listing available providers.
+description = "Local LXD installation"
+# DisableJITConfig explicitly disables JIT configuration and forces runner registration
+# tokens to be used. This may happen if a provider has not yet been updated to support
+# JIT configuration.
+#
+# Set this to true if your provider does not support JIT configuration.
+disable_jit_config = false
   [provider.lxd]
     # the path to the unix socket that LXD is listening on. This works if garm and LXD
     # are on the same system, and this option takes precedence over the "url" option,
@@ -191,6 +197,12 @@ time_to_live = "8760h"
 name = "openstack_external"
 description = "external openstack provider"
 provider_type = "external"
+# DisableJITConfig explicitly disables JIT configuration and forces runner registration
+# tokens to be used. This may happen if a provider has not yet been updated to support
+# JIT configuration.
+#
+# Set this to true if your provider does not support JIT configuration.
+disable_jit_config = false
   [provider.external]
   # config file passed to the executable via GARM_PROVIDER_CONFIG_FILE environment variable
   config_file = "/etc/garm/providers.d/openstack/keystonerc"
@@ -203,6 +215,12 @@ provider_type = "external"
 name = "azure_external"
 description = "external azure provider"
 provider_type = "external"
+# DisableJITConfig explicitly disables JIT configuration and forces runner registration
+# tokens to be used. This may happen if a provider has not yet been updated to support
+# JIT configuration.
+#
+# Set this to true if your provider does not support JIT configuration.
+disable_jit_config = false
   [provider.external]
   # config file passed to the executable via GARM_PROVIDER_CONFIG_FILE environment variable
   config_file = "/etc/garm/providers.d/azure/config.sh"


### PR DESCRIPTION
This change adds a flag on providers that allows users to disable JIT configuration even when it's available. For context, JIT is available on github.com and any GHES instance >=3.10.

This option is a stopgap measure for providers that have not yet been updated to use JIT configs instead of runner registration tokens.