### PR TITLE
Small fixes

### DIFF
--- a/cmd/garm/main.go
+++ b/cmd/garm/main.go
@@ -372,6 +372,13 @@ func main() {
 
 	<-ctx.Done()
 
+	slog.InfoContext(ctx, "shutting down http server")
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer shutdownCancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "graceful api server shutdown failed")
+	}
+
 	if err := cacheWorker.Stop(); err != nil {
 		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to stop credentials worker")
 	}
@@ -384,13 +391,6 @@ func main() {
 	slog.InfoContext(ctx, "shutting down provider worker")
 	if err := providerWorker.Stop(); err != nil {
 		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to stop provider worker")
-	}
-
-	slog.InfoContext(ctx, "shutting down http server")
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer shutdownCancel()
-	if err := srv.Shutdown(shutdownCtx); err != nil {
-		slog.With(slog.Any("error", err)).ErrorContext(ctx, "graceful api server shutdown failed")
 	}
 
 	slog.With(slog.Any("error", err)).InfoContext(ctx, "waiting for runner to stop")


### PR DESCRIPTION
* Shut down the web server first to prevent errors caused by clients trying to use functionality that has already been shut down, causing errors and potentially delaying the shutdown process.
* remove write timeout from the websocket Write() function.