### PR TITLE
Export required variables

### DIFF
--- a/test/integration/scripts/setup-garm.sh
+++ b/test/integration/scripts/setup-garm.sh
@@ -7,8 +7,8 @@ CONTRIB_DIR="$PWD/contrib"
 CONFIG_DIR="$PWD/test/integration/config"
 CONFIG_DIR_PROV="$PWD/test/integration/provider"
 PROVIDER_BIN_DIR="/opt/garm/providers.d/lxd"
-LXD_PROVIDER_EXECUTABLE="$PROVIDER_BIN_DIR/garm-provider-lxd"
-LXD_PROVIDER_CONFIG="$CONFIG_DIR/garm-provider-lxd.toml"
+export LXD_PROVIDER_EXECUTABLE="$PROVIDER_BIN_DIR/garm-provider-lxd"
+export LXD_PROVIDER_CONFIG="$CONFIG_DIR/garm-provider-lxd.toml"
 
 if [[ ! -f $BINARIES_DIR/garm ]] || [[ ! -f $BINARIES_DIR/garm-cli ]]; then
     echo "ERROR: Please build GARM binaries first"
@@ -49,7 +49,7 @@ sudo useradd --shell /usr/bin/false --system --groups adm --no-create-home garm
 sudo mkdir -p $PROVIDER_BIN_DIR
 git clone https://github.com/cloudbase/garm-provider-lxd ~/garm-provider-lxd
 pushd ~/garm-provider-lxd
-go build -o $PROVIDER_BIN_DIR/garm-provider-lxd
+go build -o $LXD_PROVIDER_EXECUTABLE
 popd
 
 sudo mkdir -p /etc/garm


### PR DESCRIPTION
We need to export the variables before they can be used with envsubst. 