### PR TITLE
Update go-swagger and run generate

### DIFF
--- a/apiserver/routers/routers.go
+++ b/apiserver/routers/routers.go
@@ -40,10 +40,10 @@
 // swagger:meta
 package routers
 
-//go:generate go run github.com/go-swagger/go-swagger/cmd/swagger@v0.30.5 generate spec --input=../swagger-models.yaml --output=../swagger.yaml --include="routers|controllers"
-//go:generate go run github.com/go-swagger/go-swagger/cmd/swagger@v0.30.5 validate ../swagger.yaml
+//go:generate go run github.com/go-swagger/go-swagger/cmd/swagger@v0.31.0 generate spec --input=../swagger-models.yaml --output=../swagger.yaml --include="routers|controllers"
+//go:generate go run github.com/go-swagger/go-swagger/cmd/swagger@v0.31.0 validate ../swagger.yaml
 //go:generate rm -rf ../../client
-//go:generate go run github.com/go-swagger/go-swagger/cmd/swagger@v0.30.5 generate client --target=../../ --spec=../swagger.yaml
+//go:generate go run github.com/go-swagger/go-swagger/cmd/swagger@v0.31.0 generate client --target=../../ --spec=../swagger.yaml
 
 import (
 	_ "expvar" // Register the expvar handlers

--- a/client/controller_info/controller_info_client.go
+++ b/client/controller_info/controller_info_client.go
@@ -9,12 +9,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new controller info API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new controller info API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new controller info API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -25,7 +51,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/controller_info/controller_info_responses.go
+++ b/client/controller_info/controller_info_responses.go
@@ -6,6 +6,7 @@ package controller_info
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ControllerInfoOK) Code() int {
 }
 
 func (o *ControllerInfoOK) Error() string {
-	return fmt.Sprintf("[GET /controller-info][%d] controllerInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /controller-info][%d] controllerInfoOK %s", 200, payload)
 }
 
 func (o *ControllerInfoOK) String() string {
-	return fmt.Sprintf("[GET /controller-info][%d] controllerInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /controller-info][%d] controllerInfoOK %s", 200, payload)
 }
 
 func (o *ControllerInfoOK) GetPayload() garm_params.ControllerInfo {
@@ -152,11 +155,13 @@ func (o *ControllerInfoConflict) Code() int {
 }
 
 func (o *ControllerInfoConflict) Error() string {
-	return fmt.Sprintf("[GET /controller-info][%d] controllerInfoConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /controller-info][%d] controllerInfoConflict %s", 409, payload)
 }
 
 func (o *ControllerInfoConflict) String() string {
-	return fmt.Sprintf("[GET /controller-info][%d] controllerInfoConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /controller-info][%d] controllerInfoConflict %s", 409, payload)
 }
 
 func (o *ControllerInfoConflict) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/credentials/create_credentials_responses.go
+++ b/client/credentials/create_credentials_responses.go
@@ -6,6 +6,7 @@ package credentials
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *CreateCredentialsOK) Code() int {
 }
 
 func (o *CreateCredentialsOK) Error() string {
-	return fmt.Sprintf("[POST /github/credentials][%d] createCredentialsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /github/credentials][%d] createCredentialsOK %s", 200, payload)
 }
 
 func (o *CreateCredentialsOK) String() string {
-	return fmt.Sprintf("[POST /github/credentials][%d] createCredentialsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /github/credentials][%d] createCredentialsOK %s", 200, payload)
 }
 
 func (o *CreateCredentialsOK) GetPayload() garm_params.GithubCredentials {
@@ -152,11 +155,13 @@ func (o *CreateCredentialsBadRequest) Code() int {
 }
 
 func (o *CreateCredentialsBadRequest) Error() string {
-	return fmt.Sprintf("[POST /github/credentials][%d] createCredentialsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /github/credentials][%d] createCredentialsBadRequest %s", 400, payload)
 }
 
 func (o *CreateCredentialsBadRequest) String() string {
-	return fmt.Sprintf("[POST /github/credentials][%d] createCredentialsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /github/credentials][%d] createCredentialsBadRequest %s", 400, payload)
 }
 
 func (o *CreateCredentialsBadRequest) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/credentials/credentials_client.go
+++ b/client/credentials/credentials_client.go
@@ -9,12 +9,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new credentials API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new credentials API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new credentials API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -25,7 +51,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/credentials/delete_credentials_responses.go
+++ b/client/credentials/delete_credentials_responses.go
@@ -6,6 +6,7 @@ package credentials
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteCredentialsDefault) Code() int {
 }
 
 func (o *DeleteCredentialsDefault) Error() string {
-	return fmt.Sprintf("[DELETE /github/credentials/{id}][%d] DeleteCredentials default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /github/credentials/{id}][%d] DeleteCredentials default %s", o._statusCode, payload)
 }
 
 func (o *DeleteCredentialsDefault) String() string {
-	return fmt.Sprintf("[DELETE /github/credentials/{id}][%d] DeleteCredentials default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /github/credentials/{id}][%d] DeleteCredentials default %s", o._statusCode, payload)
 }
 
 func (o *DeleteCredentialsDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/credentials/get_credentials_responses.go
+++ b/client/credentials/get_credentials_responses.go
@@ -6,6 +6,7 @@ package credentials
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *GetCredentialsOK) Code() int {
 }
 
 func (o *GetCredentialsOK) Error() string {
-	return fmt.Sprintf("[GET /github/credentials/{id}][%d] getCredentialsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/credentials/{id}][%d] getCredentialsOK %s", 200, payload)
 }
 
 func (o *GetCredentialsOK) String() string {
-	return fmt.Sprintf("[GET /github/credentials/{id}][%d] getCredentialsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/credentials/{id}][%d] getCredentialsOK %s", 200, payload)
 }
 
 func (o *GetCredentialsOK) GetPayload() garm_params.GithubCredentials {
@@ -152,11 +155,13 @@ func (o *GetCredentialsBadRequest) Code() int {
 }
 
 func (o *GetCredentialsBadRequest) Error() string {
-	return fmt.Sprintf("[GET /github/credentials/{id}][%d] getCredentialsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/credentials/{id}][%d] getCredentialsBadRequest %s", 400, payload)
 }
 
 func (o *GetCredentialsBadRequest) String() string {
-	return fmt.Sprintf("[GET /github/credentials/{id}][%d] getCredentialsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/credentials/{id}][%d] getCredentialsBadRequest %s", 400, payload)
 }
 
 func (o *GetCredentialsBadRequest) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/credentials/list_credentials_responses.go
+++ b/client/credentials/list_credentials_responses.go
@@ -6,6 +6,7 @@ package credentials
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ListCredentialsOK) Code() int {
 }
 
 func (o *ListCredentialsOK) Error() string {
-	return fmt.Sprintf("[GET /github/credentials][%d] listCredentialsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/credentials][%d] listCredentialsOK %s", 200, payload)
 }
 
 func (o *ListCredentialsOK) String() string {
-	return fmt.Sprintf("[GET /github/credentials][%d] listCredentialsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/credentials][%d] listCredentialsOK %s", 200, payload)
 }
 
 func (o *ListCredentialsOK) GetPayload() garm_params.Credentials {
@@ -152,11 +155,13 @@ func (o *ListCredentialsBadRequest) Code() int {
 }
 
 func (o *ListCredentialsBadRequest) Error() string {
-	return fmt.Sprintf("[GET /github/credentials][%d] listCredentialsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/credentials][%d] listCredentialsBadRequest %s", 400, payload)
 }
 
 func (o *ListCredentialsBadRequest) String() string {
-	return fmt.Sprintf("[GET /github/credentials][%d] listCredentialsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/credentials][%d] listCredentialsBadRequest %s", 400, payload)
 }
 
 func (o *ListCredentialsBadRequest) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/credentials/update_credentials_responses.go
+++ b/client/credentials/update_credentials_responses.go
@@ -6,6 +6,7 @@ package credentials
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *UpdateCredentialsOK) Code() int {
 }
 
 func (o *UpdateCredentialsOK) Error() string {
-	return fmt.Sprintf("[PUT /github/credentials/{id}][%d] updateCredentialsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /github/credentials/{id}][%d] updateCredentialsOK %s", 200, payload)
 }
 
 func (o *UpdateCredentialsOK) String() string {
-	return fmt.Sprintf("[PUT /github/credentials/{id}][%d] updateCredentialsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /github/credentials/{id}][%d] updateCredentialsOK %s", 200, payload)
 }
 
 func (o *UpdateCredentialsOK) GetPayload() garm_params.GithubCredentials {
@@ -152,11 +155,13 @@ func (o *UpdateCredentialsBadRequest) Code() int {
 }
 
 func (o *UpdateCredentialsBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /github/credentials/{id}][%d] updateCredentialsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /github/credentials/{id}][%d] updateCredentialsBadRequest %s", 400, payload)
 }
 
 func (o *UpdateCredentialsBadRequest) String() string {
-	return fmt.Sprintf("[PUT /github/credentials/{id}][%d] updateCredentialsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /github/credentials/{id}][%d] updateCredentialsBadRequest %s", 400, payload)
 }
 
 func (o *UpdateCredentialsBadRequest) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/endpoints/create_github_endpoint_responses.go
+++ b/client/endpoints/create_github_endpoint_responses.go
@@ -6,6 +6,7 @@ package endpoints
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *CreateGithubEndpointOK) Code() int {
 }
 
 func (o *CreateGithubEndpointOK) Error() string {
-	return fmt.Sprintf("[POST /github/endpoints][%d] createGithubEndpointOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /github/endpoints][%d] createGithubEndpointOK %s", 200, payload)
 }
 
 func (o *CreateGithubEndpointOK) String() string {
-	return fmt.Sprintf("[POST /github/endpoints][%d] createGithubEndpointOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /github/endpoints][%d] createGithubEndpointOK %s", 200, payload)
 }
 
 func (o *CreateGithubEndpointOK) GetPayload() garm_params.GithubEndpoint {
@@ -157,11 +160,13 @@ func (o *CreateGithubEndpointDefault) Code() int {
 }
 
 func (o *CreateGithubEndpointDefault) Error() string {
-	return fmt.Sprintf("[POST /github/endpoints][%d] CreateGithubEndpoint default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /github/endpoints][%d] CreateGithubEndpoint default %s", o._statusCode, payload)
 }
 
 func (o *CreateGithubEndpointDefault) String() string {
-	return fmt.Sprintf("[POST /github/endpoints][%d] CreateGithubEndpoint default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /github/endpoints][%d] CreateGithubEndpoint default %s", o._statusCode, payload)
 }
 
 func (o *CreateGithubEndpointDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/endpoints/delete_github_endpoint_responses.go
+++ b/client/endpoints/delete_github_endpoint_responses.go
@@ -6,6 +6,7 @@ package endpoints
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteGithubEndpointDefault) Code() int {
 }
 
 func (o *DeleteGithubEndpointDefault) Error() string {
-	return fmt.Sprintf("[DELETE /github/endpoints/{name}][%d] DeleteGithubEndpoint default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /github/endpoints/{name}][%d] DeleteGithubEndpoint default %s", o._statusCode, payload)
 }
 
 func (o *DeleteGithubEndpointDefault) String() string {
-	return fmt.Sprintf("[DELETE /github/endpoints/{name}][%d] DeleteGithubEndpoint default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /github/endpoints/{name}][%d] DeleteGithubEndpoint default %s", o._statusCode, payload)
 }
 
 func (o *DeleteGithubEndpointDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/endpoints/endpoints_client.go
+++ b/client/endpoints/endpoints_client.go
@@ -7,12 +7,38 @@ package endpoints
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new endpoints API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new endpoints API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new endpoints API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/endpoints/get_github_endpoint_responses.go
+++ b/client/endpoints/get_github_endpoint_responses.go
@@ -6,6 +6,7 @@ package endpoints
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetGithubEndpointOK) Code() int {
 }
 
 func (o *GetGithubEndpointOK) Error() string {
-	return fmt.Sprintf("[GET /github/endpoints/{name}][%d] getGithubEndpointOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/endpoints/{name}][%d] getGithubEndpointOK %s", 200, payload)
 }
 
 func (o *GetGithubEndpointOK) String() string {
-	return fmt.Sprintf("[GET /github/endpoints/{name}][%d] getGithubEndpointOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/endpoints/{name}][%d] getGithubEndpointOK %s", 200, payload)
 }
 
 func (o *GetGithubEndpointOK) GetPayload() garm_params.GithubEndpoint {
@@ -157,11 +160,13 @@ func (o *GetGithubEndpointDefault) Code() int {
 }
 
 func (o *GetGithubEndpointDefault) Error() string {
-	return fmt.Sprintf("[GET /github/endpoints/{name}][%d] GetGithubEndpoint default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/endpoints/{name}][%d] GetGithubEndpoint default %s", o._statusCode, payload)
 }
 
 func (o *GetGithubEndpointDefault) String() string {
-	return fmt.Sprintf("[GET /github/endpoints/{name}][%d] GetGithubEndpoint default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/endpoints/{name}][%d] GetGithubEndpoint default %s", o._statusCode, payload)
 }
 
 func (o *GetGithubEndpointDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/endpoints/list_github_endpoints_responses.go
+++ b/client/endpoints/list_github_endpoints_responses.go
@@ -6,6 +6,7 @@ package endpoints
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListGithubEndpointsOK) Code() int {
 }
 
 func (o *ListGithubEndpointsOK) Error() string {
-	return fmt.Sprintf("[GET /github/endpoints][%d] listGithubEndpointsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/endpoints][%d] listGithubEndpointsOK %s", 200, payload)
 }
 
 func (o *ListGithubEndpointsOK) String() string {
-	return fmt.Sprintf("[GET /github/endpoints][%d] listGithubEndpointsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/endpoints][%d] listGithubEndpointsOK %s", 200, payload)
 }
 
 func (o *ListGithubEndpointsOK) GetPayload() garm_params.GithubEndpoints {
@@ -157,11 +160,13 @@ func (o *ListGithubEndpointsDefault) Code() int {
 }
 
 func (o *ListGithubEndpointsDefault) Error() string {
-	return fmt.Sprintf("[GET /github/endpoints][%d] ListGithubEndpoints default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/endpoints][%d] ListGithubEndpoints default %s", o._statusCode, payload)
 }
 
 func (o *ListGithubEndpointsDefault) String() string {
-	return fmt.Sprintf("[GET /github/endpoints][%d] ListGithubEndpoints default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /github/endpoints][%d] ListGithubEndpoints default %s", o._statusCode, payload)
 }
 
 func (o *ListGithubEndpointsDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/endpoints/update_github_endpoint_responses.go
+++ b/client/endpoints/update_github_endpoint_responses.go
@@ -6,6 +6,7 @@ package endpoints
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *UpdateGithubEndpointOK) Code() int {
 }
 
 func (o *UpdateGithubEndpointOK) Error() string {
-	return fmt.Sprintf("[PUT /github/endpoints/{name}][%d] updateGithubEndpointOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /github/endpoints/{name}][%d] updateGithubEndpointOK %s", 200, payload)
 }
 
 func (o *UpdateGithubEndpointOK) String() string {
-	return fmt.Sprintf("[PUT /github/endpoints/{name}][%d] updateGithubEndpointOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /github/endpoints/{name}][%d] updateGithubEndpointOK %s", 200, payload)
 }
 
 func (o *UpdateGithubEndpointOK) GetPayload() garm_params.GithubEndpoint {
@@ -157,11 +160,13 @@ func (o *UpdateGithubEndpointDefault) Code() int {
 }
 
 func (o *UpdateGithubEndpointDefault) Error() string {
-	return fmt.Sprintf("[PUT /github/endpoints/{name}][%d] UpdateGithubEndpoint default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /github/endpoints/{name}][%d] UpdateGithubEndpoint default %s", o._statusCode, payload)
 }
 
 func (o *UpdateGithubEndpointDefault) String() string {
-	return fmt.Sprintf("[PUT /github/endpoints/{name}][%d] UpdateGithubEndpoint default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /github/endpoints/{name}][%d] UpdateGithubEndpoint default %s", o._statusCode, payload)
 }
 
 func (o *UpdateGithubEndpointDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/create_enterprise_pool_responses.go
+++ b/client/enterprises/create_enterprise_pool_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *CreateEnterprisePoolOK) Code() int {
 }
 
 func (o *CreateEnterprisePoolOK) Error() string {
-	return fmt.Sprintf("[POST /enterprises/{enterpriseID}/pools][%d] createEnterprisePoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /enterprises/{enterpriseID}/pools][%d] createEnterprisePoolOK %s", 200, payload)
 }
 
 func (o *CreateEnterprisePoolOK) String() string {
-	return fmt.Sprintf("[POST /enterprises/{enterpriseID}/pools][%d] createEnterprisePoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /enterprises/{enterpriseID}/pools][%d] createEnterprisePoolOK %s", 200, payload)
 }
 
 func (o *CreateEnterprisePoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *CreateEnterprisePoolDefault) Code() int {
 }
 
 func (o *CreateEnterprisePoolDefault) Error() string {
-	return fmt.Sprintf("[POST /enterprises/{enterpriseID}/pools][%d] CreateEnterprisePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /enterprises/{enterpriseID}/pools][%d] CreateEnterprisePool default %s", o._statusCode, payload)
 }
 
 func (o *CreateEnterprisePoolDefault) String() string {
-	return fmt.Sprintf("[POST /enterprises/{enterpriseID}/pools][%d] CreateEnterprisePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /enterprises/{enterpriseID}/pools][%d] CreateEnterprisePool default %s", o._statusCode, payload)
 }
 
 func (o *CreateEnterprisePoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/create_enterprise_responses.go
+++ b/client/enterprises/create_enterprise_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *CreateEnterpriseOK) Code() int {
 }
 
 func (o *CreateEnterpriseOK) Error() string {
-	return fmt.Sprintf("[POST /enterprises][%d] createEnterpriseOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /enterprises][%d] createEnterpriseOK %s", 200, payload)
 }
 
 func (o *CreateEnterpriseOK) String() string {
-	return fmt.Sprintf("[POST /enterprises][%d] createEnterpriseOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /enterprises][%d] createEnterpriseOK %s", 200, payload)
 }
 
 func (o *CreateEnterpriseOK) GetPayload() garm_params.Enterprise {
@@ -157,11 +160,13 @@ func (o *CreateEnterpriseDefault) Code() int {
 }
 
 func (o *CreateEnterpriseDefault) Error() string {
-	return fmt.Sprintf("[POST /enterprises][%d] CreateEnterprise default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /enterprises][%d] CreateEnterprise default %s", o._statusCode, payload)
 }
 
 func (o *CreateEnterpriseDefault) String() string {
-	return fmt.Sprintf("[POST /enterprises][%d] CreateEnterprise default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /enterprises][%d] CreateEnterprise default %s", o._statusCode, payload)
 }
 
 func (o *CreateEnterpriseDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/delete_enterprise_pool_responses.go
+++ b/client/enterprises/delete_enterprise_pool_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteEnterprisePoolDefault) Code() int {
 }
 
 func (o *DeleteEnterprisePoolDefault) Error() string {
-	return fmt.Sprintf("[DELETE /enterprises/{enterpriseID}/pools/{poolID}][%d] DeleteEnterprisePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /enterprises/{enterpriseID}/pools/{poolID}][%d] DeleteEnterprisePool default %s", o._statusCode, payload)
 }
 
 func (o *DeleteEnterprisePoolDefault) String() string {
-	return fmt.Sprintf("[DELETE /enterprises/{enterpriseID}/pools/{poolID}][%d] DeleteEnterprisePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /enterprises/{enterpriseID}/pools/{poolID}][%d] DeleteEnterprisePool default %s", o._statusCode, payload)
 }
 
 func (o *DeleteEnterprisePoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/delete_enterprise_responses.go
+++ b/client/enterprises/delete_enterprise_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteEnterpriseDefault) Code() int {
 }
 
 func (o *DeleteEnterpriseDefault) Error() string {
-	return fmt.Sprintf("[DELETE /enterprises/{enterpriseID}][%d] DeleteEnterprise default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /enterprises/{enterpriseID}][%d] DeleteEnterprise default %s", o._statusCode, payload)
 }
 
 func (o *DeleteEnterpriseDefault) String() string {
-	return fmt.Sprintf("[DELETE /enterprises/{enterpriseID}][%d] DeleteEnterprise default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /enterprises/{enterpriseID}][%d] DeleteEnterprise default %s", o._statusCode, payload)
 }
 
 func (o *DeleteEnterpriseDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/enterprises_client.go
+++ b/client/enterprises/enterprises_client.go
@@ -7,12 +7,38 @@ package enterprises
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new enterprises API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new enterprises API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new enterprises API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/enterprises/get_enterprise_pool_responses.go
+++ b/client/enterprises/get_enterprise_pool_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetEnterprisePoolOK) Code() int {
 }
 
 func (o *GetEnterprisePoolOK) Error() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools/{poolID}][%d] getEnterprisePoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools/{poolID}][%d] getEnterprisePoolOK %s", 200, payload)
 }
 
 func (o *GetEnterprisePoolOK) String() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools/{poolID}][%d] getEnterprisePoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools/{poolID}][%d] getEnterprisePoolOK %s", 200, payload)
 }
 
 func (o *GetEnterprisePoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *GetEnterprisePoolDefault) Code() int {
 }
 
 func (o *GetEnterprisePoolDefault) Error() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools/{poolID}][%d] GetEnterprisePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools/{poolID}][%d] GetEnterprisePool default %s", o._statusCode, payload)
 }
 
 func (o *GetEnterprisePoolDefault) String() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools/{poolID}][%d] GetEnterprisePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools/{poolID}][%d] GetEnterprisePool default %s", o._statusCode, payload)
 }
 
 func (o *GetEnterprisePoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/get_enterprise_responses.go
+++ b/client/enterprises/get_enterprise_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetEnterpriseOK) Code() int {
 }
 
 func (o *GetEnterpriseOK) Error() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}][%d] getEnterpriseOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}][%d] getEnterpriseOK %s", 200, payload)
 }
 
 func (o *GetEnterpriseOK) String() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}][%d] getEnterpriseOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}][%d] getEnterpriseOK %s", 200, payload)
 }
 
 func (o *GetEnterpriseOK) GetPayload() garm_params.Enterprise {
@@ -157,11 +160,13 @@ func (o *GetEnterpriseDefault) Code() int {
 }
 
 func (o *GetEnterpriseDefault) Error() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}][%d] GetEnterprise default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}][%d] GetEnterprise default %s", o._statusCode, payload)
 }
 
 func (o *GetEnterpriseDefault) String() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}][%d] GetEnterprise default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}][%d] GetEnterprise default %s", o._statusCode, payload)
 }
 
 func (o *GetEnterpriseDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/list_enterprise_instances_responses.go
+++ b/client/enterprises/list_enterprise_instances_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListEnterpriseInstancesOK) Code() int {
 }
 
 func (o *ListEnterpriseInstancesOK) Error() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/instances][%d] listEnterpriseInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/instances][%d] listEnterpriseInstancesOK %s", 200, payload)
 }
 
 func (o *ListEnterpriseInstancesOK) String() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/instances][%d] listEnterpriseInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/instances][%d] listEnterpriseInstancesOK %s", 200, payload)
 }
 
 func (o *ListEnterpriseInstancesOK) GetPayload() garm_params.Instances {
@@ -157,11 +160,13 @@ func (o *ListEnterpriseInstancesDefault) Code() int {
 }
 
 func (o *ListEnterpriseInstancesDefault) Error() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/instances][%d] ListEnterpriseInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/instances][%d] ListEnterpriseInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListEnterpriseInstancesDefault) String() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/instances][%d] ListEnterpriseInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/instances][%d] ListEnterpriseInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListEnterpriseInstancesDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/list_enterprise_pools_responses.go
+++ b/client/enterprises/list_enterprise_pools_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListEnterprisePoolsOK) Code() int {
 }
 
 func (o *ListEnterprisePoolsOK) Error() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools][%d] listEnterprisePoolsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools][%d] listEnterprisePoolsOK %s", 200, payload)
 }
 
 func (o *ListEnterprisePoolsOK) String() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools][%d] listEnterprisePoolsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools][%d] listEnterprisePoolsOK %s", 200, payload)
 }
 
 func (o *ListEnterprisePoolsOK) GetPayload() garm_params.Pools {
@@ -157,11 +160,13 @@ func (o *ListEnterprisePoolsDefault) Code() int {
 }
 
 func (o *ListEnterprisePoolsDefault) Error() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools][%d] ListEnterprisePools default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools][%d] ListEnterprisePools default %s", o._statusCode, payload)
 }
 
 func (o *ListEnterprisePoolsDefault) String() string {
-	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools][%d] ListEnterprisePools default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises/{enterpriseID}/pools][%d] ListEnterprisePools default %s", o._statusCode, payload)
 }
 
 func (o *ListEnterprisePoolsDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/list_enterprises_responses.go
+++ b/client/enterprises/list_enterprises_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListEnterprisesOK) Code() int {
 }
 
 func (o *ListEnterprisesOK) Error() string {
-	return fmt.Sprintf("[GET /enterprises][%d] listEnterprisesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises][%d] listEnterprisesOK %s", 200, payload)
 }
 
 func (o *ListEnterprisesOK) String() string {
-	return fmt.Sprintf("[GET /enterprises][%d] listEnterprisesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises][%d] listEnterprisesOK %s", 200, payload)
 }
 
 func (o *ListEnterprisesOK) GetPayload() garm_params.Enterprises {
@@ -157,11 +160,13 @@ func (o *ListEnterprisesDefault) Code() int {
 }
 
 func (o *ListEnterprisesDefault) Error() string {
-	return fmt.Sprintf("[GET /enterprises][%d] ListEnterprises default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises][%d] ListEnterprises default %s", o._statusCode, payload)
 }
 
 func (o *ListEnterprisesDefault) String() string {
-	return fmt.Sprintf("[GET /enterprises][%d] ListEnterprises default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /enterprises][%d] ListEnterprises default %s", o._statusCode, payload)
 }
 
 func (o *ListEnterprisesDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/update_enterprise_pool_responses.go
+++ b/client/enterprises/update_enterprise_pool_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *UpdateEnterprisePoolOK) Code() int {
 }
 
 func (o *UpdateEnterprisePoolOK) Error() string {
-	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}/pools/{poolID}][%d] updateEnterprisePoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}/pools/{poolID}][%d] updateEnterprisePoolOK %s", 200, payload)
 }
 
 func (o *UpdateEnterprisePoolOK) String() string {
-	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}/pools/{poolID}][%d] updateEnterprisePoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}/pools/{poolID}][%d] updateEnterprisePoolOK %s", 200, payload)
 }
 
 func (o *UpdateEnterprisePoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *UpdateEnterprisePoolDefault) Code() int {
 }
 
 func (o *UpdateEnterprisePoolDefault) Error() string {
-	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}/pools/{poolID}][%d] UpdateEnterprisePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}/pools/{poolID}][%d] UpdateEnterprisePool default %s", o._statusCode, payload)
 }
 
 func (o *UpdateEnterprisePoolDefault) String() string {
-	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}/pools/{poolID}][%d] UpdateEnterprisePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}/pools/{poolID}][%d] UpdateEnterprisePool default %s", o._statusCode, payload)
 }
 
 func (o *UpdateEnterprisePoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/enterprises/update_enterprise_responses.go
+++ b/client/enterprises/update_enterprise_responses.go
@@ -6,6 +6,7 @@ package enterprises
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *UpdateEnterpriseOK) Code() int {
 }
 
 func (o *UpdateEnterpriseOK) Error() string {
-	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}][%d] updateEnterpriseOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}][%d] updateEnterpriseOK %s", 200, payload)
 }
 
 func (o *UpdateEnterpriseOK) String() string {
-	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}][%d] updateEnterpriseOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}][%d] updateEnterpriseOK %s", 200, payload)
 }
 
 func (o *UpdateEnterpriseOK) GetPayload() garm_params.Enterprise {
@@ -157,11 +160,13 @@ func (o *UpdateEnterpriseDefault) Code() int {
 }
 
 func (o *UpdateEnterpriseDefault) Error() string {
-	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}][%d] UpdateEnterprise default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}][%d] UpdateEnterprise default %s", o._statusCode, payload)
 }
 
 func (o *UpdateEnterpriseDefault) String() string {
-	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}][%d] UpdateEnterprise default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /enterprises/{enterpriseID}][%d] UpdateEnterprise default %s", o._statusCode, payload)
 }
 
 func (o *UpdateEnterpriseDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/first_run/first_run_client.go
+++ b/client/first_run/first_run_client.go
@@ -9,12 +9,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new first run API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new first run API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new first run API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -25,7 +51,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/first_run/first_run_responses.go
+++ b/client/first_run/first_run_responses.go
@@ -6,6 +6,7 @@ package first_run
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *FirstRunOK) Code() int {
 }
 
 func (o *FirstRunOK) Error() string {
-	return fmt.Sprintf("[POST /first-run][%d] firstRunOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /first-run][%d] firstRunOK %s", 200, payload)
 }
 
 func (o *FirstRunOK) String() string {
-	return fmt.Sprintf("[POST /first-run][%d] firstRunOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /first-run][%d] firstRunOK %s", 200, payload)
 }
 
 func (o *FirstRunOK) GetPayload() garm_params.User {
@@ -152,11 +155,13 @@ func (o *FirstRunBadRequest) Code() int {
 }
 
 func (o *FirstRunBadRequest) Error() string {
-	return fmt.Sprintf("[POST /first-run][%d] firstRunBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /first-run][%d] firstRunBadRequest %s", 400, payload)
 }
 
 func (o *FirstRunBadRequest) String() string {
-	return fmt.Sprintf("[POST /first-run][%d] firstRunBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /first-run][%d] firstRunBadRequest %s", 400, payload)
 }
 
 func (o *FirstRunBadRequest) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/instances/delete_instance_responses.go
+++ b/client/instances/delete_instance_responses.go
@@ -6,6 +6,7 @@ package instances
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteInstanceDefault) Code() int {
 }
 
 func (o *DeleteInstanceDefault) Error() string {
-	return fmt.Sprintf("[DELETE /instances/{instanceName}][%d] DeleteInstance default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /instances/{instanceName}][%d] DeleteInstance default %s", o._statusCode, payload)
 }
 
 func (o *DeleteInstanceDefault) String() string {
-	return fmt.Sprintf("[DELETE /instances/{instanceName}][%d] DeleteInstance default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /instances/{instanceName}][%d] DeleteInstance default %s", o._statusCode, payload)
 }
 
 func (o *DeleteInstanceDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/instances/get_instance_responses.go
+++ b/client/instances/get_instance_responses.go
@@ -6,6 +6,7 @@ package instances
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetInstanceOK) Code() int {
 }
 
 func (o *GetInstanceOK) Error() string {
-	return fmt.Sprintf("[GET /instances/{instanceName}][%d] getInstanceOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /instances/{instanceName}][%d] getInstanceOK %s", 200, payload)
 }
 
 func (o *GetInstanceOK) String() string {
-	return fmt.Sprintf("[GET /instances/{instanceName}][%d] getInstanceOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /instances/{instanceName}][%d] getInstanceOK %s", 200, payload)
 }
 
 func (o *GetInstanceOK) GetPayload() garm_params.Instance {
@@ -157,11 +160,13 @@ func (o *GetInstanceDefault) Code() int {
 }
 
 func (o *GetInstanceDefault) Error() string {
-	return fmt.Sprintf("[GET /instances/{instanceName}][%d] GetInstance default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /instances/{instanceName}][%d] GetInstance default %s", o._statusCode, payload)
 }
 
 func (o *GetInstanceDefault) String() string {
-	return fmt.Sprintf("[GET /instances/{instanceName}][%d] GetInstance default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /instances/{instanceName}][%d] GetInstance default %s", o._statusCode, payload)
 }
 
 func (o *GetInstanceDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/instances/instances_client.go
+++ b/client/instances/instances_client.go
@@ -7,12 +7,38 @@ package instances
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new instances API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new instances API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new instances API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/instances/list_instances_responses.go
+++ b/client/instances/list_instances_responses.go
@@ -6,6 +6,7 @@ package instances
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListInstancesOK) Code() int {
 }
 
 func (o *ListInstancesOK) Error() string {
-	return fmt.Sprintf("[GET /instances][%d] listInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /instances][%d] listInstancesOK %s", 200, payload)
 }
 
 func (o *ListInstancesOK) String() string {
-	return fmt.Sprintf("[GET /instances][%d] listInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /instances][%d] listInstancesOK %s", 200, payload)
 }
 
 func (o *ListInstancesOK) GetPayload() garm_params.Instances {
@@ -157,11 +160,13 @@ func (o *ListInstancesDefault) Code() int {
 }
 
 func (o *ListInstancesDefault) Error() string {
-	return fmt.Sprintf("[GET /instances][%d] ListInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /instances][%d] ListInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListInstancesDefault) String() string {
-	return fmt.Sprintf("[GET /instances][%d] ListInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /instances][%d] ListInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListInstancesDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/instances/list_pool_instances_responses.go
+++ b/client/instances/list_pool_instances_responses.go
@@ -6,6 +6,7 @@ package instances
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListPoolInstancesOK) Code() int {
 }
 
 func (o *ListPoolInstancesOK) Error() string {
-	return fmt.Sprintf("[GET /pools/{poolID}/instances][%d] listPoolInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools/{poolID}/instances][%d] listPoolInstancesOK %s", 200, payload)
 }
 
 func (o *ListPoolInstancesOK) String() string {
-	return fmt.Sprintf("[GET /pools/{poolID}/instances][%d] listPoolInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools/{poolID}/instances][%d] listPoolInstancesOK %s", 200, payload)
 }
 
 func (o *ListPoolInstancesOK) GetPayload() garm_params.Instances {
@@ -157,11 +160,13 @@ func (o *ListPoolInstancesDefault) Code() int {
 }
 
 func (o *ListPoolInstancesDefault) Error() string {
-	return fmt.Sprintf("[GET /pools/{poolID}/instances][%d] ListPoolInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools/{poolID}/instances][%d] ListPoolInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListPoolInstancesDefault) String() string {
-	return fmt.Sprintf("[GET /pools/{poolID}/instances][%d] ListPoolInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools/{poolID}/instances][%d] ListPoolInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListPoolInstancesDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/jobs/jobs_client.go
+++ b/client/jobs/jobs_client.go
@@ -9,12 +9,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new jobs API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new jobs API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new jobs API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -25,7 +51,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/jobs/list_jobs_responses.go
+++ b/client/jobs/list_jobs_responses.go
@@ -6,6 +6,7 @@ package jobs
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ListJobsOK) Code() int {
 }
 
 func (o *ListJobsOK) Error() string {
-	return fmt.Sprintf("[GET /jobs][%d] listJobsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /jobs][%d] listJobsOK %s", 200, payload)
 }
 
 func (o *ListJobsOK) String() string {
-	return fmt.Sprintf("[GET /jobs][%d] listJobsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /jobs][%d] listJobsOK %s", 200, payload)
 }
 
 func (o *ListJobsOK) GetPayload() garm_params.Jobs {
@@ -152,11 +155,13 @@ func (o *ListJobsBadRequest) Code() int {
 }
 
 func (o *ListJobsBadRequest) Error() string {
-	return fmt.Sprintf("[GET /jobs][%d] listJobsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /jobs][%d] listJobsBadRequest %s", 400, payload)
 }
 
 func (o *ListJobsBadRequest) String() string {
-	return fmt.Sprintf("[GET /jobs][%d] listJobsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /jobs][%d] listJobsBadRequest %s", 400, payload)
 }
 
 func (o *ListJobsBadRequest) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/login/login_client.go
+++ b/client/login/login_client.go
@@ -9,12 +9,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new login API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new login API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new login API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -25,7 +51,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/login/login_responses.go
+++ b/client/login/login_responses.go
@@ -6,6 +6,7 @@ package login
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *LoginOK) Code() int {
 }
 
 func (o *LoginOK) Error() string {
-	return fmt.Sprintf("[POST /auth/login][%d] loginOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /auth/login][%d] loginOK %s", 200, payload)
 }
 
 func (o *LoginOK) String() string {
-	return fmt.Sprintf("[POST /auth/login][%d] loginOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /auth/login][%d] loginOK %s", 200, payload)
 }
 
 func (o *LoginOK) GetPayload() garm_params.JWTResponse {
@@ -152,11 +155,13 @@ func (o *LoginBadRequest) Code() int {
 }
 
 func (o *LoginBadRequest) Error() string {
-	return fmt.Sprintf("[POST /auth/login][%d] loginBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /auth/login][%d] loginBadRequest %s", 400, payload)
 }
 
 func (o *LoginBadRequest) String() string {
-	return fmt.Sprintf("[POST /auth/login][%d] loginBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /auth/login][%d] loginBadRequest %s", 400, payload)
 }
 
 func (o *LoginBadRequest) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/metrics_token/get_metrics_token_responses.go
+++ b/client/metrics_token/get_metrics_token_responses.go
@@ -6,6 +6,7 @@ package metrics_token
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *GetMetricsTokenOK) Code() int {
 }
 
 func (o *GetMetricsTokenOK) Error() string {
-	return fmt.Sprintf("[GET /metrics-token][%d] getMetricsTokenOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /metrics-token][%d] getMetricsTokenOK %s", 200, payload)
 }
 
 func (o *GetMetricsTokenOK) String() string {
-	return fmt.Sprintf("[GET /metrics-token][%d] getMetricsTokenOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /metrics-token][%d] getMetricsTokenOK %s", 200, payload)
 }
 
 func (o *GetMetricsTokenOK) GetPayload() garm_params.JWTResponse {
@@ -152,11 +155,13 @@ func (o *GetMetricsTokenUnauthorized) Code() int {
 }
 
 func (o *GetMetricsTokenUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /metrics-token][%d] getMetricsTokenUnauthorized  %+v", 401, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /metrics-token][%d] getMetricsTokenUnauthorized %s", 401, payload)
 }
 
 func (o *GetMetricsTokenUnauthorized) String() string {
-	return fmt.Sprintf("[GET /metrics-token][%d] getMetricsTokenUnauthorized  %+v", 401, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /metrics-token][%d] getMetricsTokenUnauthorized %s", 401, payload)
 }
 
 func (o *GetMetricsTokenUnauthorized) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/metrics_token/metrics_token_client.go
+++ b/client/metrics_token/metrics_token_client.go
@@ -9,12 +9,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new metrics token API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new metrics token API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new metrics token API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -25,7 +51,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/organizations/create_org_pool_responses.go
+++ b/client/organizations/create_org_pool_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *CreateOrgPoolOK) Code() int {
 }
 
 func (o *CreateOrgPoolOK) Error() string {
-	return fmt.Sprintf("[POST /organizations/{orgID}/pools][%d] createOrgPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations/{orgID}/pools][%d] createOrgPoolOK %s", 200, payload)
 }
 
 func (o *CreateOrgPoolOK) String() string {
-	return fmt.Sprintf("[POST /organizations/{orgID}/pools][%d] createOrgPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations/{orgID}/pools][%d] createOrgPoolOK %s", 200, payload)
 }
 
 func (o *CreateOrgPoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *CreateOrgPoolDefault) Code() int {
 }
 
 func (o *CreateOrgPoolDefault) Error() string {
-	return fmt.Sprintf("[POST /organizations/{orgID}/pools][%d] CreateOrgPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations/{orgID}/pools][%d] CreateOrgPool default %s", o._statusCode, payload)
 }
 
 func (o *CreateOrgPoolDefault) String() string {
-	return fmt.Sprintf("[POST /organizations/{orgID}/pools][%d] CreateOrgPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations/{orgID}/pools][%d] CreateOrgPool default %s", o._statusCode, payload)
 }
 
 func (o *CreateOrgPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/create_org_responses.go
+++ b/client/organizations/create_org_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *CreateOrgOK) Code() int {
 }
 
 func (o *CreateOrgOK) Error() string {
-	return fmt.Sprintf("[POST /organizations][%d] createOrgOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations][%d] createOrgOK %s", 200, payload)
 }
 
 func (o *CreateOrgOK) String() string {
-	return fmt.Sprintf("[POST /organizations][%d] createOrgOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations][%d] createOrgOK %s", 200, payload)
 }
 
 func (o *CreateOrgOK) GetPayload() garm_params.Organization {
@@ -157,11 +160,13 @@ func (o *CreateOrgDefault) Code() int {
 }
 
 func (o *CreateOrgDefault) Error() string {
-	return fmt.Sprintf("[POST /organizations][%d] CreateOrg default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations][%d] CreateOrg default %s", o._statusCode, payload)
 }
 
 func (o *CreateOrgDefault) String() string {
-	return fmt.Sprintf("[POST /organizations][%d] CreateOrg default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations][%d] CreateOrg default %s", o._statusCode, payload)
 }
 
 func (o *CreateOrgDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/delete_org_pool_responses.go
+++ b/client/organizations/delete_org_pool_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteOrgPoolDefault) Code() int {
 }
 
 func (o *DeleteOrgPoolDefault) Error() string {
-	return fmt.Sprintf("[DELETE /organizations/{orgID}/pools/{poolID}][%d] DeleteOrgPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /organizations/{orgID}/pools/{poolID}][%d] DeleteOrgPool default %s", o._statusCode, payload)
 }
 
 func (o *DeleteOrgPoolDefault) String() string {
-	return fmt.Sprintf("[DELETE /organizations/{orgID}/pools/{poolID}][%d] DeleteOrgPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /organizations/{orgID}/pools/{poolID}][%d] DeleteOrgPool default %s", o._statusCode, payload)
 }
 
 func (o *DeleteOrgPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/delete_org_responses.go
+++ b/client/organizations/delete_org_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteOrgDefault) Code() int {
 }
 
 func (o *DeleteOrgDefault) Error() string {
-	return fmt.Sprintf("[DELETE /organizations/{orgID}][%d] DeleteOrg default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /organizations/{orgID}][%d] DeleteOrg default %s", o._statusCode, payload)
 }
 
 func (o *DeleteOrgDefault) String() string {
-	return fmt.Sprintf("[DELETE /organizations/{orgID}][%d] DeleteOrg default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /organizations/{orgID}][%d] DeleteOrg default %s", o._statusCode, payload)
 }
 
 func (o *DeleteOrgDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/get_org_pool_responses.go
+++ b/client/organizations/get_org_pool_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetOrgPoolOK) Code() int {
 }
 
 func (o *GetOrgPoolOK) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/pools/{poolID}][%d] getOrgPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/pools/{poolID}][%d] getOrgPoolOK %s", 200, payload)
 }
 
 func (o *GetOrgPoolOK) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/pools/{poolID}][%d] getOrgPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/pools/{poolID}][%d] getOrgPoolOK %s", 200, payload)
 }
 
 func (o *GetOrgPoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *GetOrgPoolDefault) Code() int {
 }
 
 func (o *GetOrgPoolDefault) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/pools/{poolID}][%d] GetOrgPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/pools/{poolID}][%d] GetOrgPool default %s", o._statusCode, payload)
 }
 
 func (o *GetOrgPoolDefault) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/pools/{poolID}][%d] GetOrgPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/pools/{poolID}][%d] GetOrgPool default %s", o._statusCode, payload)
 }
 
 func (o *GetOrgPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/get_org_responses.go
+++ b/client/organizations/get_org_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetOrgOK) Code() int {
 }
 
 func (o *GetOrgOK) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}][%d] getOrgOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}][%d] getOrgOK %s", 200, payload)
 }
 
 func (o *GetOrgOK) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}][%d] getOrgOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}][%d] getOrgOK %s", 200, payload)
 }
 
 func (o *GetOrgOK) GetPayload() garm_params.Organization {
@@ -157,11 +160,13 @@ func (o *GetOrgDefault) Code() int {
 }
 
 func (o *GetOrgDefault) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}][%d] GetOrg default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}][%d] GetOrg default %s", o._statusCode, payload)
 }
 
 func (o *GetOrgDefault) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}][%d] GetOrg default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}][%d] GetOrg default %s", o._statusCode, payload)
 }
 
 func (o *GetOrgDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/get_org_webhook_info_responses.go
+++ b/client/organizations/get_org_webhook_info_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetOrgWebhookInfoOK) Code() int {
 }
 
 func (o *GetOrgWebhookInfoOK) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/webhook][%d] getOrgWebhookInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/webhook][%d] getOrgWebhookInfoOK %s", 200, payload)
 }
 
 func (o *GetOrgWebhookInfoOK) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/webhook][%d] getOrgWebhookInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/webhook][%d] getOrgWebhookInfoOK %s", 200, payload)
 }
 
 func (o *GetOrgWebhookInfoOK) GetPayload() garm_params.HookInfo {
@@ -157,11 +160,13 @@ func (o *GetOrgWebhookInfoDefault) Code() int {
 }
 
 func (o *GetOrgWebhookInfoDefault) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/webhook][%d] GetOrgWebhookInfo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/webhook][%d] GetOrgWebhookInfo default %s", o._statusCode, payload)
 }
 
 func (o *GetOrgWebhookInfoDefault) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/webhook][%d] GetOrgWebhookInfo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/webhook][%d] GetOrgWebhookInfo default %s", o._statusCode, payload)
 }
 
 func (o *GetOrgWebhookInfoDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/install_org_webhook_responses.go
+++ b/client/organizations/install_org_webhook_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *InstallOrgWebhookOK) Code() int {
 }
 
 func (o *InstallOrgWebhookOK) Error() string {
-	return fmt.Sprintf("[POST /organizations/{orgID}/webhook][%d] installOrgWebhookOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations/{orgID}/webhook][%d] installOrgWebhookOK %s", 200, payload)
 }
 
 func (o *InstallOrgWebhookOK) String() string {
-	return fmt.Sprintf("[POST /organizations/{orgID}/webhook][%d] installOrgWebhookOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations/{orgID}/webhook][%d] installOrgWebhookOK %s", 200, payload)
 }
 
 func (o *InstallOrgWebhookOK) GetPayload() garm_params.HookInfo {
@@ -157,11 +160,13 @@ func (o *InstallOrgWebhookDefault) Code() int {
 }
 
 func (o *InstallOrgWebhookDefault) Error() string {
-	return fmt.Sprintf("[POST /organizations/{orgID}/webhook][%d] InstallOrgWebhook default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations/{orgID}/webhook][%d] InstallOrgWebhook default %s", o._statusCode, payload)
 }
 
 func (o *InstallOrgWebhookDefault) String() string {
-	return fmt.Sprintf("[POST /organizations/{orgID}/webhook][%d] InstallOrgWebhook default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /organizations/{orgID}/webhook][%d] InstallOrgWebhook default %s", o._statusCode, payload)
 }
 
 func (o *InstallOrgWebhookDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/list_org_instances_responses.go
+++ b/client/organizations/list_org_instances_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListOrgInstancesOK) Code() int {
 }
 
 func (o *ListOrgInstancesOK) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/instances][%d] listOrgInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/instances][%d] listOrgInstancesOK %s", 200, payload)
 }
 
 func (o *ListOrgInstancesOK) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/instances][%d] listOrgInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/instances][%d] listOrgInstancesOK %s", 200, payload)
 }
 
 func (o *ListOrgInstancesOK) GetPayload() garm_params.Instances {
@@ -157,11 +160,13 @@ func (o *ListOrgInstancesDefault) Code() int {
 }
 
 func (o *ListOrgInstancesDefault) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/instances][%d] ListOrgInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/instances][%d] ListOrgInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListOrgInstancesDefault) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/instances][%d] ListOrgInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/instances][%d] ListOrgInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListOrgInstancesDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/list_org_pools_responses.go
+++ b/client/organizations/list_org_pools_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListOrgPoolsOK) Code() int {
 }
 
 func (o *ListOrgPoolsOK) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/pools][%d] listOrgPoolsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/pools][%d] listOrgPoolsOK %s", 200, payload)
 }
 
 func (o *ListOrgPoolsOK) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/pools][%d] listOrgPoolsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/pools][%d] listOrgPoolsOK %s", 200, payload)
 }
 
 func (o *ListOrgPoolsOK) GetPayload() garm_params.Pools {
@@ -157,11 +160,13 @@ func (o *ListOrgPoolsDefault) Code() int {
 }
 
 func (o *ListOrgPoolsDefault) Error() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/pools][%d] ListOrgPools default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/pools][%d] ListOrgPools default %s", o._statusCode, payload)
 }
 
 func (o *ListOrgPoolsDefault) String() string {
-	return fmt.Sprintf("[GET /organizations/{orgID}/pools][%d] ListOrgPools default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations/{orgID}/pools][%d] ListOrgPools default %s", o._statusCode, payload)
 }
 
 func (o *ListOrgPoolsDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/list_orgs_responses.go
+++ b/client/organizations/list_orgs_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListOrgsOK) Code() int {
 }
 
 func (o *ListOrgsOK) Error() string {
-	return fmt.Sprintf("[GET /organizations][%d] listOrgsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations][%d] listOrgsOK %s", 200, payload)
 }
 
 func (o *ListOrgsOK) String() string {
-	return fmt.Sprintf("[GET /organizations][%d] listOrgsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations][%d] listOrgsOK %s", 200, payload)
 }
 
 func (o *ListOrgsOK) GetPayload() garm_params.Organizations {
@@ -157,11 +160,13 @@ func (o *ListOrgsDefault) Code() int {
 }
 
 func (o *ListOrgsDefault) Error() string {
-	return fmt.Sprintf("[GET /organizations][%d] ListOrgs default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations][%d] ListOrgs default %s", o._statusCode, payload)
 }
 
 func (o *ListOrgsDefault) String() string {
-	return fmt.Sprintf("[GET /organizations][%d] ListOrgs default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /organizations][%d] ListOrgs default %s", o._statusCode, payload)
 }
 
 func (o *ListOrgsDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/organizations_client.go
+++ b/client/organizations/organizations_client.go
@@ -7,12 +7,38 @@ package organizations
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new organizations API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new organizations API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new organizations API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/organizations/uninstall_org_webhook_responses.go
+++ b/client/organizations/uninstall_org_webhook_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *UninstallOrgWebhookDefault) Code() int {
 }
 
 func (o *UninstallOrgWebhookDefault) Error() string {
-	return fmt.Sprintf("[DELETE /organizations/{orgID}/webhook][%d] UninstallOrgWebhook default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /organizations/{orgID}/webhook][%d] UninstallOrgWebhook default %s", o._statusCode, payload)
 }
 
 func (o *UninstallOrgWebhookDefault) String() string {
-	return fmt.Sprintf("[DELETE /organizations/{orgID}/webhook][%d] UninstallOrgWebhook default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /organizations/{orgID}/webhook][%d] UninstallOrgWebhook default %s", o._statusCode, payload)
 }
 
 func (o *UninstallOrgWebhookDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/update_org_pool_responses.go
+++ b/client/organizations/update_org_pool_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *UpdateOrgPoolOK) Code() int {
 }
 
 func (o *UpdateOrgPoolOK) Error() string {
-	return fmt.Sprintf("[PUT /organizations/{orgID}/pools/{poolID}][%d] updateOrgPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /organizations/{orgID}/pools/{poolID}][%d] updateOrgPoolOK %s", 200, payload)
 }
 
 func (o *UpdateOrgPoolOK) String() string {
-	return fmt.Sprintf("[PUT /organizations/{orgID}/pools/{poolID}][%d] updateOrgPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /organizations/{orgID}/pools/{poolID}][%d] updateOrgPoolOK %s", 200, payload)
 }
 
 func (o *UpdateOrgPoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *UpdateOrgPoolDefault) Code() int {
 }
 
 func (o *UpdateOrgPoolDefault) Error() string {
-	return fmt.Sprintf("[PUT /organizations/{orgID}/pools/{poolID}][%d] UpdateOrgPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /organizations/{orgID}/pools/{poolID}][%d] UpdateOrgPool default %s", o._statusCode, payload)
 }
 
 func (o *UpdateOrgPoolDefault) String() string {
-	return fmt.Sprintf("[PUT /organizations/{orgID}/pools/{poolID}][%d] UpdateOrgPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /organizations/{orgID}/pools/{poolID}][%d] UpdateOrgPool default %s", o._statusCode, payload)
 }
 
 func (o *UpdateOrgPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/organizations/update_org_responses.go
+++ b/client/organizations/update_org_responses.go
@@ -6,6 +6,7 @@ package organizations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *UpdateOrgOK) Code() int {
 }
 
 func (o *UpdateOrgOK) Error() string {
-	return fmt.Sprintf("[PUT /organizations/{orgID}][%d] updateOrgOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /organizations/{orgID}][%d] updateOrgOK %s", 200, payload)
 }
 
 func (o *UpdateOrgOK) String() string {
-	return fmt.Sprintf("[PUT /organizations/{orgID}][%d] updateOrgOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /organizations/{orgID}][%d] updateOrgOK %s", 200, payload)
 }
 
 func (o *UpdateOrgOK) GetPayload() garm_params.Organization {
@@ -157,11 +160,13 @@ func (o *UpdateOrgDefault) Code() int {
 }
 
 func (o *UpdateOrgDefault) Error() string {
-	return fmt.Sprintf("[PUT /organizations/{orgID}][%d] UpdateOrg default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /organizations/{orgID}][%d] UpdateOrg default %s", o._statusCode, payload)
 }
 
 func (o *UpdateOrgDefault) String() string {
-	return fmt.Sprintf("[PUT /organizations/{orgID}][%d] UpdateOrg default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /organizations/{orgID}][%d] UpdateOrg default %s", o._statusCode, payload)
 }
 
 func (o *UpdateOrgDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/pools/delete_pool_responses.go
+++ b/client/pools/delete_pool_responses.go
@@ -6,6 +6,7 @@ package pools
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeletePoolDefault) Code() int {
 }
 
 func (o *DeletePoolDefault) Error() string {
-	return fmt.Sprintf("[DELETE /pools/{poolID}][%d] DeletePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /pools/{poolID}][%d] DeletePool default %s", o._statusCode, payload)
 }
 
 func (o *DeletePoolDefault) String() string {
-	return fmt.Sprintf("[DELETE /pools/{poolID}][%d] DeletePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /pools/{poolID}][%d] DeletePool default %s", o._statusCode, payload)
 }
 
 func (o *DeletePoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/pools/get_pool_responses.go
+++ b/client/pools/get_pool_responses.go
@@ -6,6 +6,7 @@ package pools
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetPoolOK) Code() int {
 }
 
 func (o *GetPoolOK) Error() string {
-	return fmt.Sprintf("[GET /pools/{poolID}][%d] getPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools/{poolID}][%d] getPoolOK %s", 200, payload)
 }
 
 func (o *GetPoolOK) String() string {
-	return fmt.Sprintf("[GET /pools/{poolID}][%d] getPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools/{poolID}][%d] getPoolOK %s", 200, payload)
 }
 
 func (o *GetPoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *GetPoolDefault) Code() int {
 }
 
 func (o *GetPoolDefault) Error() string {
-	return fmt.Sprintf("[GET /pools/{poolID}][%d] GetPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools/{poolID}][%d] GetPool default %s", o._statusCode, payload)
 }
 
 func (o *GetPoolDefault) String() string {
-	return fmt.Sprintf("[GET /pools/{poolID}][%d] GetPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools/{poolID}][%d] GetPool default %s", o._statusCode, payload)
 }
 
 func (o *GetPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/pools/list_pools_responses.go
+++ b/client/pools/list_pools_responses.go
@@ -6,6 +6,7 @@ package pools
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListPoolsOK) Code() int {
 }
 
 func (o *ListPoolsOK) Error() string {
-	return fmt.Sprintf("[GET /pools][%d] listPoolsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools][%d] listPoolsOK %s", 200, payload)
 }
 
 func (o *ListPoolsOK) String() string {
-	return fmt.Sprintf("[GET /pools][%d] listPoolsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools][%d] listPoolsOK %s", 200, payload)
 }
 
 func (o *ListPoolsOK) GetPayload() garm_params.Pools {
@@ -157,11 +160,13 @@ func (o *ListPoolsDefault) Code() int {
 }
 
 func (o *ListPoolsDefault) Error() string {
-	return fmt.Sprintf("[GET /pools][%d] ListPools default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools][%d] ListPools default %s", o._statusCode, payload)
 }
 
 func (o *ListPoolsDefault) String() string {
-	return fmt.Sprintf("[GET /pools][%d] ListPools default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /pools][%d] ListPools default %s", o._statusCode, payload)
 }
 
 func (o *ListPoolsDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/pools/pools_client.go
+++ b/client/pools/pools_client.go
@@ -7,12 +7,38 @@ package pools
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new pools API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new pools API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new pools API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/pools/update_pool_responses.go
+++ b/client/pools/update_pool_responses.go
@@ -6,6 +6,7 @@ package pools
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *UpdatePoolOK) Code() int {
 }
 
 func (o *UpdatePoolOK) Error() string {
-	return fmt.Sprintf("[PUT /pools/{poolID}][%d] updatePoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /pools/{poolID}][%d] updatePoolOK %s", 200, payload)
 }
 
 func (o *UpdatePoolOK) String() string {
-	return fmt.Sprintf("[PUT /pools/{poolID}][%d] updatePoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /pools/{poolID}][%d] updatePoolOK %s", 200, payload)
 }
 
 func (o *UpdatePoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *UpdatePoolDefault) Code() int {
 }
 
 func (o *UpdatePoolDefault) Error() string {
-	return fmt.Sprintf("[PUT /pools/{poolID}][%d] UpdatePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /pools/{poolID}][%d] UpdatePool default %s", o._statusCode, payload)
 }
 
 func (o *UpdatePoolDefault) String() string {
-	return fmt.Sprintf("[PUT /pools/{poolID}][%d] UpdatePool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /pools/{poolID}][%d] UpdatePool default %s", o._statusCode, payload)
 }
 
 func (o *UpdatePoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/providers/list_providers_responses.go
+++ b/client/providers/list_providers_responses.go
@@ -6,6 +6,7 @@ package providers
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -86,11 +87,13 @@ func (o *ListProvidersOK) Code() int {
 }
 
 func (o *ListProvidersOK) Error() string {
-	return fmt.Sprintf("[GET /providers][%d] listProvidersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /providers][%d] listProvidersOK %s", 200, payload)
 }
 
 func (o *ListProvidersOK) String() string {
-	return fmt.Sprintf("[GET /providers][%d] listProvidersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /providers][%d] listProvidersOK %s", 200, payload)
 }
 
 func (o *ListProvidersOK) GetPayload() garm_params.Providers {
@@ -152,11 +155,13 @@ func (o *ListProvidersBadRequest) Code() int {
 }
 
 func (o *ListProvidersBadRequest) Error() string {
-	return fmt.Sprintf("[GET /providers][%d] listProvidersBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /providers][%d] listProvidersBadRequest %s", 400, payload)
 }
 
 func (o *ListProvidersBadRequest) String() string {
-	return fmt.Sprintf("[GET /providers][%d] listProvidersBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /providers][%d] listProvidersBadRequest %s", 400, payload)
 }
 
 func (o *ListProvidersBadRequest) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/providers/providers_client.go
+++ b/client/providers/providers_client.go
@@ -9,12 +9,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new providers API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new providers API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new providers API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -25,7 +51,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/repositories/create_repo_pool_responses.go
+++ b/client/repositories/create_repo_pool_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *CreateRepoPoolOK) Code() int {
 }
 
 func (o *CreateRepoPoolOK) Error() string {
-	return fmt.Sprintf("[POST /repositories/{repoID}/pools][%d] createRepoPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories/{repoID}/pools][%d] createRepoPoolOK %s", 200, payload)
 }
 
 func (o *CreateRepoPoolOK) String() string {
-	return fmt.Sprintf("[POST /repositories/{repoID}/pools][%d] createRepoPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories/{repoID}/pools][%d] createRepoPoolOK %s", 200, payload)
 }
 
 func (o *CreateRepoPoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *CreateRepoPoolDefault) Code() int {
 }
 
 func (o *CreateRepoPoolDefault) Error() string {
-	return fmt.Sprintf("[POST /repositories/{repoID}/pools][%d] CreateRepoPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories/{repoID}/pools][%d] CreateRepoPool default %s", o._statusCode, payload)
 }
 
 func (o *CreateRepoPoolDefault) String() string {
-	return fmt.Sprintf("[POST /repositories/{repoID}/pools][%d] CreateRepoPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories/{repoID}/pools][%d] CreateRepoPool default %s", o._statusCode, payload)
 }
 
 func (o *CreateRepoPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/create_repo_responses.go
+++ b/client/repositories/create_repo_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *CreateRepoOK) Code() int {
 }
 
 func (o *CreateRepoOK) Error() string {
-	return fmt.Sprintf("[POST /repositories][%d] createRepoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories][%d] createRepoOK %s", 200, payload)
 }
 
 func (o *CreateRepoOK) String() string {
-	return fmt.Sprintf("[POST /repositories][%d] createRepoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories][%d] createRepoOK %s", 200, payload)
 }
 
 func (o *CreateRepoOK) GetPayload() garm_params.Repository {
@@ -157,11 +160,13 @@ func (o *CreateRepoDefault) Code() int {
 }
 
 func (o *CreateRepoDefault) Error() string {
-	return fmt.Sprintf("[POST /repositories][%d] CreateRepo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories][%d] CreateRepo default %s", o._statusCode, payload)
 }
 
 func (o *CreateRepoDefault) String() string {
-	return fmt.Sprintf("[POST /repositories][%d] CreateRepo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories][%d] CreateRepo default %s", o._statusCode, payload)
 }
 
 func (o *CreateRepoDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/delete_repo_pool_responses.go
+++ b/client/repositories/delete_repo_pool_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteRepoPoolDefault) Code() int {
 }
 
 func (o *DeleteRepoPoolDefault) Error() string {
-	return fmt.Sprintf("[DELETE /repositories/{repoID}/pools/{poolID}][%d] DeleteRepoPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /repositories/{repoID}/pools/{poolID}][%d] DeleteRepoPool default %s", o._statusCode, payload)
 }
 
 func (o *DeleteRepoPoolDefault) String() string {
-	return fmt.Sprintf("[DELETE /repositories/{repoID}/pools/{poolID}][%d] DeleteRepoPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /repositories/{repoID}/pools/{poolID}][%d] DeleteRepoPool default %s", o._statusCode, payload)
 }
 
 func (o *DeleteRepoPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/delete_repo_responses.go
+++ b/client/repositories/delete_repo_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *DeleteRepoDefault) Code() int {
 }
 
 func (o *DeleteRepoDefault) Error() string {
-	return fmt.Sprintf("[DELETE /repositories/{repoID}][%d] DeleteRepo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /repositories/{repoID}][%d] DeleteRepo default %s", o._statusCode, payload)
 }
 
 func (o *DeleteRepoDefault) String() string {
-	return fmt.Sprintf("[DELETE /repositories/{repoID}][%d] DeleteRepo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /repositories/{repoID}][%d] DeleteRepo default %s", o._statusCode, payload)
 }
 
 func (o *DeleteRepoDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/get_repo_pool_responses.go
+++ b/client/repositories/get_repo_pool_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetRepoPoolOK) Code() int {
 }
 
 func (o *GetRepoPoolOK) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/pools/{poolID}][%d] getRepoPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/pools/{poolID}][%d] getRepoPoolOK %s", 200, payload)
 }
 
 func (o *GetRepoPoolOK) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/pools/{poolID}][%d] getRepoPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/pools/{poolID}][%d] getRepoPoolOK %s", 200, payload)
 }
 
 func (o *GetRepoPoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *GetRepoPoolDefault) Code() int {
 }
 
 func (o *GetRepoPoolDefault) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/pools/{poolID}][%d] GetRepoPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/pools/{poolID}][%d] GetRepoPool default %s", o._statusCode, payload)
 }
 
 func (o *GetRepoPoolDefault) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/pools/{poolID}][%d] GetRepoPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/pools/{poolID}][%d] GetRepoPool default %s", o._statusCode, payload)
 }
 
 func (o *GetRepoPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/get_repo_responses.go
+++ b/client/repositories/get_repo_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetRepoOK) Code() int {
 }
 
 func (o *GetRepoOK) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}][%d] getRepoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}][%d] getRepoOK %s", 200, payload)
 }
 
 func (o *GetRepoOK) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}][%d] getRepoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}][%d] getRepoOK %s", 200, payload)
 }
 
 func (o *GetRepoOK) GetPayload() garm_params.Repository {
@@ -157,11 +160,13 @@ func (o *GetRepoDefault) Code() int {
 }
 
 func (o *GetRepoDefault) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}][%d] GetRepo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}][%d] GetRepo default %s", o._statusCode, payload)
 }
 
 func (o *GetRepoDefault) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}][%d] GetRepo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}][%d] GetRepo default %s", o._statusCode, payload)
 }
 
 func (o *GetRepoDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/get_repo_webhook_info_responses.go
+++ b/client/repositories/get_repo_webhook_info_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *GetRepoWebhookInfoOK) Code() int {
 }
 
 func (o *GetRepoWebhookInfoOK) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/webhook][%d] getRepoWebhookInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/webhook][%d] getRepoWebhookInfoOK %s", 200, payload)
 }
 
 func (o *GetRepoWebhookInfoOK) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/webhook][%d] getRepoWebhookInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/webhook][%d] getRepoWebhookInfoOK %s", 200, payload)
 }
 
 func (o *GetRepoWebhookInfoOK) GetPayload() garm_params.HookInfo {
@@ -157,11 +160,13 @@ func (o *GetRepoWebhookInfoDefault) Code() int {
 }
 
 func (o *GetRepoWebhookInfoDefault) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/webhook][%d] GetRepoWebhookInfo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/webhook][%d] GetRepoWebhookInfo default %s", o._statusCode, payload)
 }
 
 func (o *GetRepoWebhookInfoDefault) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/webhook][%d] GetRepoWebhookInfo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/webhook][%d] GetRepoWebhookInfo default %s", o._statusCode, payload)
 }
 
 func (o *GetRepoWebhookInfoDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/install_repo_webhook_responses.go
+++ b/client/repositories/install_repo_webhook_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *InstallRepoWebhookOK) Code() int {
 }
 
 func (o *InstallRepoWebhookOK) Error() string {
-	return fmt.Sprintf("[POST /repositories/{repoID}/webhook][%d] installRepoWebhookOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories/{repoID}/webhook][%d] installRepoWebhookOK %s", 200, payload)
 }
 
 func (o *InstallRepoWebhookOK) String() string {
-	return fmt.Sprintf("[POST /repositories/{repoID}/webhook][%d] installRepoWebhookOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories/{repoID}/webhook][%d] installRepoWebhookOK %s", 200, payload)
 }
 
 func (o *InstallRepoWebhookOK) GetPayload() garm_params.HookInfo {
@@ -157,11 +160,13 @@ func (o *InstallRepoWebhookDefault) Code() int {
 }
 
 func (o *InstallRepoWebhookDefault) Error() string {
-	return fmt.Sprintf("[POST /repositories/{repoID}/webhook][%d] InstallRepoWebhook default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories/{repoID}/webhook][%d] InstallRepoWebhook default %s", o._statusCode, payload)
 }
 
 func (o *InstallRepoWebhookDefault) String() string {
-	return fmt.Sprintf("[POST /repositories/{repoID}/webhook][%d] InstallRepoWebhook default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /repositories/{repoID}/webhook][%d] InstallRepoWebhook default %s", o._statusCode, payload)
 }
 
 func (o *InstallRepoWebhookDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/list_repo_instances_responses.go
+++ b/client/repositories/list_repo_instances_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListRepoInstancesOK) Code() int {
 }
 
 func (o *ListRepoInstancesOK) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/instances][%d] listRepoInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/instances][%d] listRepoInstancesOK %s", 200, payload)
 }
 
 func (o *ListRepoInstancesOK) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/instances][%d] listRepoInstancesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/instances][%d] listRepoInstancesOK %s", 200, payload)
 }
 
 func (o *ListRepoInstancesOK) GetPayload() garm_params.Instances {
@@ -157,11 +160,13 @@ func (o *ListRepoInstancesDefault) Code() int {
 }
 
 func (o *ListRepoInstancesDefault) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/instances][%d] ListRepoInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/instances][%d] ListRepoInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListRepoInstancesDefault) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/instances][%d] ListRepoInstances default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/instances][%d] ListRepoInstances default %s", o._statusCode, payload)
 }
 
 func (o *ListRepoInstancesDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/list_repo_pools_responses.go
+++ b/client/repositories/list_repo_pools_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListRepoPoolsOK) Code() int {
 }
 
 func (o *ListRepoPoolsOK) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/pools][%d] listRepoPoolsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/pools][%d] listRepoPoolsOK %s", 200, payload)
 }
 
 func (o *ListRepoPoolsOK) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/pools][%d] listRepoPoolsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/pools][%d] listRepoPoolsOK %s", 200, payload)
 }
 
 func (o *ListRepoPoolsOK) GetPayload() garm_params.Pools {
@@ -157,11 +160,13 @@ func (o *ListRepoPoolsDefault) Code() int {
 }
 
 func (o *ListRepoPoolsDefault) Error() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/pools][%d] ListRepoPools default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/pools][%d] ListRepoPools default %s", o._statusCode, payload)
 }
 
 func (o *ListRepoPoolsDefault) String() string {
-	return fmt.Sprintf("[GET /repositories/{repoID}/pools][%d] ListRepoPools default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories/{repoID}/pools][%d] ListRepoPools default %s", o._statusCode, payload)
 }
 
 func (o *ListRepoPoolsDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/list_repos_responses.go
+++ b/client/repositories/list_repos_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *ListReposOK) Code() int {
 }
 
 func (o *ListReposOK) Error() string {
-	return fmt.Sprintf("[GET /repositories][%d] listReposOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories][%d] listReposOK %s", 200, payload)
 }
 
 func (o *ListReposOK) String() string {
-	return fmt.Sprintf("[GET /repositories][%d] listReposOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories][%d] listReposOK %s", 200, payload)
 }
 
 func (o *ListReposOK) GetPayload() garm_params.Repositories {
@@ -157,11 +160,13 @@ func (o *ListReposDefault) Code() int {
 }
 
 func (o *ListReposDefault) Error() string {
-	return fmt.Sprintf("[GET /repositories][%d] ListRepos default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories][%d] ListRepos default %s", o._statusCode, payload)
 }
 
 func (o *ListReposDefault) String() string {
-	return fmt.Sprintf("[GET /repositories][%d] ListRepos default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /repositories][%d] ListRepos default %s", o._statusCode, payload)
 }
 
 func (o *ListReposDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/repositories_client.go
+++ b/client/repositories/repositories_client.go
@@ -7,12 +7,38 @@ package repositories
 
 import (
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new repositories API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new repositories API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new repositories API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -23,7 +49,7 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
 
 // ClientService is the interface for Client methods

--- a/client/repositories/uninstall_repo_webhook_responses.go
+++ b/client/repositories/uninstall_repo_webhook_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,11 +82,13 @@ func (o *UninstallRepoWebhookDefault) Code() int {
 }
 
 func (o *UninstallRepoWebhookDefault) Error() string {
-	return fmt.Sprintf("[DELETE /repositories/{repoID}/webhook][%d] UninstallRepoWebhook default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /repositories/{repoID}/webhook][%d] UninstallRepoWebhook default %s", o._statusCode, payload)
 }
 
 func (o *UninstallRepoWebhookDefault) String() string {
-	return fmt.Sprintf("[DELETE /repositories/{repoID}/webhook][%d] UninstallRepoWebhook default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /repositories/{repoID}/webhook][%d] UninstallRepoWebhook default %s", o._statusCode, payload)
 }
 
 func (o *UninstallRepoWebhookDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/update_repo_pool_responses.go
+++ b/client/repositories/update_repo_pool_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *UpdateRepoPoolOK) Code() int {
 }
 
 func (o *UpdateRepoPoolOK) Error() string {
-	return fmt.Sprintf("[PUT /repositories/{repoID}/pools/{poolID}][%d] updateRepoPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /repositories/{repoID}/pools/{poolID}][%d] updateRepoPoolOK %s", 200, payload)
 }
 
 func (o *UpdateRepoPoolOK) String() string {
-	return fmt.Sprintf("[PUT /repositories/{repoID}/pools/{poolID}][%d] updateRepoPoolOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /repositories/{repoID}/pools/{poolID}][%d] updateRepoPoolOK %s", 200, payload)
 }
 
 func (o *UpdateRepoPoolOK) GetPayload() garm_params.Pool {
@@ -157,11 +160,13 @@ func (o *UpdateRepoPoolDefault) Code() int {
 }
 
 func (o *UpdateRepoPoolDefault) Error() string {
-	return fmt.Sprintf("[PUT /repositories/{repoID}/pools/{poolID}][%d] UpdateRepoPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /repositories/{repoID}/pools/{poolID}][%d] UpdateRepoPool default %s", o._statusCode, payload)
 }
 
 func (o *UpdateRepoPoolDefault) String() string {
-	return fmt.Sprintf("[PUT /repositories/{repoID}/pools/{poolID}][%d] UpdateRepoPool default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /repositories/{repoID}/pools/{poolID}][%d] UpdateRepoPool default %s", o._statusCode, payload)
 }
 
 func (o *UpdateRepoPoolDefault) GetPayload() apiserver_params.APIErrorResponse {

--- a/client/repositories/update_repo_responses.go
+++ b/client/repositories/update_repo_responses.go
@@ -6,6 +6,7 @@ package repositories
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,11 +88,13 @@ func (o *UpdateRepoOK) Code() int {
 }
 
 func (o *UpdateRepoOK) Error() string {
-	return fmt.Sprintf("[PUT /repositories/{repoID}][%d] updateRepoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /repositories/{repoID}][%d] updateRepoOK %s", 200, payload)
 }
 
 func (o *UpdateRepoOK) String() string {
-	return fmt.Sprintf("[PUT /repositories/{repoID}][%d] updateRepoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /repositories/{repoID}][%d] updateRepoOK %s", 200, payload)
 }
 
 func (o *UpdateRepoOK) GetPayload() garm_params.Repository {
@@ -157,11 +160,13 @@ func (o *UpdateRepoDefault) Code() int {
 }
 
 func (o *UpdateRepoDefault) Error() string {
-	return fmt.Sprintf("[PUT /repositories/{repoID}][%d] UpdateRepo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /repositories/{repoID}][%d] UpdateRepo default %s", o._statusCode, payload)
 }
 
 func (o *UpdateRepoDefault) String() string {
-	return fmt.Sprintf("[PUT /repositories/{repoID}][%d] UpdateRepo default  %+v", o._statusCode, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /repositories/{repoID}][%d] UpdateRepo default %s", o._statusCode, payload)
 }
 
 func (o *UpdateRepoDefault) GetPayload() apiserver_params.APIErrorResponse {


### PR DESCRIPTION
This updates go-swagger to v0.31.0, which no longer panics when used with golang v1.22+.