### PR TITLE
Add version to controller info response

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone https://github.com/cloudbase/garm-provider-equinix /build/garm-pro
 
 RUN cd /build/garm && go build -o /bin/garm \
     -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" \
+    -ldflags "-linkmode external -extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" \
     /build/garm/cmd/garm && upx /bin/garm
 RUN mkdir -p /opt/garm/providers.d
 RUN cd /build/garm-provider-azure && go build -ldflags="-linkmode external -extldflags '-static' -s -w" -o /opt/garm/providers.d/garm-provider-azure . && upx /opt/garm/providers.d/garm-provider-azure

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ clean: ## Clean up build artifacts
 build: ## Build garm
 	@echo Building garm ${VERSION}
 	$(shell mkdir -p ./bin)
-	@$(GO) build -ldflags "-s -w -X main.Version=${VERSION}" -tags osusergo,netgo,sqlite_omit_load_extension -o bin/garm ./cmd/garm
-	@$(GO) build -ldflags "-s -w -X github.com/cloudbase/garm/cmd/garm-cli/cmd.Version=${VERSION}" -tags osusergo,netgo,sqlite_omit_load_extension -o bin/garm-cli ./cmd/garm-cli
+	@$(GO) build -ldflags "-s -w -X github.com/cloudbase/garm/util/appdefaults.Version=${VERSION}" -tags osusergo,netgo,sqlite_omit_load_extension -o bin/garm ./cmd/garm
+	@$(GO) build -ldflags "-s -w -X github.com/cloudbase/garm/util/appdefaults.Version=${VERSION}" -tags osusergo,netgo,sqlite_omit_load_extension -o bin/garm-cli ./cmd/garm-cli
 	@echo Binaries are available in $(PWD)/bin
 
 test: verify go-test ## Run tests

--- a/cmd/garm-cli/cmd/controller.go
+++ b/cmd/garm-cli/cmd/controller.go
@@ -145,7 +145,10 @@ func renderControllerInfoTable(info params.ControllerInfo) string {
 	if info.ControllerWebhookURL == "" {
 		info.ControllerWebhookURL = "N/A"
 	}
-
+	serverVersion := "v0.0.0-unknown"
+	if info.Version != "" {
+		serverVersion = info.Version
+	}
 	t.AppendHeader(header)
 	t.AppendRow(table.Row{"Controller ID", info.ControllerID})
 	if info.Hostname != "" {
@@ -156,6 +159,7 @@ func renderControllerInfoTable(info params.ControllerInfo) string {
 	t.AppendRow(table.Row{"Webhook Base URL", info.WebhookURL})
 	t.AppendRow(table.Row{"Controller Webhook URL", info.ControllerWebhookURL})
 	t.AppendRow(table.Row{"Minimum Job Age Backoff", info.MinimumJobAgeBackoff})
+	t.AppendRow(table.Row{"Version", serverVersion})
 	return t.Render()
 }
 

--- a/cmd/garm-cli/cmd/root.go
+++ b/cmd/garm-cli/cmd/root.go
@@ -29,8 +29,6 @@ import (
 	"github.com/cloudbase/garm/params"
 )
 
-var Version string
-
 var (
 	cfg               *config.Config
 	mgr               config.Manager

--- a/cmd/garm-cli/cmd/version.go
+++ b/cmd/garm-cli/cmd/version.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	apiClientControllerInfo "github.com/cloudbase/garm/client/controller_info"
+	"github.com/cloudbase/garm/util/appdefaults"
 )
 
 // runnerCmd represents the runner command
@@ -26,7 +29,18 @@ var versionCmd = &cobra.Command{
 	SilenceUsage: true,
 	Short:        "Print version and exit",
 	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Println(Version)
+		serverVersion := "v0.0.0-unknown"
+
+		if !needsInit {
+			showInfo := apiClientControllerInfo.NewControllerInfoParams()
+			response, err := apiCli.ControllerInfo.ControllerInfo(showInfo, authToken)
+			if err == nil {
+				serverVersion = response.Payload.Version
+			}
+		}
+
+		fmt.Printf("garm-cli: %s\n", appdefaults.GetVersion())
+		fmt.Printf("garm server: %s\n", serverVersion)
 	},
 }
 

--- a/cmd/garm/main.go
+++ b/cmd/garm/main.go
@@ -55,8 +55,6 @@ var (
 	version = flag.Bool("version", false, "prints version")
 )
 
-var Version string
-
 var signals = []os.Signal{
 	os.Interrupt,
 	syscall.SIGTERM,
@@ -179,7 +177,7 @@ func maybeUpdateURLsFromConfig(cfg config.Config, store common.Store) error {
 func main() {
 	flag.Parse()
 	if *version {
-		fmt.Println(Version)
+		fmt.Println(appdefaults.GetVersion())
 		return
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), signals...)

--- a/database/sql/controller.go
+++ b/database/sql/controller.go
@@ -24,6 +24,7 @@ import (
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/database/common"
 	"github.com/cloudbase/garm/params"
+	"github.com/cloudbase/garm/util/appdefaults"
 )
 
 func dbControllerToCommonController(dbInfo ControllerInfo) (params.ControllerInfo, error) {
@@ -39,6 +40,7 @@ func dbControllerToCommonController(dbInfo ControllerInfo) (params.ControllerInf
 		ControllerWebhookURL: url,
 		CallbackURL:          dbInfo.CallbackURL,
 		MinimumJobAgeBackoff: dbInfo.MinimumJobAgeBackoff,
+		Version:              appdefaults.GetVersion(),
 	}, nil
 }
 

--- a/params/params.go
+++ b/params/params.go
@@ -594,6 +594,8 @@ type ControllerInfo struct {
 	// runners to pick up the job before GARM attempts to allocate a new runner, thus avoiding
 	// the need to potentially scale down runners later.
 	MinimumJobAgeBackoff uint `json:"minimum_job_age_backoff"`
+	// Version is the version of the GARM controller.
+	Version string `json:"version"`
 }
 
 type GithubCredentials struct {

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -30,18 +30,18 @@ cd $GARM_SOURCE/cmd/garm
 GOOS=linux GOARCH=amd64 go build -mod vendor \
     -o $BUILD_DIR/linux/amd64/garm \
     -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-extldflags '-static' -s -w -X main.Version=$VERSION" .
+    -ldflags "-extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$VERSION" .
 GOOS=linux GOARCH=arm64 CC=aarch64-linux-musl-gcc go build \
     -mod vendor \
     -o $BUILD_DIR/linux/arm64/garm \
     -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-extldflags '-static' -s -w -X main.Version=$VERSION" .
+    -ldflags "-extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$VERSION" .
 
 # Windows
 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-cc go build -mod vendor \
     -o $BUILD_DIR/windows/amd64/garm.exe \
     -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-s -w -X main.Version=$VERSION" .
+    -ldflags "-s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$VERSION" .
 
 # garm-cli
 cd $GARM_SOURCE/cmd/garm-cli
@@ -50,17 +50,17 @@ cd $GARM_SOURCE/cmd/garm-cli
 GOOS=linux GOARCH=amd64 go build -mod vendor \
     -o $BUILD_DIR/linux/amd64/garm-cli \
     -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-extldflags '-static' -s -w -X github.com/cloudbase/garm/cmd/garm-cli/cmd.Version=$VERSION" .
+    -ldflags "-extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$VERSION" .
 GOOS=linux GOARCH=arm64 CC=aarch64-linux-musl-gcc go build -mod vendor \
     -o $BUILD_DIR/linux/arm64/garm-cli \
     -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-extldflags '-static' -s -w -X github.com/cloudbase/garm/cmd/garm-cli/cmd.Version=$VERSION" .
+    -ldflags "-extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$VERSION" .
 
 # Windows
 GOOS=windows GOARCH=amd64 go build -mod vendor \
     -o $BUILD_DIR/windows/amd64/garm-cli.exe \
     -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-s -w -X github.com/cloudbase/garm/cmd/garm-cli/cmd.Version=$VERSION" .
+    -ldflags "-s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$VERSION" .
 
 
 git checkout $CURRENT_BRANCH || true

--- a/util/appdefaults/appdefaults.go
+++ b/util/appdefaults/appdefaults.go
@@ -31,3 +31,12 @@ const (
 	// metrics data update interval
 	DefaultMetricsUpdateInterval = 60 * time.Second
 )
+
+var Version string
+
+func GetVersion() string {
+	if Version == "" {
+		Version = "v0.0.0-unknown"
+	}
+	return Version
+}


### PR DESCRIPTION
This change adds the GARM server version to the controller info response. It also amends the `version` sub-command to include the server version if available. 