### PR TITLE
Fix hardcoded user value in template

### DIFF
--- a/runner/metadata.go
+++ b/runner/metadata.go
@@ -23,7 +23,7 @@ After=network.target
 
 [Service]
 ExecStart=/home/{{.RunAsUser}}/actions-runner/runsvc.sh
-User=runner
+User={{.RunAsUser}}
 WorkingDirectory=/home/{{.RunAsUser}}/actions-runner
 KillMode=process
 KillSignal=SIGTERM


### PR DESCRIPTION
The User option in the systemd unit file used when JIT configs are enabled had a hardcoded value of "runner". This change fixes that oversight.