### PR TITLE
Reduce getworkflowjobbyid gh requests

### DIFF
--- a/apiserver/controllers/controllers.go
+++ b/apiserver/controllers/controllers.go
@@ -121,6 +121,11 @@ func (a *APIController) handleWorkflowJobEvent(ctx context.Context, w http.Respo
 				"false",             // label: valid
 				"signature_invalid", // label: reason
 			).Inc()
+		case strings.Contains(err.Error(), "no pools matching tags"):
+			metrics.WebhooksReceived.WithLabelValues(
+				"false",           // label: valid
+				"not_responsible", // label: reason
+			).Inc()
 		default:
 			metrics.WebhooksReceived.WithLabelValues(
 				"false",   // label: valid


### PR DESCRIPTION
As our garm-instance is running on an enterprise level, we are having a large error rate when it came to `GetWorkflowJobByID` requests towards github.

This is mostly, because our enterprise-token does not have (and it also does not need) permissions to read on a repo-level.
The current (on `main`) implementation already check, if the garm-instance is responsible for this webhook event (by filtering on pool labels). The proposed implementation only moves the label-check a few lines on top to return a bit earlier and with that reduce the number of api-calls towards github.

![image](https://github.com/cloudbase/garm/assets/21329055/4a530fa7-03fe-4dee-ad45-35bd6dfa1a25)


commit [a0a344ba99097fb7a1be959c11c0458558f3b600](https://github.com/cloudbase/garm/commit/a0a344ba99097fb7a1be959c11c0458558f3b600) is a small restructuring to probably make some conditions obsolete and increase the readability.
