### PR TITLE
Fix typos in garm-cli

### DIFF
--- a/cmd/garm-cli/cmd/enterprise.go
+++ b/cmd/garm-cli/cmd/enterprise.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/cloudbase/garm-provider-common/util"
 	apiClientEnterprises "github.com/cloudbase/garm/client/enterprises"
 	"github.com/cloudbase/garm/params"
 
@@ -26,10 +25,9 @@ import (
 )
 
 var (
-	enterpriseName                string
-	enterpriseWebhookSecret       string
-	enterpriseCreds               string
-	enterpriseRandomWebhookSecret bool
+	enterpriseName          string
+	enterpriseWebhookSecret string
+	enterpriseCreds         string
 )
 
 // enterpriseCmd represents the enterprise command
@@ -55,14 +53,6 @@ var enterpriseAddCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if needsInit {
 			return errNeedsInitError
-		}
-
-		if enterpriseRandomWebhookSecret {
-			secret, err := util.GetRandomString(32)
-			if err != nil {
-				return err
-			}
-			enterpriseWebhookSecret = secret
 		}
 
 		newEnterpriseReq := apiClientEnterprises.NewCreateEnterpriseParams()
@@ -189,8 +179,6 @@ func init() {
 	enterpriseAddCmd.Flags().StringVar(&enterpriseName, "name", "", "The name of the enterprise")
 	enterpriseAddCmd.Flags().StringVar(&enterpriseWebhookSecret, "webhook-secret", "", "The webhook secret for this enterprise")
 	enterpriseAddCmd.Flags().StringVar(&enterpriseCreds, "credentials", "", "Credentials name. See credentials list.")
-	enterpriseAddCmd.Flags().BoolVar(&enterpriseRandomWebhookSecret, "random-webhook-secret", false, "Generate a random webhook secret for this organization.")
-	enterpriseAddCmd.MarkFlagsMutuallyExclusive("webhook-secret", "random-webhook-secret")
 
 	enterpriseAddCmd.MarkFlagRequired("credentials") //nolint
 	enterpriseAddCmd.MarkFlagRequired("name")        //nolint

--- a/cmd/garm-cli/cmd/pool.go
+++ b/cmd/garm-cli/cmd/pool.go
@@ -87,9 +87,9 @@ Example:
 	garm-cli pool list --org=5493e51f-3170-4ce3-9f05-3fe690fc6ec6
 
 	List pools from one enterprise:
-	garm-cli pool list --org=a8ee4c66-e762-4cbe-a35d-175dba2c9e62
+	garm-cli pool list --enterprise=a8ee4c66-e762-4cbe-a35d-175dba2c9e62
 
-	List all pools from all repos and orgs:
+	List all pools from all repos, orgs and enterprises:
 	garm-cli pool list --all
 
 `,
@@ -285,7 +285,7 @@ var poolUpdateCmd = &cobra.Command{
 	Long: `Updates pool characteristics.
 
 This command updates the pool characteristics. Runners already created prior to updating
-the pool, will not be recreated. IF they no longer suit your needs, you will need to
+the pool, will not be recreated. If they no longer suit your needs, you will need to
 explicitly remove them using the runner delete command.
 	`,
 	SilenceUsage: true,


### PR DESCRIPTION
This change:

* Removes the `--random-webhook-secret` option from enterprises
* Fixed some help typos