### PR TITLE
Refactor CI/CD builds

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,14 +1,16 @@
-name: "Build GARM images"
+name: "Build and push GARM images"
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       push_to_project:
         description: "Project to build images for"
         required: true
+        type: string
         default: "ghcr.io/cloudbase"
       ref:
         description: "Ref to build"
         required: true
+        type: string
         default: "main"
   schedule:
     - cron: "0 2 * * *"
@@ -24,8 +26,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: "Checkout"
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
+            ref: ${{ inputs.ref }}
             path: src/github.com/cloudbase/garm
             fetch-depth: 0
 
@@ -40,15 +43,12 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Build and push
+          env:
+            REGISTRY_INPUT: ${{ inputs.push_to_project }}
+            GH_REF: ${{ inputs.ref }}
+          working-directory: src/github.com/cloudbase/garm
           run: |
             set -x
-            REGISTRY_INPUT="${{ github.event.inputs.push_to_project }}"
-            REF_INPUT="${{ github.event.inputs.ref }}"
-
-            PUSH_TO_PROJECT="${REGISTRY_INPUT:-ghcr.io/cloudbase}"
-            GH_REF="${REF_INPUT:-main}"
-            cd src/github.com/cloudbase/garm && git checkout "${GH_REF}"
-
             VERSION=$(git describe --tags --match='v[0-9]*' --always)
             AZURE_REF=v0.1.0
             OPENSTACK_REF=v0.1.0
@@ -68,6 +68,9 @@ jobs:
               EQUINIX_REF="main"
               K8S_REF="main"
               VERSION="nightly"
+            fi
+            if [ "$GH_REF" == "release/v1" ]; then
+              VERSION="v0.1"
             fi
             docker buildx build \
               --provenance=false \

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -48,7 +48,6 @@ jobs:
             GH_REF: ${{ inputs.ref }}
           working-directory: src/github.com/cloudbase/garm
           run: |
-            set -x
             if [ "$GH_REF" == "main" ]; then
               VERSION="nightly"
             else
@@ -67,5 +66,5 @@ jobs:
               --label "org.opencontainers.image.description=GARM ${GH_REF}" \
               --label "org.opencontainers.image.licenses=Apache 2.0" \
               --build-arg="GARM_REF=${GH_REF}" \
-              -t ${PUSH_TO_PROJECT}/garm:"${VERSION}" \
+              -t ${REGISTRY_INPUT}/garm:"${VERSION}" \
               --push .

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -78,10 +78,10 @@ jobs:
               LINODE_REF=$(get_gh_latest_release flatcar/garm-provider-linode)
               K8S_REF=$(get_gh_latest_release mercedes-benz/garm-provider-k8s)
             fi
-            if [ "$GH_REF" == "release/v1" ]; then
+            if [ "$GH_REF" == "release/v0.1" ]; then
               VERSION="v0.1"
             fi
-            if [ "$GH_REF" == "release/v2" ]; then
+            if [ "$GH_REF" == "release/v0.2" ]; then
               VERSION="v0.2"
             fi
             docker buildx build \

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -48,35 +48,11 @@ jobs:
             GH_REF: ${{ inputs.ref }}
           working-directory: src/github.com/cloudbase/garm
           run: |
-            get_gh_latest_release() {
-              curl -s -L -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/$1/latest" \
-              | jq -r '.tag_name'
-            }
             set -x
             if [ "$GH_REF" == "main" ]; then
               VERSION="nightly"
-              AZURE_REF="main"
-              OPENSTACK_REF="main"
-              LXD_REF="main"
-              INCUS_REF="main"
-              AWS_REF="main"
-              GCP_REF="main"
-              EQUINIX_REF="main"
-              LINODE_REF="main"
-              K8S_REF="main"
             else
               VERSION=$(git describe --tags --match='v[0-9]*' --always)
-              AZURE_REF=$(get_gh_latest_release cloudbase/garm-provider-azure)
-              OPENSTACK_REF=$(get_gh_latest_release cloudbase/garm-provider-openstack)
-              LXD_REF=$(get_gh_latest_release cloudbase/garm-provider-lxd)
-              INCUS_REF=$(get_gh_latest_release cloudbase/garm-provider-incus)
-              AWS_REF=$(get_gh_latest_release cloudbase/garm-provider-aws)
-              GCP_REF=$(get_gh_latest_release cloudbase/garm-provider-gcp)
-              EQUINIX_REF=$(get_gh_latest_release cloudbase/garm-provider-equinix)
-              LINODE_REF=$(get_gh_latest_release flatcar/garm-provider-linode)
-              K8S_REF=$(get_gh_latest_release mercedes-benz/garm-provider-k8s)
             fi
             if [ "$GH_REF" == "release/v0.1" ]; then
               VERSION="v0.1"
@@ -91,13 +67,5 @@ jobs:
               --label "org.opencontainers.image.description=GARM ${GH_REF}" \
               --label "org.opencontainers.image.licenses=Apache 2.0" \
               --build-arg="GARM_REF=${GH_REF}" \
-              --build-arg="AZURE_REF=${AZURE_REF}" \
-              --build-arg="OPENSTACK_REF=${OPENSTACK_REF}" \
-              --build-arg="LXD_REF=${LXD_REF}" \
-              --build-arg="INCUS_REF=${INCUS_REF}" \
-              --build-arg="AWS_REF=${AWS_REF}" \
-              --build-arg="GCP_REF=${GCP_REF}" \
-              --build-arg="EQUINIX_REF=${EQUINIX_REF}" \
-              --build-arg="K8S_REF=${K8S_REF}" \
               -t ${PUSH_TO_PROJECT}/garm:"${VERSION}" \
               --push .

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -48,17 +48,15 @@ jobs:
             GH_REF: ${{ inputs.ref }}
           working-directory: src/github.com/cloudbase/garm
           run: |
+            get_gh_latest_release() {
+              curl -s -L -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/$1/latest" \
+              | jq -r '.tag_name'
+            }
             set -x
-            VERSION=$(git describe --tags --match='v[0-9]*' --always)
-            AZURE_REF=v0.1.0
-            OPENSTACK_REF=v0.1.0
-            LXD_REF=v0.1.0
-            INCUS_REF=v0.1.0
-            AWS_REF=v0.1.0
-            GCP_REF=v0.1.0
-            EQUINIX_REF=v0.1.0
-            K8S_REF=v0.3.2
             if [ "$GH_REF" == "main" ]; then
+              VERSION="nightly"
               AZURE_REF="main"
               OPENSTACK_REF="main"
               LXD_REF="main"
@@ -66,11 +64,25 @@ jobs:
               AWS_REF="main"
               GCP_REF="main"
               EQUINIX_REF="main"
+              LINODE_REF="main"
               K8S_REF="main"
-              VERSION="nightly"
+            else
+              VERSION=$(git describe --tags --match='v[0-9]*' --always)
+              AZURE_REF=$(get_gh_latest_release cloudbase/garm-provider-azure)
+              OPENSTACK_REF=$(get_gh_latest_release cloudbase/garm-provider-openstack)
+              LXD_REF=$(get_gh_latest_release cloudbase/garm-provider-lxd)
+              INCUS_REF=$(get_gh_latest_release cloudbase/garm-provider-incus)
+              AWS_REF=$(get_gh_latest_release cloudbase/garm-provider-aws)
+              GCP_REF=$(get_gh_latest_release cloudbase/garm-provider-gcp)
+              EQUINIX_REF=$(get_gh_latest_release cloudbase/garm-provider-equinix)
+              LINODE_REF=$(get_gh_latest_release flatcar/garm-provider-linode)
+              K8S_REF=$(get_gh_latest_release mercedes-benz/garm-provider-k8s)
             fi
             if [ "$GH_REF" == "release/v1" ]; then
               VERSION="v0.1"
+            fi
+            if [ "$GH_REF" == "release/v2" ]; then
+              VERSION="v0.2"
             fi
             docker buildx build \
               --provenance=false \

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,22 +42,16 @@ jobs:
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
-        - name: Build and push
+        - name: Build and push image
           env:
-            REGISTRY_INPUT: ${{ inputs.push_to_project }}
+            IMAGE_REGISTRY: ${{ inputs.push_to_project }}
             GH_REF: ${{ inputs.ref }}
           working-directory: src/github.com/cloudbase/garm
           run: |
             if [ "$GH_REF" == "main" ]; then
-              VERSION="nightly"
+              IMAGE_TAG="nightly"
             else
-              VERSION=$(git describe --tags --match='v[0-9]*' --always)
-            fi
-            if [ "$GH_REF" == "release/v0.1" ]; then
-              VERSION="v0.1"
-            fi
-            if [ "$GH_REF" == "release/v0.2" ]; then
-              VERSION="v0.2"
+              IMAGE_TAG=$(git describe --tags --match='v[0-9]*' --always)
             fi
             docker buildx build \
               --provenance=false \
@@ -66,5 +60,5 @@ jobs:
               --label "org.opencontainers.image.description=GARM ${GH_REF}" \
               --label "org.opencontainers.image.licenses=Apache 2.0" \
               --build-arg="GARM_REF=${GH_REF}" \
-              -t ${REGISTRY_INPUT}/garm:"${VERSION}" \
+              -t ${IMAGE_REGISTRY}/garm:"${IMAGE_TAG}" \
               --push .

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,16 +4,14 @@ on:
     inputs:
       push_to_project:
         description: "Project to build images for"
-        required: true
+        required: false
         type: string
         default: "ghcr.io/cloudbase"
       ref:
         description: "Ref to build"
-        required: true
+        required: false
         type: string
         default: "main"
-  schedule:
-    - cron: "0 2 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/trigger-manual.yml
+++ b/.github/workflows/trigger-manual.yml
@@ -1,0 +1,19 @@
+name: Manual build of GARM images
+on:
+  workflow_dispatch:
+    inputs:
+      push_to_project:
+        description: "Project to build images for"
+        required: true
+        default: "ghcr.io/cloudbase"
+      ref:
+        description: "Ref to build"
+        required: true
+        default: "main"
+
+jobs:
+  call-build-and-push:
+    uses: ./.github/workflows/build-and-push.yml
+    with:
+      push_to_project: ${{ inputs.push_to_project }}
+      ref: ${{ inputs.ref }}

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -1,0 +1,13 @@
+name: Nightly build of GARM images
+on:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  call-build-and-push:
+    uses: ./.github/workflows/build-and-push.yml
+    strategy:
+      matrix:
+        ref: ["main", "release/v1"]
+    with:
+      ref: ${{ matrix.ref }}

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -6,8 +6,5 @@ on:
 jobs:
   call-build-and-push:
     uses: ./.github/workflows/build-and-push.yml
-    strategy:
-      matrix:
-        ref: ["main", "release/v0.1", "release/v0.2"]
     with:
-      ref: ${{ matrix.ref }}
+      ref: "main"

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -8,6 +8,6 @@ jobs:
     uses: ./.github/workflows/build-and-push.yml
     strategy:
       matrix:
-        ref: ["main", "release/v1"]
+        ref: ["main", "release/v1", "release/v2"]
     with:
       ref: ${{ matrix.ref }}

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -8,6 +8,6 @@ jobs:
     uses: ./.github/workflows/build-and-push.yml
     strategy:
       matrix:
-        ref: ["main", "release/v1", "release/v2"]
+        ref: ["main", "release/v0.1", "release/v0.2"]
     with:
       ref: ${{ matrix.ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG K8S_REF=v0.3.2
 
 LABEL stage=builder
 
-RUN apk add musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers upx
+RUN apk add --no-cache musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers upx
 RUN git config --global --add safe.directory /build
 
 ADD . /build/garm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,60 @@
 FROM docker.io/golang:alpine AS builder
 ARG GARM_REF
-ARG AZURE_REF=v0.1.0
-ARG OPENSTACK_REF=v0.1.0
-ARG LXD_REF=v0.1.0
-ARG INCUS_REF=v0.1.0
-ARG AWS_REF=v0.1.0
-ARG GCP_REF=v0.1.0
-ARG EQUINIX_REF=v0.1.0
-ARG K8S_REF=v0.3.2
 
 LABEL stage=builder
 
-RUN apk add --no-cache musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers upx
-RUN git config --global --add safe.directory /build
+RUN apk add --no-cache musl-dev gcc libtool m4 autoconf g++ make libblkid util-linux-dev git linux-headers upx curl jq
+RUN git config --global --add safe.directory /build && git config --global --add advice.detachedHead false
 
 ADD . /build/garm
-RUN cd /build/garm && git checkout ${GARM_REF}
-RUN git clone --depth 1 --branch ${AZURE_REF} https://github.com/cloudbase/garm-provider-azure /build/garm-provider-azure
-RUN git clone --depth 1 --branch ${OPENSTACK_REF} https://github.com/cloudbase/garm-provider-openstack /build/garm-provider-openstack
-RUN git clone --depth 1 --branch ${LXD_REF} https://github.com/cloudbase/garm-provider-lxd /build/garm-provider-lxd
-RUN git clone --depth 1 --branch ${INCUS_REF} https://github.com/cloudbase/garm-provider-incus /build/garm-provider-incus
-RUN git clone --depth 1 --branch ${AWS_REF} https://github.com/cloudbase/garm-provider-aws /build/garm-provider-aws
-RUN git clone --depth 1 --branch ${GCP_REF} https://github.com/cloudbase/garm-provider-gcp /build/garm-provider-gcp
-RUN git clone --depth 1 --branch ${EQUINIX_REF} https://github.com/cloudbase/garm-provider-equinix /build/garm-provider-equinix
 
-RUN git clone --depth 1 --branch ${K8S_REF} https://github.com/mercedes-benz/garm-provider-k8s /build/garm-provider-k8s
-
-RUN cd /build/garm && go build -o /bin/garm \
-    -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-linkmode external -extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" \
-    /build/garm/cmd/garm && upx /bin/garm
-RUN cd /build/garm/cmd/garm-cli && go build -o /bin/garm-cli \
-    -tags osusergo,netgo,sqlite_omit_load_extension \
-    -ldflags "-linkmode external -extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" \
-    . && upx /bin/garm-cli
-RUN mkdir -p /opt/garm/providers.d
-RUN cd /build/garm-provider-azure && go build -ldflags="-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" -o /opt/garm/providers.d/garm-provider-azure . && upx /opt/garm/providers.d/garm-provider-azure
-RUN cd /build/garm-provider-openstack && go build -ldflags="-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" -o /opt/garm/providers.d/garm-provider-openstack . && upx /opt/garm/providers.d/garm-provider-openstack
-RUN cd /build/garm-provider-lxd && go build -ldflags="-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" -o /opt/garm/providers.d/garm-provider-lxd . && upx /opt/garm/providers.d/garm-provider-lxd
-RUN cd /build/garm-provider-incus && go build -ldflags="-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" -o /opt/garm/providers.d/garm-provider-incus . && upx /opt/garm/providers.d/garm-provider-incus
-RUN cd /build/garm-provider-aws && go build -ldflags="-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" -o /opt/garm/providers.d/garm-provider-aws . && upx /opt/garm/providers.d/garm-provider-aws
-RUN cd /build/garm-provider-gcp && go build -ldflags="-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" -o /opt/garm/providers.d/garm-provider-gcp . && upx /opt/garm/providers.d/garm-provider-gcp
-RUN cd /build/garm-provider-equinix && go build -ldflags="-linkmode external -extldflags '-static' -s -w -X main.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" -o /opt/garm/providers.d/garm-provider-equinix . && upx /opt/garm/providers.d/garm-provider-equinix
-
-RUN cd /build/garm-provider-k8s/cmd/garm-provider-k8s && go build -ldflags="-linkmode external -extldflags '-static' -s -w" -o /opt/garm/providers.d/garm-provider-k8s . && upx /opt/garm/providers.d/garm-provider-k8s
+RUN cd /build/garm && git checkout ${GARM_REF} \
+    && go build -o /bin/garm \
+      -tags osusergo,netgo,sqlite_omit_load_extension \
+      -ldflags "-linkmode external -extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" \
+      /build/garm/cmd/garm && upx /bin/garm
+RUN cd /build/garm/cmd/garm-cli \
+    && go build -o /bin/garm-cli \
+      -tags osusergo,netgo,sqlite_omit_load_extension \
+      -ldflags "-linkmode external -extldflags '-static' -s -w -X github.com/cloudbase/garm/util/appdefaults.Version=$(git describe --tags --match='v[0-9]*' --dirty --always)" \
+      . && upx /bin/garm-cli
+RUN mkdir -p /opt/garm/providers.d; \
+    for repo in \
+      cloudbase/garm-provider-azure \
+      cloudbase/garm-provider-openstack \
+      cloudbase/garm-provider-lxd \
+      cloudbase/garm-provider-incus \
+      cloudbase/garm-provider-aws \
+      cloudbase/garm-provider-gcp \
+      cloudbase/garm-provider-equinix \
+      flatcar/garm-provider-linode \
+      mercedes-benz/garm-provider-k8s; \
+    do \
+        export PROVIDER_NAME="$(basename $repo)"; \
+        export PROVIDER_SUBDIR=""; \
+        if [ "$GARM_REF" == "main" ]; then \
+          export PROVIDER_TAG="main"; \
+        else \
+          export PROVIDER_TAG="$(curl -s -L https://api.github.com/repos/$repo/releases/latest | jq -r '.tag_name')"; \
+        fi; \
+        case $PROVIDER_NAME in \
+        "garm-provider-k8s") \
+            export PROVIDER_TAG=v0.3.1; \
+            export PROVIDER_SUBDIR="cmd/garm-provider-k8s"; \
+            export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w"; \
+            ;; \
+        "garm-provider-linode") \
+            export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w"; \
+            ;; \
+        *) \
+            export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w -X main.Version=$PROVIDER_TAG"; \
+            ;; \
+        esac; \
+        git clone --depth 1 --branch "$PROVIDER_TAG" "https://github.com/$repo" "/build/$PROVIDER_NAME" \
+        && cd "/build/$PROVIDER_NAME/$PROVIDER_SUBDIR" \
+        && go build -ldflags="$PROVIDER_LDFLAGS" -o /opt/garm/providers.d/$PROVIDER_NAME . \
+        && upx /opt/garm/providers.d/$PROVIDER_NAME; \
+    done
 
 FROM busybox
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ RUN set -e; \
         "garm-provider-k8s") \
             export PROVIDER_SUBDIR="cmd/garm-provider-k8s"; \
             export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w"; \
-            git -C /build/garm-provider-k8s checkout v0.3.1; \
             ;; \
         "garm-provider-linode") \
             export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w"; \
@@ -53,7 +52,7 @@ RUN set -e; \
             export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w -X main.Version=$(git -C /build/$PROVIDER_NAME describe --tags --match='v[0-9]*' --dirty --always)"; \
             ;; \
         esac; \
-        && cd "/build/$PROVIDER_NAME/$PROVIDER_SUBDIR" \
+        cd "/build/$PROVIDER_NAME/$PROVIDER_SUBDIR" \
         && go build -ldflags="$PROVIDER_LDFLAGS" -o /opt/garm/providers.d/$PROVIDER_NAME . \
         && upx /opt/garm/providers.d/$PROVIDER_NAME; \
     done

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,11 +35,11 @@ RUN set -e; \
         export PROVIDER_NAME="$(basename $repo)"; \
         export PROVIDER_SUBDIR=""; \
         if [ "$GARM_REF" == "main" ]; then \
-          export PROVIDER_TAG="main"; \
+          export PROVIDER_REF="main"; \
         else \
-          export PROVIDER_TAG="$(curl -s -L https://api.github.com/repos/$repo/releases/latest | jq -r '.tag_name')"; \
+          export PROVIDER_REF="$(curl -s -L https://api.github.com/repos/$repo/releases/latest | jq -r '.tag_name')"; \
         fi; \
-        git clone --branch "$PROVIDER_TAG" "https://github.com/$repo" "/build/$PROVIDER_NAME"; \
+        git clone --branch "$PROVIDER_REF" "https://github.com/$repo" "/build/$PROVIDER_NAME"; \
         case $PROVIDER_NAME in \
         "garm-provider-k8s") \
             export PROVIDER_SUBDIR="cmd/garm-provider-k8s"; \
@@ -49,7 +49,8 @@ RUN set -e; \
             export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w"; \
             ;; \
         *) \
-            export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w -X main.Version=$(git -C /build/$PROVIDER_NAME describe --tags --match='v[0-9]*' --dirty --always)"; \
+            export PROVIDER_VERSION=$(git -C /build/$PROVIDER_NAME describe --tags --match='v[0-9]*' --dirty --always); \
+            export PROVIDER_LDFLAGS="-linkmode external -extldflags \"-static\" -s -w -X main.Version=$PROVIDER_VERSION"; \
             ;; \
         esac; \
         cd "/build/$PROVIDER_NAME/$PROVIDER_SUBDIR" \


### PR DESCRIPTION
This P/R makes the workflows a bit cleaner and enable the build and push of 2 versions of garm images.

* The providers branch computation is done inside the Dockerfile now
* It automatically computes the latest (non pre-release) release of each provider before cloning