### PR TITLE
Add a default value to the new --format option

### DIFF
--- a/cmd/garm-cli/cmd/root.go
+++ b/cmd/garm-cli/cmd/root.go
@@ -39,8 +39,8 @@ var (
 	needsInit         bool
 	debug             bool
 	poolBalancerType  string
-	outputFormat      common.OutputFormat
-	errNeedsInitError = fmt.Errorf("please log into a garm installation first")
+	outputFormat      common.OutputFormat = common.OutputFormatTable
+	errNeedsInitError                     = fmt.Errorf("please log into a garm installation first")
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -55,9 +55,6 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug on all API calls")
 	rootCmd.PersistentFlags().VarP(&outputFormat, "format", "f", "Output format (table, json)")
-	if outputFormat.String() == "" {
-		outputFormat = common.OutputFormatTable
-	}
 
 	cobra.OnInitialize(initConfig)
 

--- a/cmd/garm-cli/common/cobra.go
+++ b/cmd/garm-cli/common/cobra.go
@@ -9,8 +9,11 @@ const (
 	OutputFormatJSON  OutputFormat = "json"
 )
 
-func (o OutputFormat) String() string {
-	return string(o)
+func (o *OutputFormat) String() string {
+	if o == nil {
+		return ""
+	}
+	return string(*o)
 }
 
 func (o *OutputFormat) Set(value string) error {
@@ -23,6 +26,6 @@ func (o *OutputFormat) Set(value string) error {
 	return nil
 }
 
-func (o OutputFormat) Type() string {
+func (o *OutputFormat) Type() string {
 	return "string"
 }


### PR DESCRIPTION
This change properly adds a default value to the new `--format` option.