### PR TITLE
Switch to slog

### DIFF
--- a/apiserver/controllers/enterprises.go
+++ b/apiserver/controllers/enterprises.go
@@ -16,7 +16,7 @@ package controllers
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 
 	gErrors "github.com/cloudbase/garm-provider-common/errors"
@@ -45,20 +45,20 @@ func (a *APIController) CreateEnterpriseHandler(w http.ResponseWriter, r *http.R
 
 	var enterpriseData runnerParams.CreateEnterpriseParams
 	if err := json.NewDecoder(r.Body).Decode(&enterpriseData); err != nil {
-		handleError(w, gErrors.ErrBadRequest)
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	enterprise, err := a.r.CreateEnterprise(ctx, enterpriseData)
 	if err != nil {
-		log.Printf("error creating enterprise: %+v", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating enterprise")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(enterprise); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -74,14 +74,14 @@ func (a *APIController) ListEnterprisesHandler(w http.ResponseWriter, r *http.Re
 
 	enterprise, err := a.r.ListEnterprises(ctx)
 	if err != nil {
-		log.Printf("listing enterprise: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing enterprise")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(enterprise); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -110,21 +110,21 @@ func (a *APIController) GetEnterpriseByIDHandler(w http.ResponseWriter, r *http.
 			Error:   "Bad Request",
 			Details: "No enterprise ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	enterprise, err := a.r.GetEnterpriseByID(ctx, enterpriseID)
 	if err != nil {
-		log.Printf("fetching enterprise: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "fetching enterprise")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(enterprise); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -152,14 +152,14 @@ func (a *APIController) DeleteEnterpriseHandler(w http.ResponseWriter, r *http.R
 			Error:   "Bad Request",
 			Details: "No enterprise ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	if err := a.r.DeleteEnterprise(ctx, enterpriseID); err != nil {
-		log.Printf("removing enterprise: %+v", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing enterprise")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -198,27 +198,27 @@ func (a *APIController) UpdateEnterpriseHandler(w http.ResponseWriter, r *http.R
 			Error:   "Bad Request",
 			Details: "No enterprise ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var updatePayload runnerParams.UpdateEntityParams
 	if err := json.NewDecoder(r.Body).Decode(&updatePayload); err != nil {
-		handleError(w, gErrors.ErrBadRequest)
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	enterprise, err := a.r.UpdateEnterprise(ctx, enterpriseID, updatePayload)
 	if err != nil {
-		log.Printf("error updating enterprise: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error updating enterprise: %s")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(enterprise); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -253,28 +253,28 @@ func (a *APIController) CreateEnterprisePoolHandler(w http.ResponseWriter, r *ht
 			Error:   "Bad Request",
 			Details: "No enterprise ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var poolData runnerParams.CreatePoolParams
 	if err := json.NewDecoder(r.Body).Decode(&poolData); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	pool, err := a.r.CreateEnterprisePool(ctx, enterpriseID, poolData)
 	if err != nil {
-		log.Printf("error creating enterprise pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating enterprise pool")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -302,21 +302,21 @@ func (a *APIController) ListEnterprisePoolsHandler(w http.ResponseWriter, r *htt
 			Error:   "Bad Request",
 			Details: "No enterprise ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	pools, err := a.r.ListEnterprisePools(ctx, enterpriseID)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pools); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 
 }
@@ -352,21 +352,21 @@ func (a *APIController) GetEnterprisePoolHandler(w http.ResponseWriter, r *http.
 			Error:   "Bad Request",
 			Details: "No enterprise or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	pool, err := a.r.GetEnterprisePoolByID(ctx, enterpriseID, poolID)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -401,14 +401,14 @@ func (a *APIController) DeleteEnterprisePoolHandler(w http.ResponseWriter, r *ht
 			Error:   "Bad Request",
 			Details: "No enterprise or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	if err := a.r.DeleteEnterprisePool(ctx, enterpriseID, poolID); err != nil {
-		log.Printf("removing pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing pool")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -455,27 +455,27 @@ func (a *APIController) UpdateEnterprisePoolHandler(w http.ResponseWriter, r *ht
 			Error:   "Bad Request",
 			Details: "No enterprise or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var poolData runnerParams.UpdatePoolParams
 	if err := json.NewDecoder(r.Body).Decode(&poolData); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	pool, err := a.r.UpdateEnterprisePool(ctx, enterpriseID, poolID, poolData)
 	if err != nil {
-		log.Printf("error creating enterprise pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating enterprise pool")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }

--- a/apiserver/controllers/instances.go
+++ b/apiserver/controllers/instances.go
@@ -16,7 +16,7 @@ package controllers
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -51,21 +51,21 @@ func (a *APIController) ListPoolInstancesHandler(w http.ResponseWriter, r *http.
 			Error:   "Bad Request",
 			Details: "No pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	instances, err := a.r.ListPoolInstances(ctx, poolID)
 	if err != nil {
-		log.Printf("listing pool instances: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pool instances")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(instances); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -93,21 +93,21 @@ func (a *APIController) GetInstanceHandler(w http.ResponseWriter, r *http.Reques
 			Error:   "Bad Request",
 			Details: "No runner name specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	instance, err := a.r.GetInstance(ctx, instanceName)
 	if err != nil {
-		log.Printf("listing instances: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing instances")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(instance); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -140,15 +140,15 @@ func (a *APIController) DeleteInstanceHandler(w http.ResponseWriter, r *http.Req
 			Error:   "Bad Request",
 			Details: "No instance name specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	forceRemove, _ := strconv.ParseBool(r.URL.Query().Get("forceRemove"))
 	if err := a.r.DeleteRunner(ctx, instanceName, forceRemove); err != nil {
-		log.Printf("removing runner: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing runner")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -180,21 +180,21 @@ func (a *APIController) ListRepoInstancesHandler(w http.ResponseWriter, r *http.
 			Error:   "Bad Request",
 			Details: "No repo ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	instances, err := a.r.ListRepoInstances(ctx, repoID)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(instances); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -222,21 +222,21 @@ func (a *APIController) ListOrgInstancesHandler(w http.ResponseWriter, r *http.R
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	instances, err := a.r.ListOrgInstances(ctx, orgID)
 	if err != nil {
-		log.Printf("listing instances: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing instances")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(instances); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -264,21 +264,21 @@ func (a *APIController) ListEnterpriseInstancesHandler(w http.ResponseWriter, r 
 			Error:   "Bad Request",
 			Details: "No enterprise ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	instances, err := a.r.ListEnterpriseInstances(ctx, enterpriseID)
 	if err != nil {
-		log.Printf("listing instances: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing instances")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(instances); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -294,14 +294,14 @@ func (a *APIController) ListAllInstancesHandler(w http.ResponseWriter, r *http.R
 
 	instances, err := a.r.ListAllInstances(ctx)
 	if err != nil {
-		log.Printf("listing instances: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing instances")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(instances); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -310,14 +310,14 @@ func (a *APIController) InstanceStatusMessageHandler(w http.ResponseWriter, r *h
 
 	var updateMessage runnerParams.InstanceUpdateMessage
 	if err := json.NewDecoder(r.Body).Decode(&updateMessage); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	if err := a.r.AddInstanceStatusMessage(ctx, updateMessage); err != nil {
-		log.Printf("error saving status message: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error saving status message")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -330,14 +330,14 @@ func (a *APIController) InstanceSystemInfoHandler(w http.ResponseWriter, r *http
 
 	var updateMessage runnerParams.UpdateSystemInfoParams
 	if err := json.NewDecoder(r.Body).Decode(&updateMessage); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	if err := a.r.UpdateSystemInfo(ctx, updateMessage); err != nil {
-		log.Printf("error saving status message: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error saving status message")
+		handleError(ctx, w, err)
 		return
 	}
 

--- a/apiserver/controllers/metadata.go
+++ b/apiserver/controllers/metadata.go
@@ -17,7 +17,7 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/cloudbase/garm/apiserver/params"
@@ -29,14 +29,14 @@ func (a *APIController) InstanceGithubRegistrationTokenHandler(w http.ResponseWr
 
 	token, err := a.r.GetInstanceGithubRegistrationToken(ctx)
 	if err != nil {
-		handleError(w, err)
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte(token)); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -50,7 +50,7 @@ func (a *APIController) JITCredentialsFileHandler(w http.ResponseWriter, r *http
 			Error:   "Not Found",
 			Details: "Not Found",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
@@ -59,8 +59,8 @@ func (a *APIController) JITCredentialsFileHandler(w http.ResponseWriter, r *http
 
 	data, err := a.r.GetJITConfigFile(ctx, dotFileName)
 	if err != nil {
-		log.Printf("getting JIT config file: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "getting JIT config file")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -71,7 +71,7 @@ func (a *APIController) JITCredentialsFileHandler(w http.ResponseWriter, r *http
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(data); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -80,14 +80,14 @@ func (a *APIController) SystemdServiceNameHandler(w http.ResponseWriter, r *http
 
 	serviceName, err := a.r.GetRunnerServiceName(ctx)
 	if err != nil {
-		handleError(w, err)
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte(serviceName)); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -97,14 +97,14 @@ func (a *APIController) SystemdUnitFileHandler(w http.ResponseWriter, r *http.Re
 
 	data, err := a.r.GenerateSystemdUnitFile(ctx, runAsUser)
 	if err != nil {
-		handleError(w, err)
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(data); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -113,12 +113,12 @@ func (a *APIController) RootCertificateBundleHandler(w http.ResponseWriter, r *h
 
 	bundle, err := a.r.GetRootCertificateBundle(ctx)
 	if err != nil {
-		handleError(w, err)
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(bundle); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }

--- a/apiserver/controllers/organizations.go
+++ b/apiserver/controllers/organizations.go
@@ -16,7 +16,7 @@ package controllers
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -46,20 +46,20 @@ func (a *APIController) CreateOrgHandler(w http.ResponseWriter, r *http.Request)
 
 	var orgData runnerParams.CreateOrgParams
 	if err := json.NewDecoder(r.Body).Decode(&orgData); err != nil {
-		handleError(w, gErrors.ErrBadRequest)
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	org, err := a.r.CreateOrganization(ctx, orgData)
 	if err != nil {
-		log.Printf("error creating organization: %+v", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating organization")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(org); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -75,14 +75,14 @@ func (a *APIController) ListOrgsHandler(w http.ResponseWriter, r *http.Request) 
 
 	orgs, err := a.r.ListOrganizations(ctx)
 	if err != nil {
-		log.Printf("listing orgs: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing orgs")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(orgs); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -111,21 +111,21 @@ func (a *APIController) GetOrgByIDHandler(w http.ResponseWriter, r *http.Request
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	org, err := a.r.GetOrganizationByID(ctx, orgID)
 	if err != nil {
-		log.Printf("fetching org: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "fetching org")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(org); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -159,7 +159,7 @@ func (a *APIController) DeleteOrgHandler(w http.ResponseWriter, r *http.Request)
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
@@ -167,8 +167,8 @@ func (a *APIController) DeleteOrgHandler(w http.ResponseWriter, r *http.Request)
 	keepWebhook, _ := strconv.ParseBool(r.URL.Query().Get("keepWebhook"))
 
 	if err := a.r.DeleteOrganization(ctx, orgID, keepWebhook); err != nil {
-		log.Printf("removing org: %+v", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing org")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -208,27 +208,27 @@ func (a *APIController) UpdateOrgHandler(w http.ResponseWriter, r *http.Request)
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var updatePayload runnerParams.UpdateEntityParams
 	if err := json.NewDecoder(r.Body).Decode(&updatePayload); err != nil {
-		handleError(w, gErrors.ErrBadRequest)
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	org, err := a.r.UpdateOrganization(ctx, orgID, updatePayload)
 	if err != nil {
-		log.Printf("error updating organization: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error updating organization")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(org); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -263,28 +263,28 @@ func (a *APIController) CreateOrgPoolHandler(w http.ResponseWriter, r *http.Requ
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var poolData runnerParams.CreatePoolParams
 	if err := json.NewDecoder(r.Body).Decode(&poolData); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	pool, err := a.r.CreateOrgPool(ctx, orgID, poolData)
 	if err != nil {
-		log.Printf("error creating organization pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating organization pool")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -312,21 +312,21 @@ func (a *APIController) ListOrgPoolsHandler(w http.ResponseWriter, r *http.Reque
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	pools, err := a.r.ListOrgPools(ctx, orgID)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pools); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -361,21 +361,21 @@ func (a *APIController) GetOrgPoolHandler(w http.ResponseWriter, r *http.Request
 			Error:   "Bad Request",
 			Details: "No org or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	pool, err := a.r.GetOrgPoolByID(ctx, orgID, poolID)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -410,14 +410,14 @@ func (a *APIController) DeleteOrgPoolHandler(w http.ResponseWriter, r *http.Requ
 			Error:   "Bad Request",
 			Details: "No org or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	if err := a.r.DeleteOrgPool(ctx, orgID, poolID); err != nil {
-		log.Printf("removing pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing pool")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -464,28 +464,28 @@ func (a *APIController) UpdateOrgPoolHandler(w http.ResponseWriter, r *http.Requ
 			Error:   "Bad Request",
 			Details: "No org or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var poolData runnerParams.UpdatePoolParams
 	if err := json.NewDecoder(r.Body).Decode(&poolData); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	pool, err := a.r.UpdateOrgPool(ctx, orgID, poolID, poolData)
 	if err != nil {
-		log.Printf("error creating organization pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating organization pool")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -521,28 +521,28 @@ func (a *APIController) InstallOrgWebhookHandler(w http.ResponseWriter, r *http.
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var hookParam runnerParams.InstallWebhookParams
 	if err := json.NewDecoder(r.Body).Decode(&hookParam); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	info, err := a.r.InstallOrgWebhook(ctx, orgID, hookParam)
 	if err != nil {
-		log.Printf("installing webhook: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "installing webhook")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(info); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -570,14 +570,14 @@ func (a *APIController) UninstallOrgWebhookHandler(w http.ResponseWriter, r *htt
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	if err := a.r.UninstallOrgWebhook(ctx, orgID); err != nil {
-		log.Printf("removing webhook: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing webhook")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -610,20 +610,20 @@ func (a *APIController) GetOrgWebhookInfoHandler(w http.ResponseWriter, r *http.
 			Error:   "Bad Request",
 			Details: "No org ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	info, err := a.r.GetOrgWebhookInfo(ctx, orgID)
 	if err != nil {
-		log.Printf("getting webhook info: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "getting webhook info")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(info); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }

--- a/apiserver/controllers/pools.go
+++ b/apiserver/controllers/pools.go
@@ -16,7 +16,7 @@ package controllers
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 
 	gErrors "github.com/cloudbase/garm-provider-common/errors"
@@ -39,14 +39,14 @@ func (a *APIController) ListAllPoolsHandler(w http.ResponseWriter, r *http.Reque
 	pools, err := a.r.ListAllPools(ctx)
 
 	if err != nil {
-		log.Printf("listing pools: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pools); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -75,15 +75,15 @@ func (a *APIController) GetPoolByIDHandler(w http.ResponseWriter, r *http.Reques
 			Error:   "Bad Request",
 			Details: "No pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	pool, err := a.r.GetPoolByID(ctx, poolID)
 	if err != nil {
-		log.Printf("fetching pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "fetching pool")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -91,7 +91,7 @@ func (a *APIController) GetPoolByIDHandler(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -119,14 +119,14 @@ func (a *APIController) DeletePoolByIDHandler(w http.ResponseWriter, r *http.Req
 			Error:   "Bad Request",
 			Details: "No pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	if err := a.r.DeletePoolByID(ctx, poolID); err != nil {
-		log.Printf("removing pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing pool")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -165,27 +165,27 @@ func (a *APIController) UpdatePoolByIDHandler(w http.ResponseWriter, r *http.Req
 			Error:   "Bad Request",
 			Details: "No pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var poolData runnerParams.UpdatePoolParams
 	if err := json.NewDecoder(r.Body).Decode(&poolData); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	pool, err := a.r.UpdatePoolByID(ctx, poolID, poolData)
 	if err != nil {
-		log.Printf("fetching pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "fetching pool")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }

--- a/apiserver/controllers/repositories.go
+++ b/apiserver/controllers/repositories.go
@@ -16,7 +16,7 @@ package controllers
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -46,20 +46,20 @@ func (a *APIController) CreateRepoHandler(w http.ResponseWriter, r *http.Request
 
 	var repoData runnerParams.CreateRepoParams
 	if err := json.NewDecoder(r.Body).Decode(&repoData); err != nil {
-		handleError(w, gErrors.ErrBadRequest)
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	repo, err := a.r.CreateRepository(ctx, repoData)
 	if err != nil {
-		log.Printf("error creating repository: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating repository")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(repo); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -75,14 +75,14 @@ func (a *APIController) ListReposHandler(w http.ResponseWriter, r *http.Request)
 
 	repos, err := a.r.ListRepositories(ctx)
 	if err != nil {
-		log.Printf("listing repos: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing repositories")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(repos); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -111,21 +111,21 @@ func (a *APIController) GetRepoByIDHandler(w http.ResponseWriter, r *http.Reques
 			Error:   "Bad Request",
 			Details: "No repo ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	repo, err := a.r.GetRepositoryByID(ctx, repoID)
 	if err != nil {
-		log.Printf("fetching repo: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "fetching repository")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(repo); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -159,15 +159,15 @@ func (a *APIController) DeleteRepoHandler(w http.ResponseWriter, r *http.Request
 			Error:   "Bad Request",
 			Details: "No repo ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	keepWebhook, _ := strconv.ParseBool(r.URL.Query().Get("keepWebhook"))
 	if err := a.r.DeleteRepository(ctx, repoID, keepWebhook); err != nil {
-		log.Printf("fetching repo: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "fetching repository")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -207,27 +207,27 @@ func (a *APIController) UpdateRepoHandler(w http.ResponseWriter, r *http.Request
 			Error:   "Bad Request",
 			Details: "No repo ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var updatePayload runnerParams.UpdateEntityParams
 	if err := json.NewDecoder(r.Body).Decode(&updatePayload); err != nil {
-		handleError(w, gErrors.ErrBadRequest)
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	repo, err := a.r.UpdateRepository(ctx, repoID, updatePayload)
 	if err != nil {
-		log.Printf("error updating repository: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error updating repository")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(repo); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -262,28 +262,28 @@ func (a *APIController) CreateRepoPoolHandler(w http.ResponseWriter, r *http.Req
 			Error:   "Bad Request",
 			Details: "No repo ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var poolData runnerParams.CreatePoolParams
 	if err := json.NewDecoder(r.Body).Decode(&poolData); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	pool, err := a.r.CreateRepoPool(ctx, repoID, poolData)
 	if err != nil {
-		log.Printf("error creating repository pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating repository pool")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -311,21 +311,21 @@ func (a *APIController) ListRepoPoolsHandler(w http.ResponseWriter, r *http.Requ
 			Error:   "Bad Request",
 			Details: "No repo ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	pools, err := a.r.ListRepoPools(ctx, repoID)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pools); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -360,21 +360,21 @@ func (a *APIController) GetRepoPoolHandler(w http.ResponseWriter, r *http.Reques
 			Error:   "Bad Request",
 			Details: "No repo or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	pool, err := a.r.GetRepoPoolByID(ctx, repoID, poolID)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -409,14 +409,14 @@ func (a *APIController) DeleteRepoPoolHandler(w http.ResponseWriter, r *http.Req
 			Error:   "Bad Request",
 			Details: "No repo or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	if err := a.r.DeleteRepoPool(ctx, repoID, poolID); err != nil {
-		log.Printf("removing pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing pool")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -463,28 +463,28 @@ func (a *APIController) UpdateRepoPoolHandler(w http.ResponseWriter, r *http.Req
 			Error:   "Bad Request",
 			Details: "No repo or pool ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var poolData runnerParams.UpdatePoolParams
 	if err := json.NewDecoder(r.Body).Decode(&poolData); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	pool, err := a.r.UpdateRepoPool(ctx, repoID, poolID, poolData)
 	if err != nil {
-		log.Printf("error creating repository pool: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "error creating repository pool")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(pool); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -520,28 +520,28 @@ func (a *APIController) InstallRepoWebhookHandler(w http.ResponseWriter, r *http
 			Error:   "Bad Request",
 			Details: "No repository ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	var hookParam runnerParams.InstallWebhookParams
 	if err := json.NewDecoder(r.Body).Decode(&hookParam); err != nil {
-		log.Printf("failed to decode: %s", err)
-		handleError(w, gErrors.ErrBadRequest)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to decode")
+		handleError(ctx, w, gErrors.ErrBadRequest)
 		return
 	}
 
 	info, err := a.r.InstallRepoWebhook(ctx, repoID, hookParam)
 	if err != nil {
-		log.Printf("installing webhook: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "installing webhook")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(info); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }
 
@@ -569,14 +569,14 @@ func (a *APIController) UninstallRepoWebhookHandler(w http.ResponseWriter, r *ht
 			Error:   "Bad Request",
 			Details: "No repository ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	if err := a.r.UninstallRepoWebhook(ctx, repoID); err != nil {
-		log.Printf("removing webhook: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "removing webhook")
+		handleError(ctx, w, err)
 		return
 	}
 
@@ -609,20 +609,20 @@ func (a *APIController) GetRepoWebhookInfoHandler(w http.ResponseWriter, r *http
 			Error:   "Bad Request",
 			Details: "No repository ID specified",
 		}); err != nil {
-			log.Printf("failed to encode response: %q", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 		}
 		return
 	}
 
 	info, err := a.r.GetRepoWebhookInfo(ctx, repoID)
 	if err != nil {
-		log.Printf("getting webhook info: %s", err)
-		handleError(w, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "getting webhook info")
+		handleError(ctx, w, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(info); err != nil {
-		log.Printf("failed to encode response: %q", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
 	}
 }

--- a/apiserver/routers/routers.go
+++ b/apiserver/routers/routers.go
@@ -47,14 +47,14 @@ package routers
 
 import (
 	_ "expvar" // Register the expvar handlers
-	"io"
+	"log/slog"
 	"net/http"
 	_ "net/http/pprof" // Register the pprof handlers
 
+	"github.com/felixge/httpsnoop"
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/cloudbase/garm-provider-common/util"
 	"github.com/cloudbase/garm/apiserver/controllers"
 	"github.com/cloudbase/garm/auth"
 )
@@ -82,10 +82,28 @@ func WithDebugServer(parentRouter *mux.Router) *mux.Router {
 	return parentRouter
 }
 
-func NewAPIRouter(han *controllers.APIController, logWriter io.Writer, authMiddleware, initMiddleware, instanceMiddleware auth.Middleware, manageWebhooks bool) *mux.Router {
+func requestLogger(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// gathers metrics from the upstream handlers
+		metrics := httpsnoop.CaptureMetrics(h, w, r)
+
+		//prints log and metrics
+		slog.Info(
+			"access_log",
+			slog.String("method", r.Method),
+			slog.String("uri", r.URL.RequestURI()),
+			slog.String("user_agent", r.Header.Get("User-Agent")),
+			slog.String("ip", r.RemoteAddr),
+			slog.Int("code", metrics.Code),
+			slog.Int64("bytes", metrics.Written),
+			slog.Duration("request_time", metrics.Duration),
+		)
+	})
+}
+
+func NewAPIRouter(han *controllers.APIController, authMiddleware, initMiddleware, instanceMiddleware auth.Middleware, manageWebhooks bool) *mux.Router {
 	router := mux.NewRouter()
-	logMiddleware := util.NewLoggingMiddleware(logWriter)
-	router.Use(logMiddleware)
+	router.Use(requestLogger)
 
 	// Handles github webhooks
 	webhookRouter := router.PathPrefix("/webhooks").Subrouter()

--- a/auth/instance_middleware.go
+++ b/auth/instance_middleware.go
@@ -111,13 +111,13 @@ func (amw *instanceMiddleware) Middleware(next http.Handler) http.Handler {
 		ctx := r.Context()
 		authorizationHeader := r.Header.Get("authorization")
 		if authorizationHeader == "" {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
 		bearerToken := strings.Split(authorizationHeader, " ")
 		if len(bearerToken) != 2 {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
@@ -130,30 +130,30 @@ func (amw *instanceMiddleware) Middleware(next http.Handler) http.Handler {
 		})
 
 		if err != nil {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
 		if !token.Valid {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
 		ctx, err = amw.claimsToContext(ctx, claims)
 		if err != nil {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
 		if InstanceID(ctx) == "" {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
 		runnerStatus := InstanceRunnerStatus(ctx)
 		if runnerStatus != params.RunnerInstalling && runnerStatus != params.RunnerPending {
 			// Instances that have finished installing can no longer authenticate to the API
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 

--- a/auth/metrics.go
+++ b/auth/metrics.go
@@ -27,13 +27,13 @@ func (m *MetricsMiddleware) Middleware(next http.Handler) http.Handler {
 		ctx := r.Context()
 		authorizationHeader := r.Header.Get("authorization")
 		if authorizationHeader == "" {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
 		bearerToken := strings.Split(authorizationHeader, " ")
 		if len(bearerToken) != 2 {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
@@ -46,18 +46,18 @@ func (m *MetricsMiddleware) Middleware(next http.Handler) http.Handler {
 		})
 
 		if err != nil {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
 		if !token.Valid {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 
 		// we fully trust the claims
 		if !claims.ReadMetrics {
-			invalidAuthResponse(w)
+			invalidAuthResponse(ctx, w)
 			return
 		}
 

--- a/cmd/garm-cli/cmd/log.go
+++ b/cmd/garm-cli/cmd/log.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -36,7 +37,7 @@ var logCmd = &cobra.Command{
 			wsScheme = "wss"
 		}
 		u := url.URL{Scheme: wsScheme, Host: parsedURL.Host, Path: "/api/v1/ws"}
-		log.Printf("connecting to %s", u.String())
+		slog.Debug("connecting", "url", u.String())
 
 		header := http.Header{}
 		header.Add("Authorization", fmt.Sprintf("Bearer %s", mgr.Token))
@@ -59,10 +60,10 @@ var logCmd = &cobra.Command{
 			for {
 				_, message, err := c.ReadMessage()
 				if err != nil {
-					log.Printf("read: %q", err)
+					slog.With(slog.Any("error", err)).Error("reading log message")
 					return
 				}
-				log.Print(util.SanitizeLogEntry(string(message)))
+				fmt.Print(util.SanitizeLogEntry(string(message)))
 			}
 		}()
 

--- a/cmd/garm/main.go
+++ b/cmd/garm/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -69,21 +70,7 @@ func maybeInitController(db common.Store) error {
 	return nil
 }
 
-func main() {
-	flag.Parse()
-	if *version {
-		fmt.Println(Version)
-		return
-	}
-	ctx, stop := signal.NotifyContext(context.Background(), signals...)
-	defer stop()
-	fmt.Println(ctx)
-
-	cfg, err := config.NewConfig(*conf)
-	if err != nil {
-		log.Fatalf("Fetching config: %+v", err)
-	}
-
+func setupLogging(ctx context.Context, cfg *config.Config, hub *websocket.Hub) {
 	logWriter, err := util.GetLoggingWriter(cfg.Default.LogFile)
 	if err != nil {
 		log.Fatalf("fetching log writer: %+v", err)
@@ -102,7 +89,7 @@ func main() {
 				// we got a SIGHUP. Rotate log file.
 				if logger, ok := logWriter.(*lumberjack.Logger); ok {
 					if err := logger.Rotate(); err != nil {
-						log.Printf("failed to rotate log file: %v", err)
+						slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to rotate log file")
 					}
 				}
 			}
@@ -112,18 +99,71 @@ func main() {
 	var writers []io.Writer = []io.Writer{
 		logWriter,
 	}
+
+	if hub != nil {
+		writers = append(writers, hub)
+	}
+
+	wr := io.MultiWriter(writers...)
+	// TODO: delete this once we migrate to slog
+	log.SetOutput(wr)
+
+	logCfg := cfg.GetLoggingConfig()
+	var logLevel slog.Level
+	switch logCfg.LogLevel {
+	case config.LevelDebug:
+		logLevel = slog.LevelDebug
+	case config.LevelInfo:
+		logLevel = slog.LevelInfo
+	case config.LevelWarn:
+		logLevel = slog.LevelWarn
+	case config.LevelError:
+		logLevel = slog.LevelError
+	default:
+		logLevel = slog.LevelInfo
+	}
+
+	// logger options
+	opts := slog.HandlerOptions{
+		AddSource: logCfg.LogSource,
+		Level:     logLevel,
+	}
+
+	var han slog.Handler
+	switch logCfg.LogFormat {
+	case config.FormatJSON:
+		han = slog.NewJSONHandler(wr, &opts)
+	default:
+		han = slog.NewTextHandler(wr, &opts)
+	}
+	slog.SetDefault(slog.New(han))
+
+}
+
+func main() {
+	flag.Parse()
+	if *version {
+		fmt.Println(Version)
+		return
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), signals...)
+	defer stop()
+
+	cfg, err := config.NewConfig(*conf)
+	if err != nil {
+		log.Fatalf("Fetching config: %+v", err)
+	}
+
 	var hub *websocket.Hub
-	if cfg.Default.EnableLogStreamer {
+	if cfg.Default.EnableLogStreamer != nil && *cfg.Default.EnableLogStreamer {
 		hub = websocket.NewHub(ctx)
 		if err := hub.Start(); err != nil {
 			log.Fatal(err)
 		}
 		defer hub.Stop() //nolint
-		writers = append(writers, hub)
 	}
 
-	multiWriter := io.MultiWriter(writers...)
-	log.SetOutput(multiWriter)
+	setupLogging(ctx, cfg, hub)
 
 	db, err := database.NewDatabase(ctx, cfg.Database)
 	if err != nil {
@@ -170,19 +210,19 @@ func main() {
 		log.Fatal(err)
 	}
 
-	router := routers.NewAPIRouter(controller, multiWriter, jwtMiddleware, initMiddleware, instanceMiddleware, cfg.Default.EnableWebhookManagement)
+	router := routers.NewAPIRouter(controller, jwtMiddleware, initMiddleware, instanceMiddleware, cfg.Default.EnableWebhookManagement)
 
 	if cfg.Metrics.Enable {
-		log.Printf("registering prometheus metrics collectors")
+		slog.InfoContext(ctx, "registering prometheus metrics collectors")
 		if err := metrics.RegisterCollectors(runner); err != nil {
 			log.Fatal(err)
 		}
-		log.Printf("setting up metric routes")
+		slog.InfoContext(ctx, "setting up metric routes")
 		router = routers.WithMetricsRouter(router, cfg.Metrics.DisableAuth, metricsMiddleware)
 	}
 
 	if cfg.Default.DebugServer {
-		log.Printf("setting up debug routes")
+		slog.InfoContext(ctx, "setting up debug routes")
 		router = routers.WithDebugServer(router)
 	}
 
@@ -207,11 +247,11 @@ func main() {
 	go func() {
 		if cfg.APIServer.UseTLS {
 			if err := srv.ServeTLS(listener, cfg.APIServer.TLSConfig.CRT, cfg.APIServer.TLSConfig.Key); err != nil {
-				log.Printf("Listening: %+v", err)
+				slog.With(slog.Any("error", err)).ErrorContext(ctx, "Listening")
 			}
 		} else {
 			if err := srv.Serve(listener); err != http.ErrServerClosed {
-				log.Printf("Listening: %+v", err)
+				slog.With(slog.Any("error", err)).ErrorContext(ctx, "Listening")
 			}
 		}
 	}()
@@ -220,12 +260,12 @@ func main() {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer shutdownCancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
-		log.Printf("graceful api server shutdown failed: %+v", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "graceful api server shutdown failed")
 	}
 
-	log.Printf("waiting for runner to stop")
+	slog.With(slog.Any("error", err)).ErrorContext(ctx, "waiting for runner to stop")
 	if err := runner.Wait(); err != nil {
-		log.Printf("failed to shutdown workers: %+v", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to shutdown workers")
 		os.Exit(1)
 	}
 }

--- a/cmd/garm/main.go
+++ b/cmd/garm/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cloudbase/garm/database/common"
 	"github.com/cloudbase/garm/metrics"
 	"github.com/cloudbase/garm/runner"
+	garmUtil "github.com/cloudbase/garm/util"
 	"github.com/cloudbase/garm/util/appdefaults"
 	"github.com/cloudbase/garm/websocket"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
@@ -105,8 +106,6 @@ func setupLogging(ctx context.Context, cfg *config.Config, hub *websocket.Hub) {
 	}
 
 	wr := io.MultiWriter(writers...)
-	// TODO: delete this once we migrate to slog
-	log.SetOutput(wr)
 
 	logCfg := cfg.GetLoggingConfig()
 	var logLevel slog.Level
@@ -136,7 +135,11 @@ func setupLogging(ctx context.Context, cfg *config.Config, hub *websocket.Hub) {
 	default:
 		han = slog.NewTextHandler(wr, &opts)
 	}
-	slog.SetDefault(slog.New(han))
+
+	wrapped := garmUtil.ContextHandler{
+		Handler: han,
+	}
+	slog.SetDefault(slog.New(wrapped))
 
 }
 

--- a/database/sql/sql.go
+++ b/database/sql/sql.go
@@ -17,7 +17,7 @@ package sql
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -151,7 +151,7 @@ func (s *sqlDatabase) cascadeMigrationSQLite(model interface{}, name string, jus
 	if model != nil {
 		if err := s.conn.Migrator().AutoMigrate(model); err != nil {
 			if err := s.conn.Exec(fmt.Sprintf(restoreNameTemplate, name, name, name)).Error; err != nil {
-				log.Printf("failed to restore table %s: %s", name, err)
+				slog.With(slog.Any("error", err)).Error("failed to restore table", "table", name)
 			}
 			return fmt.Errorf("failed to create table %s: %w", name, err)
 		}
@@ -193,13 +193,13 @@ func (s *sqlDatabase) cascadeMigration() error {
 func (s *sqlDatabase) migrateDB() error {
 	if s.conn.Migrator().HasIndex(&Organization{}, "idx_organizations_name") {
 		if err := s.conn.Migrator().DropIndex(&Organization{}, "idx_organizations_name"); err != nil {
-			log.Printf("failed to drop index idx_organizations_name: %s", err)
+			slog.With(slog.Any("error", err)).Error("failed to drop index idx_organizations_name")
 		}
 	}
 
 	if s.conn.Migrator().HasIndex(&Repository{}, "idx_owner") {
 		if err := s.conn.Migrator().DropIndex(&Repository{}, "idx_owner"); err != nil {
-			log.Printf("failed to drop index idx_owner: %s", err)
+			slog.With(slog.Any("error", err)).Error("failed to drop index idx_owner")
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/cloudbase/garm-provider-common v0.1.1
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-openapi/errors v0.21.0
 	github.com/go-openapi/runtime v0.26.2
 	github.com/go-openapi/strfmt v0.21.10
@@ -41,7 +42,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/analysis v0.21.5 // indirect

--- a/metrics/enterprise.go
+++ b/metrics/enterprise.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 	"strconv"
 
 	"github.com/cloudbase/garm/auth"
@@ -14,7 +14,7 @@ func (c *GarmCollector) CollectEnterpriseMetric(ch chan<- prometheus.Metric, hos
 
 	enterprises, err := c.runner.ListEnterprises(ctx)
 	if err != nil {
-		log.Printf("listing providers: %s", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing providers")
 		return
 	}
 
@@ -28,7 +28,7 @@ func (c *GarmCollector) CollectEnterpriseMetric(ch chan<- prometheus.Metric, hos
 			enterprise.ID,   // label: id
 		)
 		if err != nil {
-			log.Printf("cannot collect enterpriseInfo metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect enterpriseInfo metric")
 			continue
 		}
 		ch <- enterpriseInfo
@@ -42,7 +42,7 @@ func (c *GarmCollector) CollectEnterpriseMetric(ch chan<- prometheus.Metric, hos
 			strconv.FormatBool(enterprise.PoolManagerStatus.IsRunning), // label: running
 		)
 		if err != nil {
-			log.Printf("cannot collect enterprisePoolManagerStatus metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect enterprisePoolManagerStatus metric")
 			continue
 		}
 		ch <- enterprisePoolManagerStatus

--- a/metrics/health.go
+++ b/metrics/health.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -15,7 +15,7 @@ func (c *GarmCollector) CollectHealthMetric(ch chan<- prometheus.Metric, hostnam
 		controllerID,
 	)
 	if err != nil {
-		log.Printf("error on creating health metric: %s", err)
+		slog.With(slog.Any("error", err)).Error("error on creating health metric")
 		return
 	}
 	ch <- m

--- a/metrics/instance.go
+++ b/metrics/instance.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/cloudbase/garm/auth"
 	"github.com/prometheus/client_golang/prometheus"
@@ -14,13 +14,13 @@ func (c *GarmCollector) CollectInstanceMetric(ch chan<- prometheus.Metric, hostn
 
 	instances, err := c.runner.ListAllInstances(ctx)
 	if err != nil {
-		log.Printf("cannot collect metrics, listing instances: %s", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect metrics, listing instances")
 		return
 	}
 
 	pools, err := c.runner.ListAllPools(ctx)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
 		return
 	}
 
@@ -71,7 +71,7 @@ func (c *GarmCollector) CollectInstanceMetric(ch chan<- prometheus.Metric, hostn
 		)
 
 		if err != nil {
-			log.Printf("cannot collect runner metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect runner metric")
 			continue
 		}
 		ch <- m

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/cloudbase/garm/auth"
 	"github.com/cloudbase/garm/params"
@@ -192,7 +192,7 @@ func (c *GarmCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *GarmCollector) Collect(ch chan<- prometheus.Metric) {
 	controllerInfo, err := c.runner.GetControllerInfo(auth.GetAdminContext())
 	if err != nil {
-		log.Printf("failed to get controller info: %s", err)
+		slog.With(slog.Any("error", err)).Error("failed to get controller info")
 		return
 	}
 

--- a/metrics/organization.go
+++ b/metrics/organization.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 	"strconv"
 
 	"github.com/cloudbase/garm/auth"
@@ -14,7 +14,7 @@ func (c *GarmCollector) CollectOrganizationMetric(ch chan<- prometheus.Metric, h
 
 	organizations, err := c.runner.ListOrganizations(ctx)
 	if err != nil {
-		log.Printf("listing providers: %s", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing providers")
 		return
 	}
 
@@ -28,7 +28,7 @@ func (c *GarmCollector) CollectOrganizationMetric(ch chan<- prometheus.Metric, h
 			organization.ID,   // label: id
 		)
 		if err != nil {
-			log.Printf("cannot collect organizationInfo metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect organizationInfo metric")
 			continue
 		}
 		ch <- organizationInfo
@@ -42,7 +42,7 @@ func (c *GarmCollector) CollectOrganizationMetric(ch chan<- prometheus.Metric, h
 			strconv.FormatBool(organization.PoolManagerStatus.IsRunning), // label: running
 		)
 		if err != nil {
-			log.Printf("cannot collect organizationPoolManagerStatus metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect organizationPoolManagerStatus metric")
 			continue
 		}
 		ch <- organizationPoolManagerStatus

--- a/metrics/pool.go
+++ b/metrics/pool.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -15,7 +15,7 @@ func (c *GarmCollector) CollectPoolMetric(ch chan<- prometheus.Metric, hostname 
 
 	pools, err := c.runner.ListAllPools(ctx)
 	if err != nil {
-		log.Printf("listing pools: %s", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pools")
 		return
 	}
 
@@ -64,7 +64,7 @@ func (c *GarmCollector) CollectPoolMetric(ch chan<- prometheus.Metric, hostname 
 			poolNames[pool.ID].Type,     // label: pool_type
 		)
 		if err != nil {
-			log.Printf("cannot collect poolInfo metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect poolInfo metric")
 			continue
 		}
 		ch <- poolInfo
@@ -77,7 +77,7 @@ func (c *GarmCollector) CollectPoolMetric(ch chan<- prometheus.Metric, hostname 
 			strconv.FormatBool(pool.Enabled), // label: enabled
 		)
 		if err != nil {
-			log.Printf("cannot collect poolStatus metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect poolStatus metric")
 			continue
 		}
 		ch <- poolStatus
@@ -89,7 +89,7 @@ func (c *GarmCollector) CollectPoolMetric(ch chan<- prometheus.Metric, hostname 
 			pool.ID, // label: id
 		)
 		if err != nil {
-			log.Printf("cannot collect poolMaxRunners metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect poolMaxRunners metric")
 			continue
 		}
 		ch <- poolMaxRunners
@@ -101,7 +101,7 @@ func (c *GarmCollector) CollectPoolMetric(ch chan<- prometheus.Metric, hostname 
 			pool.ID, // label: id
 		)
 		if err != nil {
-			log.Printf("cannot collect poolMinIdleRunners metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect poolMinIdleRunners metric")
 			continue
 		}
 		ch <- poolMinIdleRunners
@@ -113,7 +113,7 @@ func (c *GarmCollector) CollectPoolMetric(ch chan<- prometheus.Metric, hostname 
 			pool.ID, // label: id
 		)
 		if err != nil {
-			log.Printf("cannot collect poolBootstrapTimeout metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect poolBootstrapTimeout metric")
 			continue
 		}
 		ch <- poolBootstrapTimeout

--- a/metrics/provider.go
+++ b/metrics/provider.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/cloudbase/garm/auth"
 	"github.com/prometheus/client_golang/prometheus"
@@ -13,7 +13,7 @@ func (c *GarmCollector) CollectProviderMetric(ch chan<- prometheus.Metric, hostn
 
 	providers, err := c.runner.ListProviders(ctx)
 	if err != nil {
-		log.Printf("listing providers: %s", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing providers")
 		return
 	}
 
@@ -28,7 +28,7 @@ func (c *GarmCollector) CollectProviderMetric(ch chan<- prometheus.Metric, hostn
 			provider.Description,          // label: description
 		)
 		if err != nil {
-			log.Printf("cannot collect providerInfo metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect providerInfo metric")
 			continue
 		}
 		ch <- providerInfo

--- a/metrics/repository.go
+++ b/metrics/repository.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 	"strconv"
 
 	"github.com/cloudbase/garm/auth"
@@ -14,7 +14,7 @@ func (c *GarmCollector) CollectRepositoryMetric(ch chan<- prometheus.Metric, hos
 
 	repositories, err := c.runner.ListRepositories(ctx)
 	if err != nil {
-		log.Printf("listing providers: %s", err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing providers")
 		return
 	}
 
@@ -29,7 +29,7 @@ func (c *GarmCollector) CollectRepositoryMetric(ch chan<- prometheus.Metric, hos
 			repository.ID,    // label: id
 		)
 		if err != nil {
-			log.Printf("cannot collect repositoryInfo metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect repositoryInfo metric")
 			continue
 		}
 		ch <- repositoryInfo
@@ -43,7 +43,7 @@ func (c *GarmCollector) CollectRepositoryMetric(ch chan<- prometheus.Metric, hos
 			strconv.FormatBool(repository.PoolManagerStatus.IsRunning), // label: running
 		)
 		if err != nil {
-			log.Printf("cannot collect repositoryPoolManagerStatus metric: %s", err)
+			slog.With(slog.Any("error", err)).ErrorContext(ctx, "cannot collect repositoryPoolManagerStatus metric")
 			continue
 		}
 		ch <- repositoryPoolManagerStatus

--- a/runner/enterprises.go
+++ b/runner/enterprises.go
@@ -3,7 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
@@ -47,7 +47,9 @@ func (r *Runner) CreateEnterprise(ctx context.Context, param params.CreateEnterp
 	defer func() {
 		if err != nil {
 			if deleteErr := r.store.DeleteEnterprise(ctx, enterprise.ID); deleteErr != nil {
-				log.Printf("failed to delete enterprise: %s", deleteErr)
+				slog.With(slog.Any("error", deleteErr)).ErrorContext(
+					ctx, "failed to delete enterprise",
+					"enterprise_id", enterprise.ID)
 			}
 		}
 	}()
@@ -59,7 +61,9 @@ func (r *Runner) CreateEnterprise(ctx context.Context, param params.CreateEnterp
 	}
 	if err := poolMgr.Start(); err != nil {
 		if deleteErr := r.poolManagerCtrl.DeleteEnterprisePoolManager(enterprise); deleteErr != nil {
-			log.Printf("failed to cleanup pool manager for enterprise %s", enterprise.ID)
+			slog.With(slog.Any("error", deleteErr)).ErrorContext(
+				ctx, "failed to cleanup pool manager for enterprise",
+				"enterprise_id", enterprise.ID)
 		}
 		return params.Enterprise{}, errors.Wrap(err, "starting enterprise pool manager")
 	}

--- a/runner/pool/enterprise.go
+++ b/runner/pool/enterprise.go
@@ -25,6 +25,7 @@ import (
 var _ poolHelper = &enterprise{}
 
 func NewEnterprisePoolManager(ctx context.Context, cfg params.Enterprise, cfgInternal params.Internal, providers map[string]common.Provider, store dbCommon.Store) (common.PoolManager, error) {
+	ctx = util.WithContext(ctx, slog.Any("pool_mgr", cfg.Name), slog.Any("pool_type", params.EnterprisePool))
 	ghc, ghEnterpriseClient, err := util.GithubClient(ctx, cfgInternal.OAuth2Token, cfgInternal.GithubCredentialsDetails)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting github client")

--- a/runner/pool/enterprise.go
+++ b/runner/pool/enterprise.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -134,7 +134,9 @@ func (r *enterprise) GetJITConfig(ctx context.Context, instance string, pool par
 	defer func() {
 		if err != nil && runner != nil {
 			_, innerErr := r.ghcEnterpriseCli.RemoveRunner(r.ctx, r.cfg.Name, runner.GetID())
-			log.Printf("failed to remove runner: %v", innerErr)
+			slog.With(slog.Any("error", innerErr)).ErrorContext(
+				ctx, "failed to remove runner",
+				"runner_id", runner.GetID(), "organization", r.cfg.Name)
 		}
 	}()
 

--- a/runner/pool/organization.go
+++ b/runner/pool/organization.go
@@ -39,6 +39,7 @@ import (
 var _ poolHelper = &organization{}
 
 func NewOrganizationPoolManager(ctx context.Context, cfg params.Organization, cfgInternal params.Internal, providers map[string]common.Provider, store dbCommon.Store) (common.PoolManager, error) {
+	ctx = util.WithContext(ctx, slog.Any("pool_mgr", cfg.Name), slog.Any("pool_type", params.OrganizationPool))
 	ghc, _, err := util.GithubClient(ctx, cfgInternal.OAuth2Token, cfgInternal.GithubCredentialsDetails)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting github client")

--- a/runner/pool/organization.go
+++ b/runner/pool/organization.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -146,7 +146,9 @@ func (r *organization) GetJITConfig(ctx context.Context, instance string, pool p
 	defer func() {
 		if err != nil && runner != nil {
 			_, innerErr := r.ghcli.RemoveOrganizationRunner(r.ctx, r.cfg.Name, runner.GetID())
-			log.Printf("failed to remove runner: %v", innerErr)
+			slog.With(slog.Any("error", innerErr)).ErrorContext(
+				ctx, "failed to remove runner",
+				"runner_id", runner.GetID(), "organization", r.cfg.Name)
 		}
 	}()
 
@@ -369,7 +371,7 @@ func (r *organization) InstallHook(ctx context.Context, req *github.Hook) (param
 	}
 
 	if _, err := r.ghcli.PingOrgHook(ctx, r.cfg.Name, hook.GetID()); err != nil {
-		log.Printf("failed to ping hook %d: %v", *hook.ID, err)
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to ping hook", "hook_id", hook.GetID())
 	}
 
 	return hookToParamsHookInfo(hook), nil

--- a/runner/pool/repository.go
+++ b/runner/pool/repository.go
@@ -19,7 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -110,7 +110,11 @@ func (r *repository) GetJITConfig(ctx context.Context, instance string, pool par
 	defer func() {
 		if err != nil && runner != nil {
 			_, innerErr := r.ghcli.RemoveRunner(r.ctx, r.cfg.Owner, r.cfg.Name, runner.GetID())
-			log.Printf("failed to remove runner: %v", innerErr)
+			slog.With(slog.Any("error", innerErr)).ErrorContext(
+				ctx, "failed to remove runner",
+				"runner_id", runner.GetID(),
+				"repo", r.cfg.Name,
+				"owner", r.cfg.Owner)
 		}
 	}()
 
@@ -332,7 +336,11 @@ func (r *repository) InstallHook(ctx context.Context, req *github.Hook) (params.
 	}
 
 	if _, err := r.ghcli.PingRepoHook(ctx, r.cfg.Owner, r.cfg.Name, hook.GetID()); err != nil {
-		log.Printf("failed to ping hook %d: %v", hook.GetID(), err)
+		slog.With(slog.Any("error", err)).ErrorContext(
+			ctx, "failed to ping hook",
+			"hook_id", hook.GetID(),
+			"repo", r.cfg.Name,
+			"owner", r.cfg.Owner)
 	}
 
 	return hookToParamsHookInfo(hook), nil

--- a/runner/pool/repository.go
+++ b/runner/pool/repository.go
@@ -39,6 +39,7 @@ import (
 var _ poolHelper = &repository{}
 
 func NewRepositoryPoolManager(ctx context.Context, cfg params.Repository, cfgInternal params.Internal, providers map[string]common.Provider, store dbCommon.Store) (common.PoolManager, error) {
+	ctx = util.WithContext(ctx, slog.Any("pool_mgr", fmt.Sprintf("%s/%s", cfg.Owner, cfg.Name)), slog.Any("pool_type", params.RepositoryPool))
 	ghc, _, err := util.GithubClient(ctx, cfgInternal.OAuth2Token, cfgInternal.GithubCredentialsDetails)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting github client")

--- a/runner/pool/util.go
+++ b/runner/pool/util.go
@@ -1,7 +1,6 @@
 package pool
 
 import (
-	"log"
 	"sort"
 	"strings"
 	"sync"
@@ -56,12 +55,4 @@ func (p *poolsForTags) Add(tags []string, pools []params.Pool) *poolRoundRobin {
 	poolRR := &poolRoundRobin{pools: pools}
 	v, _ := p.pools.LoadOrStore(key, poolRR)
 	return v.(*poolRoundRobin)
-}
-
-func (r *basePoolManager) log(msg string, args ...interface{}) {
-	msgArgs := []interface{}{
-		r.helper.String(),
-	}
-	msgArgs = append(msgArgs, args...)
-	log.Printf("[Pool mgr %s] "+msg, msgArgs...)
 }

--- a/runner/providers/providers.go
+++ b/runner/providers/providers.go
@@ -16,7 +16,7 @@ package providers
 
 import (
 	"context"
-	"log"
+	"log/slog"
 
 	"github.com/cloudbase/garm/config"
 	"github.com/cloudbase/garm/params"
@@ -31,7 +31,9 @@ import (
 func LoadProvidersFromConfig(ctx context.Context, cfg config.Config, controllerID string) (map[string]common.Provider, error) {
 	providers := make(map[string]common.Provider, len(cfg.Providers))
 	for _, providerCfg := range cfg.Providers {
-		log.Printf("Loading provider %s", providerCfg.Name)
+		slog.InfoContext(
+			ctx, "Loading provider",
+			"provider", providerCfg.Name)
 		switch providerCfg.ProviderType {
 		case params.ExternalProvider:
 			conf := providerCfg

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
@@ -449,7 +449,9 @@ func (r *Runner) loadReposOrgsAndEnterprises() error {
 	for _, repo := range repos {
 		repo := repo
 		g.Go(func() error {
-			log.Printf("creating pool manager for repo %s/%s", repo.Owner, repo.Name)
+			slog.InfoContext(
+				r.ctx, "creating pool manager for repo",
+				"repo_owner", repo.Owner, "repo_name", repo.Name)
 			_, err := r.poolManagerCtrl.CreateRepoPoolManager(r.ctx, repo, r.providers, r.store)
 			return err
 		})
@@ -458,7 +460,7 @@ func (r *Runner) loadReposOrgsAndEnterprises() error {
 	for _, org := range orgs {
 		org := org
 		g.Go(func() error {
-			log.Printf("creating pool manager for organization %s", org.Name)
+			slog.InfoContext(r.ctx, "creating pool manager for organization", "org_name", org.Name)
 			_, err := r.poolManagerCtrl.CreateOrgPoolManager(r.ctx, org, r.providers, r.store)
 			return err
 		})
@@ -467,7 +469,7 @@ func (r *Runner) loadReposOrgsAndEnterprises() error {
 	for _, enterprise := range enterprises {
 		enterprise := enterprise
 		g.Go(func() error {
-			log.Printf("creating pool manager for enterprise %s", enterprise.Name)
+			slog.InfoContext(r.ctx, "creating pool manager for enterprise", "enterprise_name", enterprise.Name)
 			_, err := r.poolManagerCtrl.CreateEnterprisePoolManager(r.ctx, enterprise, r.providers, r.store)
 			return err
 		})
@@ -630,7 +632,7 @@ func (r *Runner) Wait() error {
 		go func(id string, poolMgr common.PoolManager) {
 			defer wg.Done()
 			if err := poolMgr.Wait(); err != nil {
-				log.Printf("timed out waiting for pool manager %s to exit", id)
+				slog.With(slog.Any("error", err)).ErrorContext(r.ctx, "timed out waiting for pool manager to exit", "pool_id", id, "pool_mgr_id", poolMgr.ID())
 			}
 		}(poolId, repo)
 	}
@@ -640,7 +642,7 @@ func (r *Runner) Wait() error {
 		go func(id string, poolMgr common.PoolManager) {
 			defer wg.Done()
 			if err := poolMgr.Wait(); err != nil {
-				log.Printf("timed out waiting for pool manager %s to exit", id)
+				slog.With(slog.Any("error", err)).ErrorContext(r.ctx, "timed out waiting for pool manager to exit", "pool_id", id)
 			}
 		}(poolId, org)
 	}
@@ -650,7 +652,7 @@ func (r *Runner) Wait() error {
 		go func(id string, poolMgr common.PoolManager) {
 			defer wg.Done()
 			if err := poolMgr.Wait(); err != nil {
-				log.Printf("timed out waiting for pool manager %s to exit", id)
+				slog.With(slog.Any("error", err)).ErrorContext(r.ctx, "timed out waiting for pool manager to exit", "pool_id", id)
 			}
 		}(poolId, enterprise)
 	}
@@ -717,12 +719,20 @@ func (r *Runner) DispatchWorkflowJob(hookTargetType, signature string, jobData [
 
 	switch HookTargetType(hookTargetType) {
 	case RepoHook:
-		log.Printf("got hook for repo %s/%s", util.SanitizeLogEntry(job.Repository.Owner.Login), util.SanitizeLogEntry(job.Repository.Name))
+		slog.DebugContext(
+			r.ctx, "got hook for repo",
+			"repo_owner", util.SanitizeLogEntry(job.Repository.Owner.Login),
+			"repo_name", util.SanitizeLogEntry(job.Repository.Name))
 		poolManager, err = r.findRepoPoolManager(job.Repository.Owner.Login, job.Repository.Name)
 	case OrganizationHook:
-		log.Printf("got hook for org %s", util.SanitizeLogEntry(job.Organization.Login))
+		slog.DebugContext(
+			r.ctx, "got hook for organization",
+			"organization", util.SanitizeLogEntry(job.Organization.Login))
 		poolManager, err = r.findOrgPoolManager(job.Organization.Login)
 	case EnterpriseHook:
+		slog.DebugContext(
+			r.ctx, "got hook for enterprise",
+			"enterprise", util.SanitizeLogEntry(job.Enterprise.Slug))
 		poolManager, err = r.findEnterprisePoolManager(job.Enterprise.Slug)
 	default:
 		return runnerErrors.NewBadRequestError("cannot handle hook target type %s", hookTargetType)
@@ -861,7 +871,7 @@ func (r *Runner) AddInstanceStatusMessage(ctx context.Context, param params.Inst
 func (r *Runner) UpdateSystemInfo(ctx context.Context, param params.UpdateSystemInfoParams) error {
 	instanceID := auth.InstanceID(ctx)
 	if instanceID == "" {
-		log.Printf("missing instance ID")
+		slog.ErrorContext(ctx, "missing instance ID")
 		return runnerErrors.ErrUnauthorized
 	}
 

--- a/test/integration/e2e/client.go
+++ b/test/integration/e2e/client.go
@@ -1,7 +1,7 @@
 package e2e
 
 import (
-	"log"
+	"log/slog"
 	"net/url"
 
 	"github.com/cloudbase/garm/client"
@@ -32,7 +32,7 @@ func InitClient(baseURL string) {
 }
 
 func FirstRun(adminUsername, adminPassword, adminFullName, adminEmail string) *params.User {
-	log.Println("First run")
+	slog.Info("First run")
 	newUser := params.NewUserParams{
 		Username: adminUsername,
 		Password: adminPassword,
@@ -47,7 +47,7 @@ func FirstRun(adminUsername, adminPassword, adminFullName, adminEmail string) *p
 }
 
 func Login(username, password string) {
-	log.Println("Login")
+	slog.Info("Login")
 	loginParams := params.PasswordLoginParams{
 		Username: username,
 		Password: password,

--- a/test/integration/e2e/e2e.go
+++ b/test/integration/e2e/e2e.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -10,7 +10,7 @@ import (
 )
 
 func ListCredentials() params.Credentials {
-	log.Println("List credentials")
+	slog.Info("List credentials")
 	credentials, err := listCredentials(cli, authToken)
 	if err != nil {
 		panic(err)
@@ -19,7 +19,7 @@ func ListCredentials() params.Credentials {
 }
 
 func ListProviders() params.Providers {
-	log.Println("List providers")
+	slog.Info("List providers")
 	providers, err := listProviders(cli, authToken)
 	if err != nil {
 		panic(err)
@@ -28,7 +28,7 @@ func ListProviders() params.Providers {
 }
 
 func GetMetricsToken() {
-	log.Println("Get metrics token")
+	slog.Info("Get metrics token")
 	_, err := getMetricsToken(cli, authToken)
 	if err != nil {
 		panic(err)
@@ -36,7 +36,7 @@ func GetMetricsToken() {
 }
 
 func GetControllerInfo() *params.ControllerInfo {
-	log.Println("Get controller info")
+	slog.Info("Get controller info")
 	controllerInfo, err := getControllerInfo(cli, authToken)
 	if err != nil {
 		panic(err)
@@ -62,7 +62,7 @@ func GracefulCleanup() {
 		if _, err := updatePool(cli, authToken, pool.ID, poolParams); err != nil {
 			panic(err)
 		}
-		log.Printf("Pool %s disabled", pool.ID)
+		slog.Info("Pool disabled", "pool_id", pool.ID)
 	}
 
 	// delete all the instances
@@ -75,7 +75,7 @@ func GracefulCleanup() {
 			if err := deleteInstance(cli, authToken, instance.Name, false); err != nil {
 				panic(err)
 			}
-			log.Printf("Instance %s deletion initiated", instance.Name)
+			slog.Info("Instance deletion initiated", "instance", instance.Name)
 		}
 	}
 
@@ -91,7 +91,7 @@ func GracefulCleanup() {
 		if err := deletePool(cli, authToken, pool.ID); err != nil {
 			panic(err)
 		}
-		log.Printf("Pool %s deleted", pool.ID)
+		slog.Info("Pool deleted", "pool_id", pool.ID)
 	}
 
 	// delete all the repositories
@@ -103,7 +103,7 @@ func GracefulCleanup() {
 		if err := deleteRepo(cli, authToken, repo.ID); err != nil {
 			panic(err)
 		}
-		log.Printf("Repo %s deleted", repo.ID)
+		slog.Info("Repo deleted", "repo_id", repo.ID)
 	}
 
 	// delete all the organizations
@@ -115,14 +115,14 @@ func GracefulCleanup() {
 		if err := deleteOrg(cli, authToken, org.ID); err != nil {
 			panic(err)
 		}
-		log.Printf("Org %s deleted", org.ID)
+		slog.Info("Org deleted", "org_id", org.ID)
 	}
 }
 
 func appendCtrlInfoToGitHubEnv(controllerInfo *params.ControllerInfo) error {
 	envFile, found := os.LookupEnv("GITHUB_ENV")
 	if !found {
-		log.Printf("GITHUB_ENV not set, skipping appending controller info")
+		slog.Info("GITHUB_ENV not set, skipping appending controller info")
 		return nil
 	}
 	file, err := os.OpenFile(envFile, os.O_WRONLY|os.O_APPEND, os.ModeAppend)

--- a/test/integration/e2e/jobs.go
+++ b/test/integration/e2e/jobs.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	commonParams "github.com/cloudbase/garm-provider-common/params"
@@ -10,7 +10,7 @@ import (
 )
 
 func ValidateJobLifecycle(label string) {
-	log.Printf("Validate GARM job lifecycle with label %s", label)
+	slog.Info("Validate GARM job lifecycle", "label", label)
 
 	// wait for job list to be updated
 	job, err := waitLabelledJob(label, 4*time.Minute)
@@ -58,7 +58,7 @@ func waitLabelledJob(label string, timeout time.Duration) (*params.Job, error) {
 	var jobs params.Jobs
 	var err error
 
-	log.Printf("Waiting for job with label %s", label)
+	slog.Info("Waiting for job", "label", label)
 	for timeWaited < timeout {
 		jobs, err = listJobs(cli, authToken)
 		if err != nil {
@@ -85,7 +85,7 @@ func waitJobStatus(id int64, status params.JobStatus, timeout time.Duration) (*p
 	var timeWaited time.Duration = 0
 	var job *params.Job
 
-	log.Printf("Waiting for job %d to reach status %s", id, status)
+	slog.Info("Waiting for job to reach status", "job_id", id, "status", status)
 	for timeWaited < timeout {
 		jobs, err := listJobs(cli, authToken)
 		if err != nil {

--- a/test/integration/e2e/organizations.go
+++ b/test/integration/e2e/organizations.go
@@ -1,7 +1,7 @@
 package e2e
 
 import (
-	"log"
+	"log/slog"
 	"time"
 
 	commonParams "github.com/cloudbase/garm-provider-common/params"
@@ -9,7 +9,7 @@ import (
 )
 
 func CreateOrg(orgName, credentialsName, orgWebhookSecret string) *params.Organization {
-	log.Printf("Create org %s", orgName)
+	slog.Info("Create org", "org_name", orgName)
 	orgParams := params.CreateOrgParams{
 		Name:            orgName,
 		CredentialsName: credentialsName,
@@ -23,7 +23,7 @@ func CreateOrg(orgName, credentialsName, orgWebhookSecret string) *params.Organi
 }
 
 func UpdateOrg(id, credentialsName string) *params.Organization {
-	log.Printf("Update org %s", id)
+	slog.Info("Update org", "org_id", id)
 	updateParams := params.UpdateEntityParams{
 		CredentialsName: credentialsName,
 	}
@@ -35,7 +35,7 @@ func UpdateOrg(id, credentialsName string) *params.Organization {
 }
 
 func InstallOrgWebhook(id string) *params.HookInfo {
-	log.Printf("Install org %s webhook", id)
+	slog.Info("Install org webhook", "org_id", id)
 	webhookParams := params.InstallWebhookParams{
 		WebhookEndpointType: params.WebhookEndpointDirect,
 	}
@@ -51,14 +51,14 @@ func InstallOrgWebhook(id string) *params.HookInfo {
 }
 
 func UninstallOrgWebhook(id string) {
-	log.Printf("Uninstall org %s webhook", id)
+	slog.Info("Uninstall org webhook", "org_id", id)
 	if err := uninstallOrgWebhook(cli, authToken, id); err != nil {
 		panic(err)
 	}
 }
 
 func CreateOrgPool(orgID string, poolParams params.CreatePoolParams) *params.Pool {
-	log.Printf("Create org %s pool", orgID)
+	slog.Info("Create org pool", "org_id", orgID)
 	pool, err := createOrgPool(cli, authToken, orgID, poolParams)
 	if err != nil {
 		panic(err)
@@ -67,7 +67,7 @@ func CreateOrgPool(orgID string, poolParams params.CreatePoolParams) *params.Poo
 }
 
 func GetOrgPool(orgID, orgPoolID string) *params.Pool {
-	log.Printf("Get org %s pool %s", orgID, orgPoolID)
+	slog.Info("Get org pool", "org_id", orgID, "pool_id", orgPoolID)
 	pool, err := getOrgPool(cli, authToken, orgID, orgPoolID)
 	if err != nil {
 		panic(err)
@@ -76,7 +76,7 @@ func GetOrgPool(orgID, orgPoolID string) *params.Pool {
 }
 
 func UpdateOrgPool(orgID, orgPoolID string, maxRunners, minIdleRunners uint) *params.Pool {
-	log.Printf("Update org %s pool %s", orgID, orgPoolID)
+	slog.Info("Update org pool", "org_id", orgID, "pool_id", orgPoolID)
 	poolParams := params.UpdatePoolParams{
 		MinIdleRunners: &minIdleRunners,
 		MaxRunners:     &maxRunners,
@@ -89,7 +89,7 @@ func UpdateOrgPool(orgID, orgPoolID string, maxRunners, minIdleRunners uint) *pa
 }
 
 func DeleteOrgPool(orgID, orgPoolID string) {
-	log.Printf("Delete org %s pool %s", orgID, orgPoolID)
+	slog.Info("Delete org pool", "org_id", orgID, "pool_id", orgPoolID)
 	if err := deleteOrgPool(cli, authToken, orgID, orgPoolID); err != nil {
 		panic(err)
 	}
@@ -111,7 +111,7 @@ func WaitOrgRunningIdleInstances(orgID string, timeout time.Duration) {
 
 func dumpOrgInstancesDetails(orgID string) error {
 	// print org details
-	log.Printf("Dumping org %s details", orgID)
+	slog.Info("Dumping org details", "org_id", orgID)
 	org, err := getOrg(cli, authToken, orgID)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func dumpOrgInstancesDetails(orgID string) error {
 	}
 
 	// print org instances details
-	log.Printf("Dumping org %s instances details", orgID)
+	slog.Info("Dumping org instances details", "org_id", orgID)
 	instances, err := listOrgInstances(cli, authToken, orgID)
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func dumpOrgInstancesDetails(orgID string) error {
 		if err != nil {
 			return err
 		}
-		log.Printf("Instance %s info:", instance.Name)
+		slog.Info("Instance info", "instance_name", instance.Name)
 		if err := printJsonResponse(instance); err != nil {
 			return err
 		}

--- a/test/integration/e2e/pools.go
+++ b/test/integration/e2e/pools.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"time"
 
 	"github.com/cloudbase/garm/params"
@@ -13,13 +13,13 @@ func waitPoolNoInstances(id string, timeout time.Duration) error {
 	var pool *params.Pool
 	var err error
 
-	log.Printf("Wait until pool %s has no instances", id)
+	slog.Info("Wait until pool has no instances", "pool_id", id)
 	for timeWaited < timeout {
 		pool, err = getPool(cli, authToken, id)
 		if err != nil {
 			return err
 		}
-		log.Printf("Current pool instances: %d", len(pool.Instances))
+		slog.Info("Current pool instances", "instance_count", len(pool.Instances))
 		if len(pool.Instances) == 0 {
 			return nil
 		}
@@ -45,7 +45,7 @@ func dumpPoolInstancesDetails(poolID string) error {
 		if err != nil {
 			return err
 		}
-		log.Printf("Instance %s details:", instance.Name)
+		slog.Info("Instance details", "instance_name", instance.Name)
 		if err := printJsonResponse(instanceDetails); err != nil {
 			return err
 		}

--- a/test/integration/e2e/repositories.go
+++ b/test/integration/e2e/repositories.go
@@ -1,7 +1,7 @@
 package e2e
 
 import (
-	"log"
+	"log/slog"
 	"time"
 
 	commonParams "github.com/cloudbase/garm-provider-common/params"
@@ -9,7 +9,7 @@ import (
 )
 
 func CreateRepo(orgName, repoName, credentialsName, repoWebhookSecret string) *params.Repository {
-	log.Printf("Create repository %s/%s", orgName, repoName)
+	slog.Info("Create repository", "owner_name", orgName, "repo_name", repoName)
 	createParams := params.CreateRepoParams{
 		Owner:           orgName,
 		Name:            repoName,
@@ -24,7 +24,7 @@ func CreateRepo(orgName, repoName, credentialsName, repoWebhookSecret string) *p
 }
 
 func UpdateRepo(id, credentialsName string) *params.Repository {
-	log.Printf("Update repo %s", id)
+	slog.Info("Update repo", "repo_id", id)
 	updateParams := params.UpdateEntityParams{
 		CredentialsName: credentialsName,
 	}
@@ -36,7 +36,7 @@ func UpdateRepo(id, credentialsName string) *params.Repository {
 }
 
 func InstallRepoWebhook(id string) *params.HookInfo {
-	log.Printf("Install repo %s webhook", id)
+	slog.Info("Install repo webhook", "repo_id", id)
 	webhookParams := params.InstallWebhookParams{
 		WebhookEndpointType: params.WebhookEndpointDirect,
 	}
@@ -52,14 +52,14 @@ func InstallRepoWebhook(id string) *params.HookInfo {
 }
 
 func UninstallRepoWebhook(id string) {
-	log.Printf("Uninstall repo %s webhook", id)
+	slog.Info("Uninstall repo webhook", "repo_id", id)
 	if err := uninstallRepoWebhook(cli, authToken, id); err != nil {
 		panic(err)
 	}
 }
 
 func CreateRepoPool(repoID string, poolParams params.CreatePoolParams) *params.Pool {
-	log.Printf("Create repo %s pool", repoID)
+	slog.Info("Create repo pool", "repo_id", repoID)
 	pool, err := createRepoPool(cli, authToken, repoID, poolParams)
 	if err != nil {
 		panic(err)
@@ -68,7 +68,7 @@ func CreateRepoPool(repoID string, poolParams params.CreatePoolParams) *params.P
 }
 
 func GetRepoPool(repoID, repoPoolID string) *params.Pool {
-	log.Printf("Get repo %s pool %s", repoID, repoPoolID)
+	slog.Info("Get repo pool", "repo_id", repoID, "pool_id", repoPoolID)
 	pool, err := getRepoPool(cli, authToken, repoID, repoPoolID)
 	if err != nil {
 		panic(err)
@@ -77,7 +77,7 @@ func GetRepoPool(repoID, repoPoolID string) *params.Pool {
 }
 
 func UpdateRepoPool(repoID, repoPoolID string, maxRunners, minIdleRunners uint) *params.Pool {
-	log.Printf("Update repo %s pool %s", repoID, repoPoolID)
+	slog.Info("Update repo pool", "repo_id", repoID, "pool_id", repoPoolID)
 	poolParams := params.UpdatePoolParams{
 		MinIdleRunners: &minIdleRunners,
 		MaxRunners:     &maxRunners,
@@ -90,14 +90,14 @@ func UpdateRepoPool(repoID, repoPoolID string, maxRunners, minIdleRunners uint) 
 }
 
 func DeleteRepoPool(repoID, repoPoolID string) {
-	log.Printf("Delete repo %s pool %s", repoID, repoPoolID)
+	slog.Info("Delete repo pool", "repo_id", repoID, "pool_id", repoPoolID)
 	if err := deleteRepoPool(cli, authToken, repoID, repoPoolID); err != nil {
 		panic(err)
 	}
 }
 
 func DisableRepoPool(repoID, repoPoolID string) {
-	log.Printf("Disable repo %s pool %s", repoID, repoPoolID)
+	slog.Info("Disable repo pool", "repo_id", repoID, "pool_id", repoPoolID)
 	enabled := false
 	poolParams := params.UpdatePoolParams{Enabled: &enabled}
 	if _, err := updateRepoPool(cli, authToken, repoID, repoPoolID, poolParams); err != nil {
@@ -121,7 +121,7 @@ func WaitRepoRunningIdleInstances(repoID string, timeout time.Duration) {
 
 func dumpRepoInstancesDetails(repoID string) error {
 	// print repo details
-	log.Printf("Dumping repo %s details", repoID)
+	slog.Info("Dumping repo details", "repo_id", repoID)
 	repo, err := getRepo(cli, authToken, repoID)
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func dumpRepoInstancesDetails(repoID string) error {
 	}
 
 	// print repo instances details
-	log.Printf("Dumping repo %s instances details", repoID)
+	slog.Info("Dumping repo instances details", "repo_id", repoID)
 	instances, err := listRepoInstances(cli, authToken, repoID)
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func dumpRepoInstancesDetails(repoID string) error {
 		if err != nil {
 			return err
 		}
-		log.Printf("Instance %s info:", instance.Name)
+		slog.Info("Instance info", "instance_name", instance.Name)
 		if err := printJsonResponse(instance); err != nil {
 			return err
 		}

--- a/test/integration/e2e/utils.go
+++ b/test/integration/e2e/utils.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 )
 
 func printJsonResponse(resp interface{}) error {
@@ -10,6 +10,6 @@ func printJsonResponse(resp interface{}) error {
 	if err != nil {
 		return err
 	}
-	log.Println(string(b))
+	slog.Info(string(b))
 	return nil
 }

--- a/test/integration/gh_cleanup/main.go
+++ b/test/integration/gh_cleanup/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/cloudbase/garm/test/integration/e2e"
@@ -21,7 +21,7 @@ func main() {
 		_ = e2e.GhOrgRunnersCleanup(ghToken, orgName, controllerID)
 		_ = e2e.GhRepoRunnersCleanup(ghToken, orgName, repoName, controllerID)
 	} else {
-		log.Println("Env variable GARM_CONTROLLER_ID is not set, skipping GitHub runners cleanup")
+		slog.Warn("Env variable GARM_CONTROLLER_ID is not set, skipping GitHub runners cleanup")
 	}
 
 	baseURL, baseUrlFound := os.LookupEnv("GARM_BASE_URL")
@@ -30,6 +30,6 @@ func main() {
 		_ = e2e.GhOrgWebhookCleanup(ghToken, webhookURL, orgName)
 		_ = e2e.GhRepoWebhookCleanup(ghToken, webhookURL, orgName, repoName)
 	} else {
-		log.Println("Env variables GARM_CONTROLLER_ID & GARM_BASE_URL are not set, skipping webhooks cleanup")
+		slog.Warn("Env variables GARM_CONTROLLER_ID & GARM_BASE_URL are not set, skipping webhooks cleanup")
 	}
 }

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -120,19 +120,19 @@ func main() {
 	_ = e2e.UpdateRepoPool(repo.ID, repoPool2.ID, repoPoolParams2.MaxRunners, 1)
 	err := e2e.WaitPoolInstances(repoPool2.ID, commonParams.InstanceRunning, params.RunnerPending, 1*time.Minute)
 	if err != nil {
-		log.Printf("Failed to wait for instance to be running: %v", err)
+		slog.With(slog.Any("error", err)).Error("Failed to wait for instance to be running")
 	}
 	repoPool2 = e2e.GetRepoPool(repo.ID, repoPool2.ID)
 	e2e.DisableRepoPool(repo.ID, repoPool2.ID)
 	e2e.DeleteInstance(repoPool2.Instances[0].Name, false)
 	err = e2e.WaitPoolInstances(repoPool2.ID, commonParams.InstancePendingDelete, params.RunnerPending, 1*time.Minute)
 	if err != nil {
-		log.Printf("Failed to wait for instance to be running: %v", err)
+		slog.With(slog.Any("error", err)).Error("Failed to wait for instance to be running")
 	}
 	e2e.DeleteInstance(repoPool2.Instances[0].Name, true) // delete instance with forceRemove
 	err = e2e.WaitInstanceToBeRemoved(repoPool2.Instances[0].Name, 1*time.Minute)
 	if err != nil {
-		log.Printf("Failed to wait for instance to be removed: %v", err)
+		slog.With(slog.Any("error", err)).Error("Failed to wait for instance to be removed")
 	}
 	e2e.DeleteRepoPool(repo.ID, repoPool2.ID)
 

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -35,14 +35,35 @@ webhook_url = "https://garm.example.com/webhooks"
 # webhooks for repositories or organizations.
 enable_webhook_management = true
 
+# DEPRECATED: Use the [logging] section to set this option.
 # Uncomment this line if you'd like to log to a file instead of standard output.
 # log_file = "/tmp/runner-manager.log"
 
+# DEPRECATED: Use the [logging] section to set this option.
 # Enable streaming logs via web sockets. Use garm-cli debug-log.
 enable_log_streamer = false
 
 # Enable the golang debug server. See the documentation in the "doc" folder for more information.
 debug_server = false
+
+
+[logging]
+# Uncomment this line if you'd like to log to a file instead of standard output.
+# log_file = "/tmp/runner-manager.log"
+
+# enable_log_streamer enables streaming the logs over websockets
+enable_log_streamer = true
+# log_format is the output format of the logs. GARM uses structured logging and can
+# output as "text" or "json"
+log_format = "text"
+# log_level is the logging level GARM will output. Available log levels are:
+#  * debug
+#  * info
+#  * warn
+#  * error
+log_level = "debug"
+# log_source will output information about the function that generated the log line.
+log_source = false
 
 [metrics]
 # Toggle metrics. If set to false, the API endpoint for metrics collection will

--- a/util/logging.go
+++ b/util/logging.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"context"
+	"log/slog"
+)
+
+type slogContextKey string
+
+const (
+	slogCtxFields slogContextKey = "slog_ctx_fields"
+)
+
+type ContextHandler struct {
+	slog.Handler
+}
+
+func (h ContextHandler) Handle(ctx context.Context, r slog.Record) error {
+	attrs, ok := ctx.Value(slogCtxFields).([]slog.Attr)
+	if ok {
+		for _, v := range attrs {
+			r.AddAttrs(v)
+		}
+	}
+	return h.Handler.Handle(ctx, r)
+}
+
+func WithContext(ctx context.Context, attrs ...slog.Attr) context.Context {
+	return context.WithValue(ctx, slogCtxFields, attrs)
+}


### PR DESCRIPTION
This change switches GARM to the new `log/slog` structured logging library. This allows us to add contextual fields to log lines, generate `json` or `text` format logs, set log levels, etc.

This change is mostly mechanic, replacing instances of `log.Print()` and the badly writen `r.log()` from `runner/pool` with `slog`.