### PR TITLE
Small adjustments

### DIFF
--- a/runner/common/pool.go
+++ b/runner/common/pool.go
@@ -27,9 +27,9 @@ const (
 	PoolReapTimeoutInterval   = 5 * time.Minute
 	// Temporary tools download token is valid for 1 hour by default.
 	// There is no point in making an API call to get available tools, for every runner
-	// we spin up. We cache the tools for one minute. This should save us a lot of API calls
+	// we spin up. We cache the tools for 5 minutes. This should save us a lot of API calls
 	// in cases where we have a lot of runners spin up at the same time.
-	PoolToolUpdateInterval = 1 * time.Minute
+	PoolToolUpdateInterval = 5 * time.Minute
 
 	// BackoffTimer is the time we wait before attempting to make another request
 	// to the github API.

--- a/runner/providers/external/external.go
+++ b/runner/providers/external/external.go
@@ -60,12 +60,6 @@ func (e *external) validateResult(ctx context.Context, inst commonParams.Provide
 		return garmErrors.NewProviderError("missing instance name")
 	}
 
-	if inst.OSName == "" || inst.OSArch == "" || inst.OSType == "" {
-		// we can still function without this info (I think)
-		slog.WarnContext(
-			ctx, "missing OS information",
-			"instance", inst.Name)
-	}
 	if !IsValidProviderStatus(inst.Status) {
 		return garmErrors.NewProviderError("invalid status returned (%s)", inst.Status)
 	}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -960,7 +960,13 @@ func (r *Runner) DeleteRunner(ctx context.Context, instanceName string, forceDel
 	case commonParams.InstanceRunning, commonParams.InstanceError,
 		commonParams.InstancePendingForceDelete, commonParams.InstancePendingDelete:
 	default:
-		return runnerErrors.NewBadRequestError("runner must be in %q or %q state", commonParams.InstanceRunning, commonParams.InstanceError)
+		validStates := []string{
+			string(commonParams.InstanceRunning),
+			string(commonParams.InstanceError),
+			string(commonParams.InstancePendingForceDelete),
+			string(commonParams.InstancePendingDelete),
+		}
+		return runnerErrors.NewBadRequestError("runner must be in one of the following states: %q", strings.Join(validStates, ", "))
 	}
 
 	poolMgr, err := r.getPoolManagerFromInstance(ctx, instance)

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -127,17 +127,14 @@ func (h *Hub) Close() error {
 
 func (h *Hub) Stop() error {
 	h.Close()
+	return h.Wait()
+}
+
+func (h *Hub) Wait() error {
 	select {
 	case <-h.closed:
-		return nil
 	case <-time.After(60 * time.Second):
 		return fmt.Errorf("timed out waiting for hub stop")
 	}
-}
-
-func (h *Hub) Wait() {
-	select {
-	case <-h.closed:
-	case <-time.After(60 * time.Second):
-	}
+	return nil
 }


### PR DESCRIPTION
This change increases the tools refresh interval to 5 minutes, cleans up the websocket code a bit, augments the error message that may be returned when trying to delete a runner in an invalid state and removes a log message that does not add much value.