### PR TITLE
Switch to self hosted runner

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-noble-garm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -17,14 +17,14 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.1
+        uses: canonical/setup-lxd@main
 
       - name: Install dependencies
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get -qq update && sudo apt-get -qq install -y apg coreutils make
+          sudo apt-get -qq update && sudo apt-get -qq install -y apg coreutils make jq build-essential libsqlite3-dev libsqlite3-0
 
-      - name: Set up localshow tunnel
+      - name: Set up tunnel
         shell: bash
         run: |
           mkdir -p /home/runner/.ssh

--- a/test/integration/config/config.toml
+++ b/test/integration/config/config.toml
@@ -38,13 +38,3 @@ provider_type = "external"
   [provider.external]
   config_file = "${GARM_CONFIG_DIR}/test-provider/config"
   provider_executable = "${GARM_CONFIG_DIR}/test-provider/garm-external-provider"
-
-[[github]]
-name = "${CREDENTIALS_NAME}"
-description = "GARM GitHub OAuth token"
-oauth2_token = "${GH_TOKEN}"
-
-[[github]]
-name = "${CREDENTIALS_NAME}-clone"
-description = "GARM GitHub OAuth token - clone"
-oauth2_token = "${GH_TOKEN}"

--- a/test/integration/scripts/setup-garm.sh
+++ b/test/integration/scripts/setup-garm.sh
@@ -71,7 +71,7 @@ sudo cp $CONFIG_DIR/garm-provider-lxd.toml $LXD_PROVIDER_CONFIG
 function clone_and_build_lxd_provider() {
     git clone https://github.com/cloudbase/garm-provider-lxd ~/garm-provider-lxd
     pushd ~/garm-provider-lxd
-    go build -o $LXD_PROVIDER_EXECUTABLE
+    CGO_ENABLED=1 go build -o $LXD_PROVIDER_EXECUTABLE
     popd
 }
 


### PR DESCRIPTION
GitHub hosted runners seem to have issues with LXD containers. In all likelihood, downloading images is slow and the tests end up timing out. This switches to self hosted runners, managed by GARM.