### PR TITLE
Generalize the websocket reader

### DIFF
--- a/cmd/garm-cli/cmd/events.go
+++ b/cmd/garm-cli/cmd/events.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
 
+	"github.com/cloudbase/garm/cmd/garm-cli/common"
 	garmWs "github.com/cloudbase/garm/websocket"
 )
 
@@ -26,7 +27,7 @@ var eventsCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(context.Background(), signals...)
 		defer stop()
 
-		reader, err := garmWs.NewReader(ctx, mgr.BaseURL, "/api/v1/events", mgr.Token)
+		reader, err := garmWs.NewReader(ctx, mgr.BaseURL, "/api/v1/events", mgr.Token, common.PrintWebsocketMessage)
 		if err != nil {
 			return err
 		}

--- a/cmd/garm-cli/cmd/log.go
+++ b/cmd/garm-cli/cmd/log.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cloudbase/garm/cmd/garm-cli/common"
 	garmWs "github.com/cloudbase/garm/websocket"
 )
 
@@ -20,7 +21,7 @@ var logCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(context.Background(), signals...)
 		defer stop()
 
-		reader, err := garmWs.NewReader(ctx, mgr.BaseURL, "/api/v1/ws", mgr.Token)
+		reader, err := garmWs.NewReader(ctx, mgr.BaseURL, "/api/v1/ws", mgr.Token, common.PrintWebsocketMessage)
 		if err != nil {
 			return err
 		}

--- a/cmd/garm-cli/common/common.go
+++ b/cmd/garm-cli/common/common.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"github.com/nbutton23/zxcvbn-go"
+
+	"github.com/cloudbase/garm-provider-common/util"
 )
 
 func PromptPassword(label string, compareTo string) (string, error) {
@@ -66,4 +68,9 @@ func PromptString(label string, a ...interface{}) (string, error) {
 		return "", err
 	}
 	return result, nil
+}
+
+func PrintWebsocketMessage(_ int, msg []byte) error {
+	fmt.Println(util.SanitizeLogEntry(string(msg)))
+	return nil
 }


### PR DESCRIPTION
This change adds a new message handler that users of the reader can use to handle websocket messages. Packages should never print to console by themselves.