### PR TITLE
Fix JIT config with empty runner group name

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -96,7 +96,7 @@ type urls struct {
 }
 
 func NewEntityPoolManager(ctx context.Context, entity params.GithubEntity, cfgInternal params.Internal, providers map[string]common.Provider, store dbCommon.Store) (common.PoolManager, error) {
-	ctx = garmUtil.WithContext(ctx, slog.Any("pool_mgr", entity), slog.Any("pool_type", params.GithubEntityTypeRepository))
+	ctx = garmUtil.WithContext(ctx, slog.Any("pool_mgr", entity.String()), slog.Any("pool_type", params.GithubEntityTypeRepository))
 	ghc, err := garmUtil.GithubClient(ctx, entity, cfgInternal.GithubCredentialsDetails)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting github client")


### PR DESCRIPTION
When no runner group is set, do not attempt to resolve the runner group. Looking for an empty runner group will just return a not found error, which will make GARM fall back to registration token.

This change fixes that.