### PR TITLE
Handle new jobID for scale sets

### DIFF
--- a/database/sql/models.go
+++ b/database/sql/models.go
@@ -319,6 +319,12 @@ type User struct {
 type WorkflowJob struct {
 	// ID is the ID of the job.
 	ID int64 `gorm:"index"`
+
+	// WorkflowJobID is the ID of the workflow job.
+	WorkflowJobID int64 `gorm:"index:workflow_job_id_idx"`
+	// ScaleSetJobID is the job ID for a scaleset job.
+	ScaleSetJobID string `gorm:"index:scaleset_job_id_idx"`
+
 	// RunID is the ID of the workflow run. A run may have multiple jobs.
 	RunID int64
 	// Action is the specific activity that triggered the event.

--- a/params/github.go
+++ b/params/github.go
@@ -420,7 +420,6 @@ func (r RunnerScaleSetMessage) GetJobsFromBody() ([]ScaleSetJobMessage, error) {
 	if r.Body == "" {
 		return nil, fmt.Errorf("no body specified")
 	}
-
 	if err := json.Unmarshal([]byte(r.Body), &body); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal body: %w", err)
 	}
@@ -519,6 +518,7 @@ type RunnerGroupList struct {
 
 type ScaleSetJobMessage struct {
 	MessageType        string    `json:"messageType,omitempty"`
+	JobID              string    `json:"jobId,omitempty"`
 	RunnerRequestID    int64     `json:"runnerRequestId,omitempty"`
 	RepositoryName     string    `json:"repositoryName,omitempty"`
 	OwnerName          string    `json:"ownerName,omitempty"`
@@ -552,7 +552,7 @@ func (s ScaleSetJobMessage) MessageTypeToStatus() JobStatus {
 
 func (s ScaleSetJobMessage) ToJob() Job {
 	return Job{
-		ID:              s.RunnerRequestID,
+		ScaleSetJobID:   s.JobID,
 		Action:          s.EventName,
 		RunID:           s.WorkflowRunID,
 		Status:          string(s.MessageTypeToStatus()),

--- a/params/params.go
+++ b/params/params.go
@@ -1035,6 +1035,10 @@ func (p RunnerPrefix) GetRunnerPrefix() string {
 type Job struct {
 	// ID is the ID of the job.
 	ID int64 `json:"id,omitempty"`
+
+	WorkflowJobID int64 `json:"workflow_job_id,omitempty"`
+	// ScaleSetJobID is the job ID when generated for a scale set.
+	ScaleSetJobID string `json:"scaleset_job_id,omitempty"`
 	// RunID is the ID of the workflow run. A run may have multiple jobs.
 	RunID int64 `json:"run_id,omitempty"`
 	// Action is the specific activity that triggered the event.

--- a/workers/scaleset/scaleset_helper.go
+++ b/workers/scaleset/scaleset_helper.go
@@ -80,7 +80,7 @@ func (w *Worker) recordOrUpdateJob(job params.ScaleSetJobMessage) error {
 	case params.ForgeEntityTypeOrganization:
 		jobParams.OrgID = &asUUID
 	default:
-		return fmt.Errorf("unknown entity type: %s", entity.EntityType)
+		return fmt.Errorf("unknown entity type: %s --> %s", entity.EntityType, entity)
 	}
 
 	if _, jobErr := w.store.CreateOrUpdateJob(w.ctx, jobParams); jobErr != nil {
@@ -163,6 +163,7 @@ func (w *Worker) HandleJobsStarted(jobs []params.ScaleSetJobMessage) (err error)
 }
 
 func (w *Worker) HandleJobsAvailable(jobs []params.ScaleSetJobMessage) error {
+	slog.DebugContext(w.ctx, "handling jobs available", "jobs", jobs)
 	for _, job := range jobs {
 		if err := w.recordOrUpdateJob(job); err != nil {
 			// recording scale set jobs are purely informational for now.


### PR DESCRIPTION
There seems to be a change in the scale set message. It now includes a jobID and sets the runner request ID to 0. This change adds separate job ID fields for workflow jobs and scaleset jobs.

Revisit the implementation of this.