### PR TITLE
Relax description validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -358,9 +358,6 @@ func (g *Github) Validate() error {
 	if g.Name == "" {
 		return fmt.Errorf("missing credentials name")
 	}
-	if g.Description == "" {
-		return fmt.Errorf("missing credentials description")
-	}
 
 	if g.APIBaseURL != "" {
 		if _, err := url.ParseRequestURI(g.APIBaseURL); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -668,15 +668,6 @@ func TestGithubConfig(t *testing.T) {
 			errString: "missing credentials name",
 		},
 		{
-			name: "Description is empty",
-			cfg: Github{
-				Name:        "dummy_creds",
-				Description: "",
-				OAuth2Token: "bogus",
-			},
-			errString: "missing credentials description",
-		},
-		{
 			name: "OAuth token is set in the PAT section",
 			cfg: Github{
 				Name:        "dummy_creds",


### PR DESCRIPTION
Description should not be mandatory when defining a github endpoint.

Fixes #312 