### PR TITLE
Fix sleepWithCancel and ensure closed channel

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -1369,6 +1369,9 @@ func (r *basePoolManager) deleteInstanceFromProvider(ctx context.Context, instan
 }
 
 func (r *basePoolManager) sleepWithCancel(sleepTime time.Duration) (canceled bool) {
+	if sleepTime == 0 {
+		return false
+	}
 	ticker := time.NewTicker(sleepTime)
 	defer ticker.Stop()
 

--- a/workers/cache/tool_cache.go
+++ b/workers/cache/tool_cache.go
@@ -135,6 +135,9 @@ func (t *toolsUpdater) Reset() {
 }
 
 func (t *toolsUpdater) sleepWithCancel(sleepTime time.Duration) (canceled bool) {
+	if sleepTime == 0 {
+		return false
+	}
 	ticker := time.NewTicker(sleepTime)
 	defer ticker.Stop()
 

--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -634,6 +634,9 @@ func (w *Worker) loop() {
 }
 
 func (w *Worker) sleepWithCancel(sleepTime time.Duration) (canceled bool) {
+	if sleepTime == 0 {
+		return false
+	}
 	ticker := time.NewTicker(sleepTime)
 	defer ticker.Stop()
 
@@ -663,10 +666,7 @@ Loop:
 			}
 			continue
 		}
-		// noop if already started. If the scaleset was just enabled, we need to
-		// start the listener here, or the <-w.listener.Wait() channel receive bellow
-		// will block forever, even if we start the listener, as a nil channel will
-		// block forever.
+		// noop if already started.
 		if err := w.listener.Start(); err != nil {
 			slog.ErrorContext(w.ctx, "error starting listener", "error", err, "consumer_id", w.consumerID)
 			if canceled := w.sleepWithCancel(2 * time.Second); canceled {


### PR DESCRIPTION
* time.NewTicker will panic if the duration is 0. Make it return early if duration is 0.
* Return a pre-closed channel in Wait() instead of nil. Ensures receiver will not block forever.

I need to create a common type for workers and de-duplicate some of the code, now that we have a clear pattern in how they are set up.