### PR TITLE
Attempt to use the scalset API and caching

### DIFF
--- a/cache/instance_cache.go
+++ b/cache/instance_cache.go
@@ -98,6 +98,22 @@ func (i *InstanceCache) GetInstancesForScaleSet(scaleSetID uint) []params.Instan
 	return filteredInstances
 }
 
+func (i *InstanceCache) GetEntityInstances(entityID string) []params.Instance {
+	pools := GetEntityPools(entityID)
+	poolsAsMap := map[string]bool{}
+	for _, pool := range pools {
+		poolsAsMap[pool.ID] = true
+	}
+
+	ret := []params.Instance{}
+	for _, val := range i.GetAllInstances() {
+		if _, ok := poolsAsMap[val.PoolID]; ok {
+			ret = append(ret, val)
+		}
+	}
+	return ret
+}
+
 func SetInstanceCache(instance params.Instance) {
 	instanceCache.SetInstance(instance)
 }
@@ -120,4 +136,8 @@ func GetInstancesForPool(poolID string) []params.Instance {
 
 func GetInstancesForScaleSet(scaleSetID uint) []params.Instance {
 	return instanceCache.GetInstancesForScaleSet(scaleSetID)
+}
+
+func GetEntityInstances(entityID string) []params.Instance {
+	return instanceCache.GetEntityInstances(entityID)
 }

--- a/params/github.go
+++ b/params/github.go
@@ -427,21 +427,21 @@ func (r RunnerScaleSetMessage) GetJobsFromBody() ([]ScaleSetJobMessage, error) {
 }
 
 type RunnerReference struct {
-	ID                int64       `json:"id"`
-	Name              string      `json:"name"`
-	OS                string      `json:"os"`
-	RunnerScaleSetID  int         `json:"runnerScaleSetId"`
-	CreatedOn         interface{} `json:"createdOn"`
-	RunnerGroupID     uint64      `json:"runnerGroupId"`
-	RunnerGroupName   string      `json:"runnerGroupName"`
-	Version           string      `json:"version"`
-	Enabled           bool        `json:"enabled"`
-	Ephemeral         bool        `json:"ephemeral"`
-	Status            interface{} `json:"status"`
-	DisableUpdate     bool        `json:"disableUpdate"`
-	ProvisioningState string      `json:"provisioningState"`
-	Busy              bool        `json:"busy"`
-	Labels            []Label     `json:"labels,omitempty"`
+	ID                int64   `json:"id"`
+	Name              string  `json:"name"`
+	OS                string  `json:"os"`
+	RunnerScaleSetID  int     `json:"runnerScaleSetId"`
+	CreatedOn         any     `json:"createdOn"`
+	RunnerGroupID     uint64  `json:"runnerGroupId"`
+	RunnerGroupName   string  `json:"runnerGroupName"`
+	Version           string  `json:"version"`
+	Enabled           bool    `json:"enabled"`
+	Ephemeral         bool    `json:"ephemeral"`
+	Status            any     `json:"status"`
+	DisableUpdate     bool    `json:"disableUpdate"`
+	ProvisioningState string  `json:"provisioningState"`
+	Busy              bool    `json:"busy"`
+	Labels            []Label `json:"labels,omitempty"`
 }
 
 func (r RunnerReference) GetStatus() RunnerStatus {

--- a/runner/pool/cache.go
+++ b/runner/pool/cache.go
@@ -1,0 +1,75 @@
+package pool
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
+	"github.com/cloudbase/garm/params"
+)
+
+type poolCacheStore interface {
+	Next() (params.Pool, error)
+	Reset()
+	Len() int
+}
+
+type poolRoundRobin struct {
+	pools []params.Pool
+	next  uint32
+}
+
+func (p *poolRoundRobin) Next() (params.Pool, error) {
+	if len(p.pools) == 0 {
+		return params.Pool{}, runnerErrors.ErrNoPoolsAvailable
+	}
+
+	n := atomic.AddUint32(&p.next, 1)
+	return p.pools[(int(n)-1)%len(p.pools)], nil
+}
+
+func (p *poolRoundRobin) Len() int {
+	return len(p.pools)
+}
+
+func (p *poolRoundRobin) Reset() {
+	atomic.StoreUint32(&p.next, 0)
+}
+
+type poolsForTags struct {
+	pools         sync.Map
+	poolCacheType params.PoolBalancerType
+}
+
+func (p *poolsForTags) Get(tags []string) (poolCacheStore, bool) {
+	sort.Strings(tags)
+	key := strings.Join(tags, "^")
+
+	v, ok := p.pools.Load(key)
+	if !ok {
+		return nil, false
+	}
+	poolCache := v.(*poolRoundRobin)
+	if p.poolCacheType == params.PoolBalancerTypePack {
+		// When we service a list of jobs, we want to try each pool in turn
+		// for each job. Pools are sorted by priority so we always start from the
+		// highest priority pool and move on to the next if the first one is full.
+		poolCache.Reset()
+	}
+	return poolCache, true
+}
+
+func (p *poolsForTags) Add(tags []string, pools []params.Pool) poolCacheStore {
+	sort.Slice(pools, func(i, j int) bool {
+		return pools[i].Priority > pools[j].Priority
+	})
+
+	sort.Strings(tags)
+	key := strings.Join(tags, "^")
+
+	poolRR := &poolRoundRobin{pools: pools}
+	v, _ := p.pools.LoadOrStore(key, poolRR)
+	return v.(*poolRoundRobin)
+}

--- a/workers/entity/util.go
+++ b/workers/entity/util.go
@@ -26,8 +26,7 @@ import (
 const (
 	// These are duplicated until we decide if we move the pool manager to the new
 	// worker flow.
-	poolIDLabelprefix     = "runner-pool-id:"
-	controllerLabelPrefix = "runner-controller-id:"
+	poolIDLabelprefix = "runner-pool-id:"
 )
 
 func composeControllerWatcherFilters() dbCommon.PayloadFilterFunc {


### PR DESCRIPTION
On github, attempt to use the scaleset API to list all runners without pagination. This will avoid missing runners and accidentally removing them.

Fall back to paginated API if we can't use the scaleset API.

Add ability to retrieve all instances from cache, for an entity.