### PR TITLE
Reword the section about labels

### DIFF
--- a/doc/labels.md
+++ b/doc/labels.md
@@ -4,12 +4,12 @@ Github Runners can be tagged with labels. These labels can be used to restrict t
 
 Whenever a new runner register themselves on Github, the runner knows its own labels as the labels are defined in the pool specification as tags.
 
-Beside the custom labels, Github also has some predefined labels that are appended by the runner script per default.
-These are: 
+Before version 2.305.0 of the runner and before JIT runners were introduced, the runner registration process would append some default labels to the runner. These labels are:
+
 ```yaml
 [ 'self-hosted', '$OS_TYPE', '$OS_ARCH' ]
 ```
 
-With Version `v0.1.2` of `garm-provider-common`, the runner script will register themselves with a new command line flag, called `--no-default-labels`. If this flag is set, the runner will not append any default label.
+This made scheduling and using runners a bit awkward in some situations. For example, in large organizations with many teams, often times workflows would simply target the `self-hosted` label. This would match all runners regardless of any other custom labels. This had the side effect that workflows would potentially use expensive runners for simple jobs or would select low resource runners for tasks that would require a lot of resources.
 
-As all labels can be defined in the pool specification, it's still possible to add the default labels manually.
+Version 2.305.0 of the runner introduced the `--no-default-labels` flag when registering the runner. When JIT is not available (GHES version < 3.10), GARM will now register the runner with the `--no-default-labels` flag. If you still need the default labels, you can add them to the pool specification.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -17,7 +17,6 @@
     - [Create a pool](#create-a-pool)
 
 <!-- /TOC -->
-* ```admin:org_hook``` - if you want to allow GARM to install webhooks on organizations
 
 This doc will be updated at a future date with the exact permissions needed in case you want to use a fine grained PAT.
 


### PR DESCRIPTION
This change removes a stray line in the quickstart and rewords the section about labels a bit.