### PR TITLE
Use self-hosted for image build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -21,7 +21,7 @@ jobs:
       permissions:
         packages: write
       name: "Build GARM images"
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-noble-garm
       steps:
         - name: "Checkout"
           uses: actions/checkout@v4


### PR DESCRIPTION
Update image build workflow to use self-hosted runner.