### PR TITLE
Use errors.Wrap() in repositories.go

### DIFF
--- a/runner/repositories.go
+++ b/runner/repositories.go
@@ -205,7 +205,7 @@ func (r *Runner) UpdateRepository(ctx context.Context, repoID string, param para
 
 	poolMgr, err := r.poolManagerCtrl.GetRepoPoolManager(repo)
 	if err != nil {
-		return params.Repository{}, fmt.Errorf("failed to get pool manager: %w", err)
+		return params.Repository{}, errors.Wrap(err, "getting pool manager")
 	}
 
 	repo.PoolManagerStatus = poolMgr.Status()
@@ -219,7 +219,7 @@ func (r *Runner) CreateRepoPool(ctx context.Context, repoID string, param params
 
 	createPoolParams, err := r.appendTagsToCreatePoolParams(param)
 	if err != nil {
-		return params.Pool{}, fmt.Errorf("failed to append tags to create pool params: %w", err)
+		return params.Pool{}, errors.Wrap(err, "appending tags to create pool params")
 	}
 
 	if createPoolParams.RunnerBootstrapTimeout == 0 {
@@ -233,7 +233,7 @@ func (r *Runner) CreateRepoPool(ctx context.Context, repoID string, param params
 
 	pool, err := r.store.CreateEntityPool(ctx, entity, createPoolParams)
 	if err != nil {
-		return params.Pool{}, fmt.Errorf("failed to create pool: %w", err)
+		return params.Pool{}, errors.Wrap(err, "creating pool")
 	}
 
 	return pool, nil

--- a/runner/repositories_test.go
+++ b/runner/repositories_test.go
@@ -373,7 +373,7 @@ func (s *RepoTestSuite) TestUpdateRepositoryPoolMgrFailed() {
 	_, err := s.Runner.UpdateRepository(s.Fixtures.AdminContext, s.Fixtures.StoreRepos["test-repo-1"].ID, s.Fixtures.UpdateRepoParams)
 
 	s.Fixtures.PoolMgrCtrlMock.AssertExpectations(s.T())
-	s.Require().Equal(fmt.Sprintf("failed to get pool manager: %s", s.Fixtures.ErrMock.Error()), err.Error())
+	s.Require().Equal(fmt.Sprintf("getting pool manager: %s", s.Fixtures.ErrMock.Error()), err.Error())
 }
 
 func (s *RepoTestSuite) TestUpdateRepositoryCreateRepoPoolMgrFailed() {
@@ -382,7 +382,7 @@ func (s *RepoTestSuite) TestUpdateRepositoryCreateRepoPoolMgrFailed() {
 	_, err := s.Runner.UpdateRepository(s.Fixtures.AdminContext, s.Fixtures.StoreRepos["test-repo-1"].ID, s.Fixtures.UpdateRepoParams)
 
 	s.Fixtures.PoolMgrCtrlMock.AssertExpectations(s.T())
-	s.Require().Equal(fmt.Sprintf("failed to get pool manager: %s", s.Fixtures.ErrMock.Error()), err.Error())
+	s.Require().Equal(fmt.Sprintf("getting pool manager: %s", s.Fixtures.ErrMock.Error()), err.Error())
 }
 
 func (s *RepoTestSuite) TestCreateRepoPool() {
@@ -415,7 +415,7 @@ func (s *RepoTestSuite) TestCreateRepoPoolFetchPoolParamsFailed() {
 
 	s.Fixtures.PoolMgrMock.AssertExpectations(s.T())
 	s.Fixtures.PoolMgrCtrlMock.AssertExpectations(s.T())
-	s.Require().Regexp("failed to append tags to create pool params: no such provider not-existent-provider-name", err.Error())
+	s.Require().Regexp("appending tags to create pool params: no such provider not-existent-provider-name", err.Error())
 }
 
 func (s *RepoTestSuite) TestGetRepoPoolByID() {


### PR DESCRIPTION
The API code unwraps errors wrapped by the errors.Wrap() function. It falls back to 500 error if it can't determine any other error type.

Ultimately we need to migrate to the fmt.Errorf() pattern. But for now at least, we need to return proper errors. Any 500 error will not output details to the API. Neither will 401 for similar reasons.