### PR TITLE
Slightly simplify code

### DIFF
--- a/database/common/common.go
+++ b/database/common/common.go
@@ -74,7 +74,7 @@ type UserStore interface {
 type InstanceStore interface {
 	CreateInstance(ctx context.Context, poolID string, param params.CreateInstanceParams) (params.Instance, error)
 	DeleteInstance(ctx context.Context, poolID string, instanceName string) error
-	UpdateInstance(ctx context.Context, instanceID string, param params.UpdateInstanceParams) (params.Instance, error)
+	UpdateInstance(ctx context.Context, instanceName string, param params.UpdateInstanceParams) (params.Instance, error)
 
 	// Probably a bad idea without some king of filter or at least pagination
 	//
@@ -83,8 +83,7 @@ type InstanceStore interface {
 	ListAllInstances(ctx context.Context) ([]params.Instance, error)
 
 	GetInstanceByName(ctx context.Context, instanceName string) (params.Instance, error)
-	AddInstanceEvent(ctx context.Context, instanceID string, event params.EventType, eventLevel params.EventLevel, eventMessage string) error
-	ListInstanceEvents(ctx context.Context, instanceID string, eventType params.EventType, eventLevel params.EventLevel) ([]params.StatusMessage, error)
+	AddInstanceEvent(ctx context.Context, instanceName string, event params.EventType, eventLevel params.EventLevel, eventMessage string) error
 }
 
 type JobsStore interface {

--- a/database/common/mocks/Store.go
+++ b/database/common/mocks/Store.go
@@ -14,9 +14,9 @@ type Store struct {
 	mock.Mock
 }
 
-// AddInstanceEvent provides a mock function with given fields: ctx, instanceID, event, eventLevel, eventMessage
-func (_m *Store) AddInstanceEvent(ctx context.Context, instanceID string, event params.EventType, eventLevel params.EventLevel, eventMessage string) error {
-	ret := _m.Called(ctx, instanceID, event, eventLevel, eventMessage)
+// AddInstanceEvent provides a mock function with given fields: ctx, instanceName, event, eventLevel, eventMessage
+func (_m *Store) AddInstanceEvent(ctx context.Context, instanceName string, event params.EventType, eventLevel params.EventLevel, eventMessage string) error {
+	ret := _m.Called(ctx, instanceName, event, eventLevel, eventMessage)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddInstanceEvent")
@@ -24,7 +24,7 @@ func (_m *Store) AddInstanceEvent(ctx context.Context, instanceID string, event 
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, params.EventType, params.EventLevel, string) error); ok {
-		r0 = rf(ctx, instanceID, event, eventLevel, eventMessage)
+		r0 = rf(ctx, instanceName, event, eventLevel, eventMessage)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1068,36 +1068,6 @@ func (_m *Store) ListEntityPools(ctx context.Context, entity params.GithubEntity
 	return r0, r1
 }
 
-// ListInstanceEvents provides a mock function with given fields: ctx, instanceID, eventType, eventLevel
-func (_m *Store) ListInstanceEvents(ctx context.Context, instanceID string, eventType params.EventType, eventLevel params.EventLevel) ([]params.StatusMessage, error) {
-	ret := _m.Called(ctx, instanceID, eventType, eventLevel)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ListInstanceEvents")
-	}
-
-	var r0 []params.StatusMessage
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, params.EventType, params.EventLevel) ([]params.StatusMessage, error)); ok {
-		return rf(ctx, instanceID, eventType, eventLevel)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, params.EventType, params.EventLevel) []params.StatusMessage); ok {
-		r0 = rf(ctx, instanceID, eventType, eventLevel)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]params.StatusMessage)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string, params.EventType, params.EventLevel) error); ok {
-		r1 = rf(ctx, instanceID, eventType, eventLevel)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // ListJobsByStatus provides a mock function with given fields: ctx, status
 func (_m *Store) ListJobsByStatus(ctx context.Context, status params.JobStatus) ([]params.Job, error) {
 	ret := _m.Called(ctx, status)
@@ -1338,9 +1308,9 @@ func (_m *Store) UpdateEntityPool(ctx context.Context, entity params.GithubEntit
 	return r0, r1
 }
 
-// UpdateInstance provides a mock function with given fields: ctx, instanceID, param
-func (_m *Store) UpdateInstance(ctx context.Context, instanceID string, param params.UpdateInstanceParams) (params.Instance, error) {
-	ret := _m.Called(ctx, instanceID, param)
+// UpdateInstance provides a mock function with given fields: ctx, instanceName, param
+func (_m *Store) UpdateInstance(ctx context.Context, instanceName string, param params.UpdateInstanceParams) (params.Instance, error) {
+	ret := _m.Called(ctx, instanceName, param)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateInstance")
@@ -1349,16 +1319,16 @@ func (_m *Store) UpdateInstance(ctx context.Context, instanceID string, param pa
 	var r0 params.Instance
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, params.UpdateInstanceParams) (params.Instance, error)); ok {
-		return rf(ctx, instanceID, param)
+		return rf(ctx, instanceName, param)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, string, params.UpdateInstanceParams) params.Instance); ok {
-		r0 = rf(ctx, instanceID, param)
+		r0 = rf(ctx, instanceName, param)
 	} else {
 		r0 = ret.Get(0).(params.Instance)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, string, params.UpdateInstanceParams) error); ok {
-		r1 = rf(ctx, instanceID, param)
+		r1 = rf(ctx, instanceName, param)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/runner/metadata.go
+++ b/runner/metadata.go
@@ -166,11 +166,11 @@ func (r *Runner) GetInstanceGithubRegistrationToken(ctx context.Context) (string
 		TokenFetched: &tokenFetched,
 	}
 
-	if _, err := r.store.UpdateInstance(r.ctx, instance.ID, updateParams); err != nil {
+	if _, err := r.store.UpdateInstance(r.ctx, instance.Name, updateParams); err != nil {
 		return "", errors.Wrap(err, "setting token_fetched for instance")
 	}
 
-	if err := r.store.AddInstanceEvent(ctx, instance.ID, params.FetchTokenEvent, params.EventInfo, "runner registration token was retrieved"); err != nil {
+	if err := r.store.AddInstanceEvent(ctx, instance.Name, params.FetchTokenEvent, params.EventInfo, "runner registration token was retrieved"); err != nil {
 		return "", errors.Wrap(err, "recording event")
 	}
 

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -745,20 +745,6 @@ func (r *basePoolManager) waitForErrorGroupOrContextCancelled(g *errgroup.Group)
 	}
 }
 
-func (r *basePoolManager) fetchInstance(runnerName string) (params.Instance, error) {
-	runner, err := r.store.GetInstanceByName(r.ctx, runnerName)
-	if err != nil {
-		return params.Instance{}, errors.Wrap(err, "fetching instance")
-	}
-
-	_, err = r.GetPoolByID(runner.PoolID)
-	if err != nil {
-		return params.Instance{}, errors.Wrap(err, "fetching pool")
-	}
-
-	return runner, nil
-}
-
 func (r *basePoolManager) setInstanceRunnerStatus(runnerName string, status params.RunnerStatus) (params.Instance, error) {
 	updateParams := params.UpdateInstanceParams{
 		RunnerStatus: status,
@@ -772,12 +758,7 @@ func (r *basePoolManager) setInstanceRunnerStatus(runnerName string, status para
 }
 
 func (r *basePoolManager) updateInstance(runnerName string, update params.UpdateInstanceParams) (params.Instance, error) {
-	runner, err := r.fetchInstance(runnerName)
-	if err != nil {
-		return params.Instance{}, errors.Wrap(err, "fetching instance")
-	}
-
-	instance, err := r.store.UpdateInstance(r.ctx, runner.ID, update)
+	instance, err := r.store.UpdateInstance(r.ctx, runnerName, update)
 	if err != nil {
 		return params.Instance{}, errors.Wrap(err, "updating runner state")
 	}
@@ -980,7 +961,7 @@ func (r *basePoolManager) addInstanceToProvider(instance params.Instance) error 
 	}
 
 	updateInstanceArgs := r.updateArgsFromProviderInstance(providerInstance)
-	if _, err := r.store.UpdateInstance(r.ctx, instance.ID, updateInstanceArgs); err != nil {
+	if _, err := r.store.UpdateInstance(r.ctx, instance.Name, updateInstanceArgs); err != nil {
 		return errors.Wrap(err, "updating instance")
 	}
 	return nil

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -870,12 +870,12 @@ func (r *Runner) ListAllInstances(ctx context.Context) ([]params.Instance, error
 }
 
 func (r *Runner) AddInstanceStatusMessage(ctx context.Context, param params.InstanceUpdateMessage) error {
-	instanceID := auth.InstanceID(ctx)
-	if instanceID == "" {
+	instanceName := auth.InstanceName(ctx)
+	if instanceName == "" {
 		return runnerErrors.ErrUnauthorized
 	}
 
-	if err := r.store.AddInstanceEvent(ctx, instanceID, params.StatusEvent, params.EventInfo, param.Message); err != nil {
+	if err := r.store.AddInstanceEvent(ctx, instanceName, params.StatusEvent, params.EventInfo, param.Message); err != nil {
 		return errors.Wrap(err, "adding status update")
 	}
 
@@ -887,7 +887,7 @@ func (r *Runner) AddInstanceStatusMessage(ctx context.Context, param params.Inst
 		updateParams.AgentID = *param.AgentID
 	}
 
-	if _, err := r.store.UpdateInstance(r.ctx, instanceID, updateParams); err != nil {
+	if _, err := r.store.UpdateInstance(r.ctx, instanceName, updateParams); err != nil {
 		return errors.Wrap(err, "updating runner agent ID")
 	}
 
@@ -895,9 +895,9 @@ func (r *Runner) AddInstanceStatusMessage(ctx context.Context, param params.Inst
 }
 
 func (r *Runner) UpdateSystemInfo(ctx context.Context, param params.UpdateSystemInfoParams) error {
-	instanceID := auth.InstanceID(ctx)
-	if instanceID == "" {
-		slog.ErrorContext(ctx, "missing instance ID")
+	instanceName := auth.InstanceName(ctx)
+	if instanceName == "" {
+		slog.ErrorContext(ctx, "missing instance name")
 		return runnerErrors.ErrUnauthorized
 	}
 
@@ -915,7 +915,7 @@ func (r *Runner) UpdateSystemInfo(ctx context.Context, param params.UpdateSystem
 		updateParams.AgentID = *param.AgentID
 	}
 
-	if _, err := r.store.UpdateInstance(r.ctx, instanceID, updateParams); err != nil {
+	if _, err := r.store.UpdateInstance(r.ctx, instanceName, updateParams); err != nil {
 		return errors.Wrap(err, "updating runner system info")
 	}
 


### PR DESCRIPTION
Change instance DB functions from querying by ID to querying by name. Names are unique in GARM, so we might as well use the name instead of the ID and spare ourselves the extra query to get the ID when a qorkflow comes in.

This change also removes an unused function.