### PR TITLE
Remove conflicting short hand option

### DIFF
--- a/cmd/garm-cli/cmd/root.go
+++ b/cmd/garm-cli/cmd/root.go
@@ -54,7 +54,7 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug on all API calls")
-	rootCmd.PersistentFlags().VarP(&outputFormat, "format", "f", "Output format (table, json)")
+	rootCmd.PersistentFlags().Var(&outputFormat, "format", "Output format (table, json)")
 
 	cobra.OnInitialize(initConfig)
 


### PR DESCRIPTION
The --format command line option is persistent to allow all commands to output to either json or table. The shorthand of this option caused a conflict with other subcommands that also define the -f option. Removing the persitent short form option.

Fixes: #305 