### PR TITLE
Relax URLs validation

### DIFF
--- a/apiserver/params/params.go
+++ b/apiserver/params/params.go
@@ -39,6 +39,6 @@ var (
 	// URLsRequired is returned if the controller does not have the required URLs
 	URLsRequired = APIErrorResponse{
 		Error:   "urls_required",
-		Details: "Missing required URLs. Make sure you update the metadata, callback and webhook URLs",
+		Details: "Missing required URLs. Make sure you update the metadata and callback URLs",
 	}
 )

--- a/auth/init_required.go
+++ b/auth/init_required.go
@@ -66,7 +66,7 @@ func (u *urlsRequired) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		ctrlInfo, err := u.store.ControllerInfo()
-		if err != nil || ctrlInfo.WebhookURL == "" || ctrlInfo.MetadataURL == "" || ctrlInfo.CallbackURL == "" {
+		if err != nil || ctrlInfo.MetadataURL == "" || ctrlInfo.CallbackURL == "" {
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusConflict)
 			if err := json.NewEncoder(w).Encode(params.URLsRequired); err != nil {


### PR DESCRIPTION
Webhook URL was not mandatory in previous versions. While it is needed if users plan to use the install webhook feature, it is not required if you want to install it yourself.

Fixes #311 