### PR TITLE
fix(jobs): Correctly handle workflow job IDs from webhooks

### DIFF
--- a/database/sql/jobs.go
+++ b/database/sql/jobs.go
@@ -248,7 +248,7 @@ func (s *sqlDatabase) CreateOrUpdateJob(ctx context.Context, job params.Job) (pa
 	var err error
 
 	searchField := "workflow_job_id = ?"
-	var searchVal any = job.ID
+	var searchVal any = job.WorkflowJobID
 	if job.ScaleSetJobID != "" {
 		searchField = "scale_set_job_id = ?"
 		searchVal = job.ScaleSetJobID

--- a/database/sql/jobs.go
+++ b/database/sql/jobs.go
@@ -79,7 +79,7 @@ func (s *sqlDatabase) paramsJobToWorkflowJob(ctx context.Context, job params.Job
 
 	workflofJob := WorkflowJob{
 		ScaleSetJobID:   job.ScaleSetJobID,
-		WorkflowJobID:   job.ID,
+		WorkflowJobID:   job.WorkflowJobID,
 		RunID:           job.RunID,
 		Action:          job.Action,
 		Status:          job.Status,
@@ -149,7 +149,7 @@ func (s *sqlDatabase) LockJob(_ context.Context, jobID int64, entityID string) e
 		return fmt.Errorf("error parsing entity id: %w", err)
 	}
 	var workflowJob WorkflowJob
-	q := s.conn.Preload("Instance").Where("id = ?", jobID).First(&workflowJob)
+	q := s.conn.Preload("Instance").Where("workflow_job_id = ?", jobID).First(&workflowJob)
 
 	if q.Error != nil {
 		if errors.Is(q.Error, gorm.ErrRecordNotFound) {

--- a/database/watcher/watcher_store_test.go
+++ b/database/watcher/watcher_store_test.go
@@ -50,12 +50,12 @@ func (s *WatcherStoreTestSuite) TestJobWatcher() {
 	consumeEvents(consumer)
 
 	jobParams := params.Job{
-		ID:         1,
-		RunID:      2,
-		Action:     "test-action",
-		Conclusion: "started",
-		Status:     "in_progress",
-		Name:       "test-job",
+		WorkflowJobID: 2,
+		RunID:         2,
+		Action:        "test-action",
+		Conclusion:    "started",
+		Status:        "in_progress",
+		Name:          "test-job",
 	}
 
 	job, err := s.store.CreateOrUpdateJob(s.ctx, jobParams)
@@ -76,8 +76,8 @@ func (s *WatcherStoreTestSuite) TestJobWatcher() {
 		s.T().Fatal("expected payload not received")
 	}
 
-	jobParams.Conclusion = "success"
-	updatedJob, err := s.store.CreateOrUpdateJob(s.ctx, jobParams)
+	job.Conclusion = "success"
+	updatedJob, err := s.store.CreateOrUpdateJob(s.ctx, job)
 	s.Require().NoError(err)
 
 	select {
@@ -94,7 +94,7 @@ func (s *WatcherStoreTestSuite) TestJobWatcher() {
 	entityID, err := uuid.NewUUID()
 	s.Require().NoError(err)
 
-	err = s.store.LockJob(s.ctx, updatedJob.ID, entityID.String())
+	err = s.store.LockJob(s.ctx, updatedJob.WorkflowJobID, entityID.String())
 	s.Require().NoError(err)
 
 	select {
@@ -110,7 +110,7 @@ func (s *WatcherStoreTestSuite) TestJobWatcher() {
 		s.T().Fatal("expected payload not received")
 	}
 
-	err = s.store.UnlockJob(s.ctx, updatedJob.ID, entityID.String())
+	err = s.store.UnlockJob(s.ctx, updatedJob.WorkflowJobID, entityID.String())
 	s.Require().NoError(err)
 
 	select {
@@ -134,7 +134,7 @@ func (s *WatcherStoreTestSuite) TestJobWatcher() {
 	// We don't care about the update event here.
 	consumeEvents(consumer)
 
-	err = s.store.BreakLockJobIsQueued(s.ctx, updatedJob.ID)
+	err = s.store.BreakLockJobIsQueued(s.ctx, updatedJob.WorkflowJobID)
 	s.Require().NoError(err)
 
 	select {


### PR DESCRIPTION
### Problem

Previously, `garm` was not automatically creating new runners when new jobs appeared in Gitea. This was happening because the system was getting confused about job identification.

Here's what went wrong:

1.  **Saving Job Data:** When `garm` tried to save information about a new job into its database, it was accidentally using its own internal database ID for the job, instead of the unique job ID provided by Gitea. So,
    the database record ended up with the wrong external ID.
2.  **Looking Up Jobs:** Later, when `garm` received updates about these jobs (like a webhook saying a job started), it tried to find the job in its database. But it was looking for the job using the unique ID from  
    Gitea, and trying to match it against its _own internal database ID_. Since the IDs didn't match (because of the first problem), `garm` couldn't find the job.

Because `garm` couldn't correctly identify the jobs, it failed to queue new runners for them.

### Solution

This change fixes how `garm` handles job IDs:

1.  **Correct Saving:** Now, when job information is saved, `garm` correctly stores the unique job ID from GitHub/Gitea in the right place in its database record.
2.  **Correct Lookup:** When `garm` needs to find a job, it now correctly searches using the unique job ID from GitHub/Gitea against the corresponding field in its database.

These fixes ensure that `garm` can properly understand and track jobs from GitHub/Gitea, allowing it to automatically create and manage runners as expected.
