### PR TITLE
Remove check for duplicate pool

### DIFF
--- a/database/sql/organizations_test.go
+++ b/database/sql/organizations_test.go
@@ -28,7 +28,6 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 
-	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/auth"
 	dbCommon "github.com/cloudbase/garm/database/common"
 	garmTesting "github.com/cloudbase/garm/internal/testing"
@@ -503,68 +502,12 @@ func (s *OrgTestSuite) TestCreateOrganizationPoolInvalidOrgID() {
 	s.Require().Equal("parsing id: invalid request", err.Error())
 }
 
-func (s *OrgTestSuite) TestCreateOrganizationPoolDBCreateErr() {
-	s.Fixtures.SQLMock.ExpectBegin()
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE id = ? AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT ?")).
-		WithArgs(s.Fixtures.Orgs[0].ID, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE (provider_name = ? and image = ? and flavor = ? and org_id = ?) AND `pools`.`deleted_at` IS NULL ORDER BY `pools`.`id` LIMIT ?")).
-		WillReturnError(fmt.Errorf("mocked creating pool error"))
-
-	entity, err := s.Fixtures.Orgs[0].GetEntity()
-	s.Require().Nil(err)
-	_, err = s.StoreSQLMocked.CreateEntityPool(s.adminCtx, entity, s.Fixtures.CreatePoolParams)
-
-	s.Require().NotNil(err)
-	s.Require().Equal("checking pool existence: mocked creating pool error", err.Error())
-	s.assertSQLMockExpectations()
-}
-
-func (s *OrgTestSuite) TestCreateOrganizationDBPoolAlreadyExistErr() {
-	s.Fixtures.SQLMock.ExpectBegin()
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE id = ? AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT ?")).
-		WithArgs(s.Fixtures.Orgs[0].ID, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE (provider_name = ? and image = ? and flavor = ? and org_id = ?) AND `pools`.`deleted_at` IS NULL ORDER BY `pools`.`id` LIMIT ?")).
-		WithArgs(
-			s.Fixtures.CreatePoolParams.ProviderName,
-			s.Fixtures.CreatePoolParams.Image,
-			s.Fixtures.CreatePoolParams.Flavor,
-			s.Fixtures.Orgs[0].ID, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"org_id", "provider_name", "image", "flavor"}).
-			AddRow(
-				s.Fixtures.Orgs[0].ID,
-				s.Fixtures.CreatePoolParams.ProviderName,
-				s.Fixtures.CreatePoolParams.Image,
-				s.Fixtures.CreatePoolParams.Flavor))
-
-	entity, err := s.Fixtures.Orgs[0].GetEntity()
-	s.Require().Nil(err)
-	_, err = s.StoreSQLMocked.CreateEntityPool(s.adminCtx, entity, s.Fixtures.CreatePoolParams)
-
-	s.Require().NotNil(err)
-	s.Require().Equal(runnerErrors.NewConflictError("pool with the same image and flavor already exists on this provider"), err)
-	s.assertSQLMockExpectations()
-}
-
 func (s *OrgTestSuite) TestCreateOrganizationPoolDBFetchTagErr() {
 	s.Fixtures.SQLMock.ExpectBegin()
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE id = ? AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT ?")).
 		WithArgs(s.Fixtures.Orgs[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE (provider_name = ? and image = ? and flavor = ? and org_id = ?) AND `pools`.`deleted_at` IS NULL ORDER BY `pools`.`id` LIMIT ?")).
-		WithArgs(
-			s.Fixtures.CreatePoolParams.ProviderName,
-			s.Fixtures.CreatePoolParams.Image,
-			s.Fixtures.CreatePoolParams.Flavor,
-			s.Fixtures.Orgs[0].ID, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"org_id"}))
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnError(fmt.Errorf("mocked fetching tag error"))
@@ -586,14 +529,6 @@ func (s *OrgTestSuite) TestCreateOrganizationPoolDBAddingPoolErr() {
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE id = ? AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT ?")).
 		WithArgs(s.Fixtures.Orgs[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE (provider_name = ? and image = ? and flavor = ? and org_id = ?) AND `pools`.`deleted_at` IS NULL ORDER BY `pools`.`id` LIMIT ?")).
-		WithArgs(
-			s.Fixtures.CreatePoolParams.ProviderName,
-			s.Fixtures.CreatePoolParams.Image,
-			s.Fixtures.CreatePoolParams.Flavor,
-			s.Fixtures.Orgs[0].ID, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"org_id"}))
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
@@ -622,14 +557,6 @@ func (s *OrgTestSuite) TestCreateOrganizationPoolDBSaveTagErr() {
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE id = ? AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT ?")).
 		WithArgs(s.Fixtures.Orgs[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE (provider_name = ? and image = ? and flavor = ? and org_id = ?) AND `pools`.`deleted_at` IS NULL ORDER BY `pools`.`id` LIMIT ?")).
-		WithArgs(
-			s.Fixtures.CreatePoolParams.ProviderName,
-			s.Fixtures.CreatePoolParams.Image,
-			s.Fixtures.CreatePoolParams.Flavor,
-			s.Fixtures.Orgs[0].ID, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"org_id"}))
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
@@ -661,14 +588,6 @@ func (s *OrgTestSuite) TestCreateOrganizationPoolDBFetchPoolErr() {
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE id = ? AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT ?")).
 		WithArgs(s.Fixtures.Orgs[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
-	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `pools` WHERE (provider_name = ? and image = ? and flavor = ? and org_id = ?) AND `pools`.`deleted_at` IS NULL ORDER BY `pools`.`id` LIMIT ?")).
-		WithArgs(
-			s.Fixtures.CreatePoolParams.ProviderName,
-			s.Fixtures.CreatePoolParams.Image,
-			s.Fixtures.CreatePoolParams.Flavor,
-			s.Fixtures.Orgs[0].ID, 1).
-		WillReturnRows(sqlmock.NewRows([]string{"org_id"}))
 	s.Fixtures.SQLMock.
 		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))

--- a/database/sql/pools.go
+++ b/database/sql/pools.go
@@ -288,14 +288,6 @@ func (s *sqlDatabase) CreateEntityPool(_ context.Context, entity params.GithubEn
 			return errors.Wrap(err, "checking entity existence")
 		}
 
-		if _, err := s.getEntityPoolByUniqueFields(tx, entity, newPool.ProviderName, newPool.Image, newPool.Flavor); err != nil {
-			if !errors.Is(err, runnerErrors.ErrNotFound) {
-				return errors.Wrap(err, "checking pool existence")
-			}
-		} else {
-			return runnerErrors.NewConflictError("pool with the same image and flavor already exists on this provider")
-		}
-
 		tags := []Tag{}
 		for _, val := range param.Tags {
 			t, err := s.getOrCreateTag(tx, val)

--- a/database/sql/repositories.go
+++ b/database/sql/repositories.go
@@ -226,31 +226,6 @@ func (s *sqlDatabase) getRepo(_ context.Context, owner, name string) (Repository
 	return repo, nil
 }
 
-func (s *sqlDatabase) getEntityPoolByUniqueFields(tx *gorm.DB, entity params.GithubEntity, provider, image, flavor string) (pool Pool, err error) {
-	var entityField string
-	switch entity.EntityType {
-	case params.GithubEntityTypeRepository:
-		entityField = entityTypeRepoName
-	case params.GithubEntityTypeOrganization:
-		entityField = entityTypeOrgName
-	case params.GithubEntityTypeEnterprise:
-		entityField = entityTypeEnterpriseName
-	}
-	entityID, err := uuid.Parse(entity.ID)
-	if err != nil {
-		return pool, fmt.Errorf("parsing entity ID: %w", err)
-	}
-	poolQueryString := fmt.Sprintf("provider_name = ? and image = ? and flavor = ? and %s = ?", entityField)
-	err = tx.Where(poolQueryString, provider, image, flavor, entityID).First(&pool).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return pool, runnerErrors.ErrNotFound
-		}
-		return
-	}
-	return Pool{}, nil
-}
-
 func (s *sqlDatabase) getRepoByID(_ context.Context, tx *gorm.DB, id string, preload ...string) (Repository, error) {
 	u, err := uuid.Parse(id)
 	if err != nil {


### PR DESCRIPTION
This change removes a check that denies the creation of a pool if the new pool has the same image and flavor set on the same provider. The reasoning for that check was that if you need to create another pool with identical settings to an existing one, you might as well scale up the min-idle-runners on the old one.

This was done when runner groups were not yet added. This in turn has forced users to alias images with new names in their provider, leading to terrible UX. In the end, being too opinionated in this case has caused more harm than good.

Fixes #245