### PR TITLE
Ensure scale set exists

### DIFF
--- a/database/sql/scalesets.go
+++ b/database/sql/scalesets.go
@@ -294,6 +294,10 @@ func (s *sqlDatabase) updateScaleSet(tx *gorm.DB, scaleSet ScaleSet, param param
 		scaleSet.ExtendedState = *param.ExtendedState
 	}
 
+	if param.ScaleSetID != 0 {
+		scaleSet.ScaleSetID = param.ScaleSetID
+	}
+
 	if param.Name != "" {
 		scaleSet.Name = param.Name
 	}

--- a/params/requests.go
+++ b/params/requests.go
@@ -636,6 +636,7 @@ type UpdateScaleSetParams struct {
 	GitHubRunnerGroup *string        `json:"runner_group,omitempty"`
 	State             *ScaleSetState `json:"state"`
 	ExtendedState     *string        `json:"extended_state"`
+	ScaleSetID        int            `json:"-"`
 }
 
 // swagger:model CreateGiteaEndpointParams

--- a/runner/common/mocks/GithubClient.go
+++ b/runner/common/mocks/GithubClient.go
@@ -385,6 +385,63 @@ func (_c *GithubClient_GetEntityJITConfig_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// GetEntityRunnerGroupIDByName provides a mock function with given fields: ctx, runnerGroupName
+func (_m *GithubClient) GetEntityRunnerGroupIDByName(ctx context.Context, runnerGroupName string) (int64, error) {
+	ret := _m.Called(ctx, runnerGroupName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEntityRunnerGroupIDByName")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (int64, error)); ok {
+		return rf(ctx, runnerGroupName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) int64); ok {
+		r0 = rf(ctx, runnerGroupName)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, runnerGroupName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GithubClient_GetEntityRunnerGroupIDByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityRunnerGroupIDByName'
+type GithubClient_GetEntityRunnerGroupIDByName_Call struct {
+	*mock.Call
+}
+
+// GetEntityRunnerGroupIDByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - runnerGroupName string
+func (_e *GithubClient_Expecter) GetEntityRunnerGroupIDByName(ctx interface{}, runnerGroupName interface{}) *GithubClient_GetEntityRunnerGroupIDByName_Call {
+	return &GithubClient_GetEntityRunnerGroupIDByName_Call{Call: _e.mock.On("GetEntityRunnerGroupIDByName", ctx, runnerGroupName)}
+}
+
+func (_c *GithubClient_GetEntityRunnerGroupIDByName_Call) Run(run func(ctx context.Context, runnerGroupName string)) *GithubClient_GetEntityRunnerGroupIDByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *GithubClient_GetEntityRunnerGroupIDByName_Call) Return(_a0 int64, _a1 error) *GithubClient_GetEntityRunnerGroupIDByName_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GithubClient_GetEntityRunnerGroupIDByName_Call) RunAndReturn(run func(context.Context, string) (int64, error)) *GithubClient_GetEntityRunnerGroupIDByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetWorkflowJobByID provides a mock function with given fields: ctx, owner, repo, jobID
 func (_m *GithubClient) GetWorkflowJobByID(ctx context.Context, owner string, repo string, jobID int64) (*github.WorkflowJob, *github.Response, error) {
 	ret := _m.Called(ctx, owner, repo, jobID)

--- a/runner/common/mocks/GithubEntityOperations.go
+++ b/runner/common/mocks/GithubEntityOperations.go
@@ -385,6 +385,63 @@ func (_c *GithubEntityOperations_GetEntityJITConfig_Call) RunAndReturn(run func(
 	return _c
 }
 
+// GetEntityRunnerGroupIDByName provides a mock function with given fields: ctx, runnerGroupName
+func (_m *GithubEntityOperations) GetEntityRunnerGroupIDByName(ctx context.Context, runnerGroupName string) (int64, error) {
+	ret := _m.Called(ctx, runnerGroupName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetEntityRunnerGroupIDByName")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (int64, error)); ok {
+		return rf(ctx, runnerGroupName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) int64); ok {
+		r0 = rf(ctx, runnerGroupName)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, runnerGroupName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GithubEntityOperations_GetEntityRunnerGroupIDByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEntityRunnerGroupIDByName'
+type GithubEntityOperations_GetEntityRunnerGroupIDByName_Call struct {
+	*mock.Call
+}
+
+// GetEntityRunnerGroupIDByName is a helper method to define mock.On call
+//   - ctx context.Context
+//   - runnerGroupName string
+func (_e *GithubEntityOperations_Expecter) GetEntityRunnerGroupIDByName(ctx interface{}, runnerGroupName interface{}) *GithubEntityOperations_GetEntityRunnerGroupIDByName_Call {
+	return &GithubEntityOperations_GetEntityRunnerGroupIDByName_Call{Call: _e.mock.On("GetEntityRunnerGroupIDByName", ctx, runnerGroupName)}
+}
+
+func (_c *GithubEntityOperations_GetEntityRunnerGroupIDByName_Call) Run(run func(ctx context.Context, runnerGroupName string)) *GithubEntityOperations_GetEntityRunnerGroupIDByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *GithubEntityOperations_GetEntityRunnerGroupIDByName_Call) Return(_a0 int64, _a1 error) *GithubEntityOperations_GetEntityRunnerGroupIDByName_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GithubEntityOperations_GetEntityRunnerGroupIDByName_Call) RunAndReturn(run func(context.Context, string) (int64, error)) *GithubEntityOperations_GetEntityRunnerGroupIDByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GithubBaseURL provides a mock function with no fields
 func (_m *GithubEntityOperations) GithubBaseURL() *url.URL {
 	ret := _m.Called()

--- a/runner/common/util.go
+++ b/runner/common/util.go
@@ -35,6 +35,7 @@ type GithubEntityOperations interface {
 	RateLimit(ctx context.Context) (*github.RateLimits, error)
 	CreateEntityRegistrationToken(ctx context.Context) (*github.RegistrationToken, *github.Response, error)
 	GetEntityJITConfig(ctx context.Context, instance string, pool params.Pool, labels []string) (jitConfigMap map[string]string, runner *github.Runner, err error)
+	GetEntityRunnerGroupIDByName(ctx context.Context, runnerGroupName string) (int64, error)
 
 	// GetEntity returns the GitHub entity for which the github client was instanciated.
 	GetEntity() params.ForgeEntity

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -771,8 +771,7 @@ func (r *basePoolManager) AddRunner(ctx context.Context, poolID string, aditiona
 		// Attempt to create JIT config
 		jitConfig, runner, err = r.ghcli.GetEntityJITConfig(ctx, name, pool, labels)
 		if err != nil {
-			slog.With(slog.Any("error", err)).ErrorContext(
-				ctx, "failed to get JIT config, falling back to registration token")
+			return fmt.Errorf("failed to generate JIT config: %w", err)
 		}
 	}
 

--- a/runner/pool/stub_client.go
+++ b/runner/pool/stub_client.go
@@ -82,3 +82,7 @@ func (s *stubGithubClient) GithubBaseURL() *url.URL {
 func (s *stubGithubClient) RateLimit(_ context.Context) (*github.RateLimits, error) {
 	return nil, s.err
 }
+
+func (s *stubGithubClient) GetEntityRunnerGroupIDByName(_ context.Context, _ string) (int64, error) {
+	return 0, s.err
+}

--- a/runner/scalesets.go
+++ b/runner/scalesets.go
@@ -225,13 +225,10 @@ func (r *Runner) CreateEntityScaleSet(ctx context.Context, entityType params.For
 	if err != nil {
 		return params.ScaleSet{}, fmt.Errorf("error getting scaleset client: %w", err)
 	}
-	var runnerGroupID int64 = 1
-	if param.GitHubRunnerGroup != "Default" {
-		runnerGroup, err := scalesetCli.GetRunnerGroupByName(ctx, param.GitHubRunnerGroup)
-		if err != nil {
-			return params.ScaleSet{}, fmt.Errorf("error getting runner group: %w", err)
-		}
-		runnerGroupID = runnerGroup.ID
+
+	runnerGroupID, err := ghCli.GetEntityRunnerGroupIDByName(ctx, param.GitHubRunnerGroup)
+	if err != nil {
+		return params.ScaleSet{}, fmt.Errorf("failed to get github runner group for entity %s: %w", entity.ID, err)
 	}
 
 	createParam := &params.RunnerScaleSet{

--- a/util/github/scalesets/client.go
+++ b/util/github/scalesets/client.go
@@ -57,6 +57,15 @@ func (s *ScaleSetClient) SetGithubClient(cli common.GithubClient) {
 	s.ghCli = cli
 }
 
+func (s *ScaleSetClient) GetGithubClient() (common.GithubClient, error) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	if s.ghCli == nil {
+		return nil, fmt.Errorf("github client is not set in scaleset client")
+	}
+	return s.ghCli, nil
+}
+
 func (s *ScaleSetClient) Do(req *http.Request) (*http.Response, error) {
 	if s.httpClient == nil {
 		return nil, fmt.Errorf("http client is not initialized")

--- a/workers/scaleset/controller.go
+++ b/workers/scaleset/controller.go
@@ -33,7 +33,10 @@ func NewController(ctx context.Context, store dbCommon.Store, entity params.Forg
 
 	ctx = garmUtil.WithSlogContext(
 		ctx,
-		slog.Any("worker", consumerID))
+		slog.Any("worker", consumerID),
+		slog.Any("entity", entity.String()),
+		slog.Any("endpoint", entity.Credentials.Endpoint),
+	)
 
 	return &Controller{
 		ctx:        ctx,


### PR DESCRIPTION
Github will remove inactive scale sets after 7 days. This change ensures the scale set exists in github before spinning up the listener.

This change also caches github runner group IDs so we don't have to fetch it from the API on every runner creation request. The cache expires in 1 hour, so we will get at most one request per runner group per hour. Which should be fine.

The fallback to registration token was also removed. Now, if JIT is enabled and we fail to create a config, no runner is created.