### PR TITLE
Rename websocket URLs

### DIFF
--- a/apiserver/routers/routers.go
+++ b/apiserver/routers/routers.go
@@ -411,9 +411,18 @@ func NewAPIRouter(han *controllers.APIController, authMiddleware, initMiddleware
 	apiRouter.Handle("/github/credentials/{id}/", http.HandlerFunc(han.UpdateGithubCredential)).Methods("PUT", "OPTIONS")
 	apiRouter.Handle("/github/credentials/{id}", http.HandlerFunc(han.UpdateGithubCredential)).Methods("PUT", "OPTIONS")
 
-	// Websocket log writer
-	apiRouter.Handle("/{ws:ws\\/?}", http.HandlerFunc(han.WSHandler)).Methods("GET")
-	apiRouter.Handle("/{events:events\\/?}", http.HandlerFunc(han.EventsHandler)).Methods("GET")
+	/////////////////////////
+	// Websocket endpoints //
+	/////////////////////////
+	// Legacy log websocket path
+	apiRouter.Handle("/ws/", http.HandlerFunc(han.WSHandler)).Methods("GET")
+	apiRouter.Handle("/ws", http.HandlerFunc(han.WSHandler)).Methods("GET")
+	// Log websocket endpoint
+	apiRouter.Handle("/ws/logs/", http.HandlerFunc(han.WSHandler)).Methods("GET")
+	apiRouter.Handle("/ws/logs", http.HandlerFunc(han.WSHandler)).Methods("GET")
+	// DB watcher websocket endpoint
+	apiRouter.Handle("/ws/events/", http.HandlerFunc(han.EventsHandler)).Methods("GET")
+	apiRouter.Handle("/ws/events", http.HandlerFunc(han.EventsHandler)).Methods("GET")
 
 	// NotFound handler
 	apiRouter.PathPrefix("/").HandlerFunc(han.NotFoundHandler).Methods("GET", "POST", "PUT", "DELETE", "OPTIONS")

--- a/cmd/garm-cli/cmd/events.go
+++ b/cmd/garm-cli/cmd/events.go
@@ -27,7 +27,7 @@ var eventsCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(context.Background(), signals...)
 		defer stop()
 
-		reader, err := garmWs.NewReader(ctx, mgr.BaseURL, "/api/v1/events", mgr.Token, common.PrintWebsocketMessage)
+		reader, err := garmWs.NewReader(ctx, mgr.BaseURL, "/api/v1/ws/events", mgr.Token, common.PrintWebsocketMessage)
 		if err != nil {
 			return err
 		}

--- a/cmd/garm-cli/cmd/log.go
+++ b/cmd/garm-cli/cmd/log.go
@@ -21,7 +21,7 @@ var logCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(context.Background(), signals...)
 		defer stop()
 
-		reader, err := garmWs.NewReader(ctx, mgr.BaseURL, "/api/v1/ws", mgr.Token, common.PrintWebsocketMessage)
+		reader, err := garmWs.NewReader(ctx, mgr.BaseURL, "/api/v1/ws/logs", mgr.Token, common.PrintWebsocketMessage)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Given that we now have multiple websocket URLs (logs and events), this change categorizes them under the same prefix.