### PR TITLE
Add rate limit cache and fixes

### DIFF
--- a/cache/credentials_cache.go
+++ b/cache/credentials_cache.go
@@ -21,6 +21,16 @@ type GithubCredentials struct {
 	cache map[uint]params.GithubCredentials
 }
 
+func (g *GithubCredentials) SetCredentialsRateLimit(credsID uint, rateLimit params.GithubRateLimit) {
+	g.mux.Lock()
+	defer g.mux.Unlock()
+
+	if creds, ok := g.cache[credsID]; ok {
+		creds.RateLimit = rateLimit
+		g.cache[credsID] = creds
+	}
+}
+
 func (g *GithubCredentials) SetCredentials(credentials params.GithubCredentials) {
 	g.mux.Lock()
 	defer g.mux.Unlock()
@@ -54,6 +64,21 @@ func (g *GithubCredentials) GetAllCredentials() []params.GithubCredentials {
 	for _, cred := range g.cache {
 		creds = append(creds, cred)
 	}
+
+	// Sort the credentials by ID
+	sortByID(creds)
+	return creds
+}
+
+func (g *GithubCredentials) GetAllCredentialsAsMap() map[uint]params.GithubCredentials {
+	g.mux.Lock()
+	defer g.mux.Unlock()
+
+	creds := make(map[uint]params.GithubCredentials, len(g.cache))
+	for id, cred := range g.cache {
+		creds[id] = cred
+	}
+
 	return creds
 }
 
@@ -71,4 +96,12 @@ func DeleteGithubCredentials(id uint) {
 
 func GetAllGithubCredentials() []params.GithubCredentials {
 	return credentialsCache.GetAllCredentials()
+}
+
+func SetCredentialsRateLimit(credsID uint, rateLimit params.GithubRateLimit) {
+	credentialsCache.SetCredentialsRateLimit(credsID, rateLimit)
+}
+
+func GetAllGithubCredentialsAsMap() map[uint]params.GithubCredentials {
+	return credentialsCache.GetAllCredentialsAsMap()
 }

--- a/cache/entity_cache.go
+++ b/cache/entity_cache.go
@@ -186,6 +186,8 @@ func (e *EntityCache) FindPoolsMatchingAllTags(entityID string, tags []string) [
 				pools = append(pools, pool)
 			}
 		}
+		// Sort the pools by creation date.
+		sortByCreationDate(pools)
 		return pools
 	}
 	return nil
@@ -200,6 +202,8 @@ func (e *EntityCache) GetEntityPools(entityID string) []params.Pool {
 		for _, pool := range cache.Pools {
 			pools = append(pools, pool)
 		}
+		// Sort the pools by creation date.
+		sortByCreationDate(pools)
 		return pools
 	}
 	return nil
@@ -214,6 +218,8 @@ func (e *EntityCache) GetEntityScaleSets(entityID string) []params.ScaleSet {
 		for _, scaleSet := range cache.ScaleSets {
 			scaleSets = append(scaleSets, scaleSet)
 		}
+		// Sort the scale sets by creation date.
+		sortByID(scaleSets)
 		return scaleSets
 	}
 	return nil
@@ -229,6 +235,7 @@ func (e *EntityCache) GetEntitiesUsingGredentials(credsID uint) []params.GithubE
 			entities = append(entities, cache.Entity)
 		}
 	}
+	sortByCreationDate(entities)
 	return entities
 }
 
@@ -245,7 +252,36 @@ func (e *EntityCache) GetAllEntities() []params.GithubEntity {
 		}
 		entities = append(entities, cache.Entity)
 	}
+	sortByCreationDate(entities)
 	return entities
+}
+
+func (e *EntityCache) GetAllPools() []params.Pool {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+
+	var pools []params.Pool
+	for _, cache := range e.entities {
+		for _, pool := range cache.Pools {
+			pools = append(pools, pool)
+		}
+	}
+	sortByCreationDate(pools)
+	return pools
+}
+
+func (e *EntityCache) GetAllScaleSets() []params.ScaleSet {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+
+	var scaleSets []params.ScaleSet
+	for _, cache := range e.entities {
+		for _, scaleSet := range cache.ScaleSets {
+			scaleSets = append(scaleSets, scaleSet)
+		}
+	}
+	sortByID(scaleSets)
+	return scaleSets
 }
 
 func GetEntity(entityID string) (params.GithubEntity, bool) {
@@ -314,4 +350,12 @@ func GetEntitiesUsingGredentials(credsID uint) []params.GithubEntity {
 
 func GetAllEntities() []params.GithubEntity {
 	return entityCache.GetAllEntities()
+}
+
+func GetAllPools() []params.Pool {
+	return entityCache.GetAllPools()
+}
+
+func GetAllScaleSets() []params.ScaleSet {
+	return entityCache.GetAllScaleSets()
 }

--- a/cache/instance_cache.go
+++ b/cache/instance_cache.go
@@ -53,6 +53,7 @@ func (i *InstanceCache) GetAllInstances() []params.Instance {
 	for _, instance := range i.cache {
 		instances = append(instances, instance)
 	}
+	sortByCreationDate(instances)
 	return instances
 }
 
@@ -66,6 +67,7 @@ func (i *InstanceCache) GetInstancesForPool(poolID string) []params.Instance {
 			filteredInstances = append(filteredInstances, instance)
 		}
 	}
+	sortByCreationDate(filteredInstances)
 	return filteredInstances
 }
 
@@ -79,6 +81,7 @@ func (i *InstanceCache) GetInstancesForScaleSet(scaleSetID uint) []params.Instan
 			filteredInstances = append(filteredInstances, instance)
 		}
 	}
+	sortByCreationDate(filteredInstances)
 	return filteredInstances
 }
 

--- a/cache/util.go
+++ b/cache/util.go
@@ -1,0 +1,19 @@
+package cache
+
+import (
+	"sort"
+
+	"github.com/cloudbase/garm/params"
+)
+
+func sortByID[T params.IDGetter](s []T) {
+	sort.Slice(s, func(i, j int) bool {
+		return s[i].GetID() < s[j].GetID()
+	})
+}
+
+func sortByCreationDate[T params.CreationDateGetter](s []T) {
+	sort.Slice(s, func(i, j int) bool {
+		return s[i].GetCreatedAt().Before(s[j].GetCreatedAt())
+	})
+}

--- a/cmd/garm-cli/cmd/github_credentials.go
+++ b/cmd/garm-cli/cmd/github_credentials.go
@@ -375,6 +375,8 @@ func formatOneGithubCredential(cred params.GithubCredentials) {
 	header := table.Row{"Field", "Value"}
 	t.AppendHeader(header)
 
+	resetMinutes := cred.RateLimit.ResetIn().Minutes()
+
 	t.AppendRow(table.Row{"ID", cred.ID})
 	t.AppendRow(table.Row{"Created At", cred.CreatedAt})
 	t.AppendRow(table.Row{"Updated At", cred.UpdatedAt})
@@ -385,6 +387,10 @@ func formatOneGithubCredential(cred params.GithubCredentials) {
 	t.AppendRow(table.Row{"Upload URL", cred.UploadBaseURL})
 	t.AppendRow(table.Row{"Type", cred.AuthType})
 	t.AppendRow(table.Row{"Endpoint", cred.Endpoint.Name})
+	if resetMinutes > 0 {
+		t.AppendRow(table.Row{"Remaining API requests", cred.RateLimit.Remaining})
+		t.AppendRow(table.Row{"Rate limit reset", fmt.Sprintf("%d minutes", int64(resetMinutes))})
+	}
 
 	if len(cred.Repositories) > 0 {
 		t.AppendRow(table.Row{"", ""})

--- a/params/interfaces.go
+++ b/params/interfaces.go
@@ -1,7 +1,17 @@
 package params
 
+import "time"
+
 // EntityGetter is implemented by all github entities (repositories, organizations and enterprises).
 // It defines the GetEntity() function which returns a github entity.
 type EntityGetter interface {
 	GetEntity() (GithubEntity, error)
+}
+
+type IDGetter interface {
+	GetID() uint
+}
+
+type CreationDateGetter interface {
+	GetCreatedAt() time.Time
 }

--- a/runner/github_credentials.go
+++ b/runner/github_credentials.go
@@ -7,6 +7,7 @@ import (
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/auth"
+	"github.com/cloudbase/garm/cache"
 	"github.com/cloudbase/garm/params"
 )
 
@@ -15,11 +16,24 @@ func (r *Runner) ListCredentials(ctx context.Context) ([]params.GithubCredential
 		return nil, runnerErrors.ErrUnauthorized
 	}
 
+	// Get the credentials from the store. The cache is always updated after the database successfully
+	// commits the transaction that created/updated the credentials.
+	// If we create a set of credentials then immediately after we call ListCredentials,
+	// there is a posibillity that not all creds will be in the cache.
 	creds, err := r.store.ListGithubCredentials(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching github credentials")
 	}
 
+	// If we do have cache, update the rate limit for each credential. The rate limits are queried
+	// every 30 seconds and set in cache.
+	credsCache := cache.GetAllGithubCredentialsAsMap()
+	for idx, cred := range creds {
+		inCache, ok := credsCache[cred.ID]
+		if ok {
+			creds[idx].RateLimit = inCache.RateLimit
+		}
+	}
 	return creds, nil
 }
 
@@ -48,6 +62,11 @@ func (r *Runner) GetGithubCredentials(ctx context.Context, id uint) (params.Gith
 	creds, err := r.store.GetGithubCredentials(ctx, id, true)
 	if err != nil {
 		return params.GithubCredentials{}, errors.Wrap(err, "failed to get github credentials")
+	}
+
+	cached, ok := cache.GetGithubCredentials((creds.ID))
+	if ok {
+		creds.RateLimit = cached.RateLimit
 	}
 
 	return creds, nil

--- a/workers/scaleset/controller.go
+++ b/workers/scaleset/controller.go
@@ -233,8 +233,8 @@ func (c *Controller) waitForErrorGroupOrContextCancelled(g *errgroup.Group) erro
 func (c *Controller) loop() {
 	defer c.Stop()
 
-	consilidateTicker := time.NewTicker(common.PoolReapTimeoutInterval)
-	defer consilidateTicker.Stop()
+	consolidateTicker := time.NewTicker(common.PoolReapTimeoutInterval)
+	defer consolidateTicker.Stop()
 
 	for {
 		select {
@@ -244,10 +244,10 @@ func (c *Controller) loop() {
 				return
 			}
 			slog.InfoContext(c.ctx, "received payload")
-			go c.handleWatcherEvent(payload)
+			c.handleWatcherEvent(payload)
 		case <-c.ctx.Done():
 			return
-		case _, ok := <-consilidateTicker.C:
+		case _, ok := <-consolidateTicker.C:
 			if !ok {
 				slog.InfoContext(c.ctx, "consolidate ticker closed")
 				return


### PR DESCRIPTION
This change adds a loop that keeps a cache of credentials rate limits as reported by the github API. The cache is updated every 30 seconds and is purely informational for the user.

This change also adds some caching improvements. Functions that return values from the cache as lists, will now sort by ID or creation date.