### PR TITLE
Properly return error when checking for fallback

### DIFF
--- a/workers/cache/gitea_tools.go
+++ b/workers/cache/gitea_tools.go
@@ -185,12 +185,13 @@ func getTools(ctx context.Context, metadataURL string, useInternal bool) ([]comm
 			slog.ErrorContext(ctx, "failed to get tools from metadata URL", "error", err)
 			if metadataURL != appdefaults.GiteaRunnerReleasesURL {
 				slog.InfoContext(ctx, "attempting to get tools from default upstream", "tools_url", appdefaults.GiteaRunnerReleasesURL)
-				latest, err = getReleasesFromURL(ctx, metadataURL)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get upstream tools: %w", err)
-				}
+				latest, err = getReleasesFromURL(ctx, appdefaults.GiteaRunnerReleasesURL)
 			}
 		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tools: %w", err)
 	}
 
 	ret := []commonParams.RunnerApplicationDownload{}


### PR DESCRIPTION
The code that attempts to fetch tools from upstream, must return the error if the current setting is the upstream repo.