### PR TITLE
Improve error messages in garm log

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,3 +38,7 @@ linters-settings:
 
   goimports:
     local-prefixes: github.com/cloudbase/garm
+
+  gosec:
+    excludes:
+    - G115

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,17 @@ create-release-files:
 release: build-static create-release-files ## Create a release
 
 ##@ Lint / Verify
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+
+## Tool Versions
+GOLANGCI_LINT_VERSION ?= v1.61.0
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary. If wrong version is installed, it will be overwritten.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	test -s $(LOCALBIN)/golangci-lint && $(LOCALBIN)/golangci-lint --version | grep -q $(GOLANGCI_LINT_VERSION) || \
+	GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
 .PHONY: lint
 lint: golangci-lint $(GOLANGCI_LINT) ## Run linting.
 	$(GOLANGCI_LINT) run -v --build-tags=testing,integration $(GOLANGCI_LINT_EXTRA_ARGS)

--- a/database/sql/jobs.go
+++ b/database/sql/jobs.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
@@ -84,7 +85,8 @@ func (s *sqlDatabase) paramsJobToWorkflowJob(ctx context.Context, job params.Job
 	if job.RunnerName != "" {
 		instance, err := s.getInstanceByName(s.ctx, job.RunnerName)
 		if err != nil {
-			slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to get instance by name")
+			// This usually is very normal as not all jobs run on our runners.
+			slog.DebugContext(ctx, fmt.Sprintf("failed to get instance by name: %s", job.RunnerName))
 		} else {
 			workflofJob.InstanceID = &instance.ID
 		}
@@ -244,7 +246,8 @@ func (s *sqlDatabase) CreateOrUpdateJob(ctx context.Context, job params.Job) (pa
 			if err == nil {
 				workflowJob.InstanceID = &instance.ID
 			} else {
-				slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to get instance by name")
+				// This usually is very normal as not all jobs run on our runners.
+				slog.DebugContext(ctx, fmt.Sprintf("failed to get instance by name: %s", job.RunnerName))
 			}
 		}
 

--- a/database/sql/jobs.go
+++ b/database/sql/jobs.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 
 	"github.com/google/uuid"
@@ -247,7 +246,7 @@ func (s *sqlDatabase) CreateOrUpdateJob(ctx context.Context, job params.Job) (pa
 				workflowJob.InstanceID = &instance.ID
 			} else {
 				// This usually is very normal as not all jobs run on our runners.
-				slog.DebugContext(ctx, fmt.Sprintf("failed to get instance by name: %s", job.RunnerName))
+				slog.DebugContext(ctx, "failed to get instance by name", "instance_name", job.RunnerName)
 			}
 		}
 

--- a/database/sql/jobs.go
+++ b/database/sql/jobs.go
@@ -86,7 +86,7 @@ func (s *sqlDatabase) paramsJobToWorkflowJob(ctx context.Context, job params.Job
 		instance, err := s.getInstanceByName(s.ctx, job.RunnerName)
 		if err != nil {
 			// This usually is very normal as not all jobs run on our runners.
-			slog.DebugContext(ctx, fmt.Sprintf("failed to get instance by name: %s", job.RunnerName))
+			slog.DebugContext(ctx, "failed to get instance by name", "instance_name", job.RunnerName)
 		} else {
 			workflofJob.InstanceID = &instance.ID
 		}

--- a/database/sql/util.go
+++ b/database/sql/util.go
@@ -402,7 +402,7 @@ func (s *sqlDatabase) updatePool(tx *gorm.DB, pool Pool, param params.UpdatePool
 	}
 
 	tags := []Tag{}
-	if param.Tags != nil && len(param.Tags) > 0 {
+	if len(param.Tags) > 0 {
 		for _, val := range param.Tags {
 			t, err := s.getOrCreateTag(tx, val)
 			if err != nil {

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -135,6 +135,14 @@ func (r *basePoolManager) HandleWorkflowJob(job params.WorkflowJob) error {
 		return errors.Wrap(err, "validating owner")
 	}
 
+	// we see events where the lables seem to be missing. We should ignore these
+	// as we can't know if we should handle them or not.
+	if len(job.WorkflowJob.Labels) == 0 {
+		slog.WarnContext(
+			r.ctx, fmt.Sprintf("job has no labels: %s", job.WorkflowJob.Name))
+		return nil
+	}
+
 	var jobParams params.Job
 	var err error
 	var triggeredBy int64

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -138,8 +138,7 @@ func (r *basePoolManager) HandleWorkflowJob(job params.WorkflowJob) error {
 	// we see events where the lables seem to be missing. We should ignore these
 	// as we can't know if we should handle them or not.
 	if len(job.WorkflowJob.Labels) == 0 {
-		slog.WarnContext(
-			r.ctx, fmt.Sprintf("job has no labels: %s", job.WorkflowJob.Name))
+		slog.WarnContext(r.ctx, "job has no labels", "workflow_job", job.WorkflowJob.Name)
 		return nil
 	}
 


### PR DESCRIPTION
finding errors in logs is very important and there are some logs that are `errors` but seem to be rather normal:

- workflow events without labels -> this happens very often (at least in our GHE instance), this might be a bug in github code .. but garm probably has to accept this and don't consider this an error
- workflows that have runner_names which are not `our` runners. This always happens in a scenario where our garm runners are not the only runner setup (and we still get the workflow_job events, e.g. enterprise wide hooks)