### PR TITLE
Scale sets stability fixes

### DIFF
--- a/workers/scaleset/controller.go
+++ b/workers/scaleset/controller.go
@@ -166,7 +166,7 @@ func (c *Controller) Stop() error {
 
 // ConsolidateRunnerState will send a list of existing github runners to each scale set worker.
 // The scale set worker will then need to cross check the existing runners in Github with the sate
-// in the database. Any inconsistencies will b reconciliated. This cleans up any manually removed
+// in the database. Any inconsistencies will be reconciliated. This cleans up any manually removed
 // runners in either github or the providers.
 func (c *Controller) ConsolidateRunnerState(byScaleSetID map[int][]params.RunnerReference) error {
 	g, ctx := errgroup.WithContext(c.ctx)

--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -131,6 +131,12 @@ func (w *Worker) ensureScaleSetInGitHub() error {
 	if err != nil {
 		return fmt.Errorf("failed to update scale set: %w", err)
 	}
+
+	// The scale set was recreated. We need to reset the last message ID we recorded previously,
+	// otherwise we'll ignore every message we get from the queue.
+	if err := w.SetLastMessageID(0); err != nil {
+		return fmt.Errorf("failed to reset last message id: %w", err)
+	}
 	w.scaleSet.ScaleSetID = runnerScaleSet.ID
 
 	return nil
@@ -615,6 +621,7 @@ func (w *Worker) handleInstanceCleanup(instance params.Instance) error {
 				return fmt.Errorf("deleting instance %s: %w", instance.ID, err)
 			}
 		}
+		delete(w.runners, instance.ID)
 	}
 	return nil
 }

--- a/workers/scaleset/scaleset_listener.go
+++ b/workers/scaleset/scaleset_listener.go
@@ -138,7 +138,7 @@ func (l *scaleSetListener) handleSessionMessage(msg params.RunnerScaleSetMessage
 	}
 
 	if msg.MessageID < l.lastMessageID {
-		slog.DebugContext(l.ctx, "message is older than last message, ignoring")
+		slog.InfoContext(l.ctx, "message is older than last message, ignoring", "received_msg_id", fmt.Sprintf("%d", msg.MessageID), "recorded_msg_id", fmt.Sprintf("%d", l.lastMessageID))
 		return
 	}
 


### PR DESCRIPTION
This change adds a number of fixes for scale sets:

* Reset last message ID when we need to recreate the scale set in GitHub. Message ID gets reset in github when this happens and we end up ignoring messages because we see that they are older than we have recorded.
* Clean up deleted instances from state scale set state
* Properly stop instance handler in the provider worker when an update operation comes in that signals that an instance has been marked as "deleted"