### PR TITLE
Copy the CA certificates to final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,6 @@ COPY --from=builder /opt/garm/providers.d/garm-provider-gcp /opt/garm/providers.
 COPY --from=builder /opt/garm/providers.d/garm-provider-equinix /opt/garm/providers.d/garm-provider-equinix
 
 COPY --from=builder /opt/garm/providers.d/garm-provider-k8s /opt/garm/providers.d/garm-provider-k8s
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/bin/garm", "-config", "/etc/garm/config.toml"]


### PR DESCRIPTION
The busybox image does not contain CA certificares. This adds them from the builder stage.