### PR TITLE
doc/gitea: remove 'version'

### DIFF
--- a/doc/gitea.md
+++ b/doc/gitea.md
@@ -36,8 +36,6 @@ sudo iptables -I DOCKER-USER -j ACCEPT
 Create a docker compose file in `$HOME/compose.yaml`. This docker compose will deploy both gitea and GARM. If you already have a Gitea >=1.24.0, you can edit this docker compose to only deploy GARM. 
 
 ```yaml
-version: "3"
-
 networks:
   default:
     external: false


### PR DESCRIPTION
This field is deprecated:
```
$ docker compose version
Docker Compose version v2.36.2
...
WARN[0000] /home/core/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```