### PR TITLE
Get the image tag from supplied ref

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -48,7 +48,7 @@ jobs:
             if [ "$GH_REF" == "main" ]; then
               IMAGE_TAG="nightly"
             else
-              IMAGE_TAG=$(git describe --tags --match='v[0-9]*' --always)
+              IMAGE_TAG=$(git describe --tags --match='v[0-9]*' --always ${GH_REF})
             fi
             docker buildx build \
               --provenance=false \


### PR DESCRIPTION
We need to pass the ref used in the workflow. If we supply a tag, we should just get that same tag. If we supply a branch, we should get the latest release from that branch.