### PR TITLE
Auto increment patch dirty version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ USER_ID=$(shell ((docker --version | grep -q podman) && echo "0" || id -u))
 USER_GROUP=$(shell ((docker --version | grep -q podman) && echo "0" || id -g))
 ROOTDIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 GOPATH ?= $(shell go env GOPATH)
-VERSION ?= $(shell git describe --tags --match='v[0-9]*' --dirty --always)
+VERSION ?= $(shell ./scripts/get-version.sh)
 GARM_REF ?= $(shell git rev-parse --abbrev-ref HEAD)
 GO ?= go
 export GARM_PASSWORD ?= ${GEN_PASSWORD}

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+latest=$(git describe --tags --match='v[0-9]*' --abbrev=0)
+IFS='.' read -r major minor patch <<< "${latest#v}"
+patch=$((patch + 1))
+next="v$major.$minor.$patch"
+commit_info=$(git describe --tags --match='v[0-9]*' --dirty --always)
+
+if [[ "$latest" == "$commit_info" ]]; then
+    echo "$latest"
+else
+    echo "${next}-${commit_info#${latest}-}"
+fi


### PR DESCRIPTION
* resolve semver comparing problems in garm-operator

* if you checkout the exact tag and do make build => version = `<tagname>`
* if you edit a file in the folder => `<tagname, patch incremented by 1>-dirty`
* if you commit the edit to the file in the folder => `<tagname, patch incremented by 1>-<no>-<shortsha>`
Before `<tagname>` was

> I need to cut v0.1.6, but that will happen from the release/v0.1 branch, which will now diverge from main, which will become release/v0.2 as soon as I have time. The nightly build will then report the version as being v0.2.0-000-g0000.

Not until you do tag v2.0.0 and the problem is still there? Or do I miss something.

I mean if make edits and you just run `make build`, I would expect a tag greater than the tag checked out.

A lot of programs consider `<tagname>-dirty` < `<tagname>` and will fail if they require `<tagname>`. Given someone making edits would not expect weird problems due to the version ordering.

See <https://github.com/mercedes-benz/garm-operator/issues/285>

CC @sailorbob134280
