### PR TITLE
Allow using LXD image mirror

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -26,9 +26,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libbtrfs-dev build-essential apg jq
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: '^1.22.3'
       - uses: actions/checkout@v3
       - name: make lint
         run: make golangci-lint && GOLANGCI_LINT_EXTRA_ARGS="--timeout=8m --build-tags=testing,integration" make lint

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup LXD
         uses: canonical/setup-lxd@main
+        with:
+          channel: latest/stable
 
       - name: Install dependencies
         run: |
@@ -42,9 +44,9 @@ jobs:
 
           echo "GARM_BASE_URL=$GARM_BASE_URL" >> $GITHUB_ENV
 
-          cat <<EOF | sudo tee /etc/systemd/system/localshow-tunnel.service
+          cat <<EOF | sudo tee /etc/systemd/system/garm-tunnel.service
           [Unit]
-          Description=Localshow tunnel
+          Description=GARM tunnel
           After=network.target
 
           [Service]
@@ -57,8 +59,8 @@ jobs:
           EOF
 
           sudo systemctl daemon-reload
-          sudo systemctl enable localshow-tunnel
-          sudo systemctl start localshow-tunnel
+          sudo systemctl enable garm-tunnel
+          sudo systemctl start garm-tunnel
 
       - name: Generate secrets
         run: |
@@ -90,6 +92,7 @@ jobs:
           CREDENTIALS_NAME: test-garm-creds
           WORKFLOW_FILE_NAME: test.yml
           GH_TOKEN: ${{ secrets.GH_OAUTH_TOKEN }}
+          LXD_REMOTE_SERVER: ${{ secrets.LXD_REMOTE_SERVER }}
 
       - name: Show GARM logs
         if: always()

--- a/test/integration/config/garm-provider-lxd.toml
+++ b/test/integration/config/garm-provider-lxd.toml
@@ -5,7 +5,7 @@ secure_boot = false
 project_name = "default"
 [image_remotes]
   [image_remotes.ubuntu]
-    addr = "https://cloud-images.ubuntu.com/releases"
+    addr = "${LXD_REMOTE_SERVER}"
     public = true
     protocol = "simplestreams"
     skip_verify = false

--- a/test/integration/external_provider_test.go
+++ b/test/integration/external_provider_test.go
@@ -22,7 +22,7 @@ func (suite *GarmSuite) TestExternalProvider() {
 		MaxRunners:     2,
 		MinIdleRunners: 0,
 		Flavor:         "default",
-		Image:          "ubuntu:22.04",
+		Image:          "ubuntu:24.04",
 		OSType:         commonParams.Linux,
 		OSArch:         commonParams.Amd64,
 		ProviderName:   "test_external",

--- a/test/integration/organizations_test.go
+++ b/test/integration/organizations_test.go
@@ -29,7 +29,7 @@ func (suite *GarmSuite) TestOrganizations() {
 		MaxRunners:     2,
 		MinIdleRunners: 0,
 		Flavor:         "default",
-		Image:          "ubuntu:22.04",
+		Image:          "ubuntu:24.04",
 		OSType:         commonParams.Linux,
 		OSArch:         commonParams.Amd64,
 		ProviderName:   "lxd_local",

--- a/test/integration/repositories_test.go
+++ b/test/integration/repositories_test.go
@@ -57,7 +57,7 @@ func (suite *GarmSuite) TestRepositories() {
 		MaxRunners:     2,
 		MinIdleRunners: 0,
 		Flavor:         "default",
-		Image:          "ubuntu:22.04",
+		Image:          "ubuntu:24.04",
 		OSType:         commonParams.Linux,
 		OSArch:         commonParams.Amd64,
 		ProviderName:   "lxd_local",

--- a/test/integration/scripts/setup-garm.sh
+++ b/test/integration/scripts/setup-garm.sh
@@ -14,6 +14,7 @@ export RUN_USER=${RUN_USER:-$USER}
 export GARM_PORT=${GARM_PORT:-"9997"}
 export GARM_SERVICE_NAME=${GARM_SERVICE_NAME:-"garm"}
 export GARM_CONFIG_FILE=${GARM_CONFIG_FILE:-"${GARM_CONFIG_DIR}/config.toml"}
+export LXD_REMOTE_SERVER=${LXD_REMOTE_SERVER:-"https://cloud-images.ubuntu.com/releases"}
 
 if [ -f "$GITHUB_ENV" ];then
     echo "export GARM_CONFIG_DIR=${GARM_CONFIG_DIR}" >> $GITHUB_ENV
@@ -66,7 +67,7 @@ sudo chown -R $RUN_USER:$RUN_USER ${GARM_CONFIG_DIR}
 
 export LXD_PROVIDER_EXECUTABLE="$PROVIDER_BIN_DIR/garm-provider-lxd"
 export LXD_PROVIDER_CONFIG="${GARM_CONFIG_DIR}/garm-provider-lxd.toml"
-sudo cp $CONFIG_DIR/garm-provider-lxd.toml $LXD_PROVIDER_CONFIG
+cat $CONFIG_DIR/garm-provider-lxd.toml| envsubst | sudo tee $LXD_PROVIDER_CONFIG > /dev/null
 
 function clone_and_build_lxd_provider() {
     git clone https://github.com/cloudbase/garm-provider-lxd ~/garm-provider-lxd


### PR DESCRIPTION
This change allows GARM tests to use a mirror for LXD images, allowing for faster image downloads.