### PR TITLE
Add system-info instance callback

### DIFF
--- a/apiserver/controllers/instances.go
+++ b/apiserver/controllers/instances.go
@@ -324,3 +324,23 @@ func (a *APIController) InstanceStatusMessageHandler(w http.ResponseWriter, r *h
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 }
+
+func (a *APIController) InstanceSystemInfoHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var updateMessage runnerParams.UpdateSystemInfoParams
+	if err := json.NewDecoder(r.Body).Decode(&updateMessage); err != nil {
+		log.Printf("failed to decode: %s", err)
+		handleError(w, gErrors.ErrBadRequest)
+		return
+	}
+
+	if err := a.r.UpdateSystemInfo(ctx, updateMessage); err != nil {
+		log.Printf("error saving status message: %s", err)
+		handleError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+}

--- a/apiserver/routers/routers.go
+++ b/apiserver/routers/routers.go
@@ -106,6 +106,8 @@ func NewAPIRouter(han *controllers.APIController, logWriter io.Writer, authMiddl
 	callbackRouter := apiSubRouter.PathPrefix("/callbacks").Subrouter()
 	callbackRouter.Handle("/status/", http.HandlerFunc(han.InstanceStatusMessageHandler)).Methods("POST", "OPTIONS")
 	callbackRouter.Handle("/status", http.HandlerFunc(han.InstanceStatusMessageHandler)).Methods("POST", "OPTIONS")
+	callbackRouter.Handle("/system-info/", http.HandlerFunc(han.InstanceSystemInfoHandler)).Methods("POST", "OPTIONS")
+	callbackRouter.Handle("/system-info", http.HandlerFunc(han.InstanceSystemInfoHandler)).Methods("POST", "OPTIONS")
 	callbackRouter.Use(instanceMiddleware.Middleware)
 
 	///////////////////

--- a/params/params.go
+++ b/params/params.go
@@ -566,3 +566,9 @@ type HookInfo struct {
 type CertificateBundle struct {
 	RootCertificates map[string][]byte `json:"root_certificates"`
 }
+
+type UpdateSystemInfoParams struct {
+	OSName    string `json:"os_name,omitempty"`
+	OSVersion string `json:"os_version,omitempty"`
+	AgentID   *int64 `json:"agent_id,omitempty"`
+}

--- a/params/requests.go
+++ b/params/requests.go
@@ -239,5 +239,5 @@ type UpdateEntityParams struct {
 type InstanceUpdateMessage struct {
 	Status  RunnerStatus `json:"status"`
 	Message string       `json:"message"`
-	AgentID *int64       `json:"agent_id"`
+	AgentID *int64       `json:"agent_id,omitempty"`
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -852,7 +852,35 @@ func (r *Runner) AddInstanceStatusMessage(ctx context.Context, param params.Inst
 	}
 
 	if _, err := r.store.UpdateInstance(r.ctx, instanceID, updateParams); err != nil {
-		return errors.Wrap(err, "updating runner state")
+		return errors.Wrap(err, "updating runner agent ID")
+	}
+
+	return nil
+}
+
+func (r *Runner) UpdateSystemInfo(ctx context.Context, param params.UpdateSystemInfoParams) error {
+	instanceID := auth.InstanceID(ctx)
+	if instanceID == "" {
+		log.Printf("missing instance ID")
+		return runnerErrors.ErrUnauthorized
+	}
+
+	if param.OSName == "" && param.OSVersion == "" && param.AgentID == nil {
+		// Nothing to update
+		return nil
+	}
+
+	updateParams := params.UpdateInstanceParams{
+		OSName:    param.OSName,
+		OSVersion: param.OSVersion,
+	}
+
+	if param.AgentID != nil {
+		updateParams.AgentID = *param.AgentID
+	}
+
+	if _, err := r.store.UpdateInstance(r.ctx, instanceID, updateParams); err != nil {
+		return errors.Wrap(err, "updating runner system info")
 	}
 
 	return nil


### PR DESCRIPTION
Allow runners to update their own system information. The goal is to get better info about the runners that we spawn. Right now we just retrieve os_name, os_version and agent_id, but this can be expanded later to include other info.

We also want to collect the actual agent_id of the GH runner using a callback that makes more sense. The status updates should only report installation status, which is informational.