### PR TITLE
Cache jobs in pool manager

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -568,7 +568,7 @@ func (s *SQLite) Validate() error {
 }
 
 func (s *SQLite) ConnectionString() (string, error) {
-	connectionString := fmt.Sprintf("%s?_journal_mode=WAL&_foreign_keys=ON", s.DBFile)
+	connectionString := fmt.Sprintf("%s?_journal_mode=WAL&_foreign_keys=ON&_txlock=immediate", s.DBFile)
 	if s.BusyTimeoutSeconds > 0 {
 		timeout := s.BusyTimeoutSeconds * 1000
 		connectionString = fmt.Sprintf("%s&_busy_timeout=%d", connectionString, timeout)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -387,13 +387,13 @@ func TestGormParams(t *testing.T) {
 	dbType, uri, err := cfg.GormParams()
 	require.Nil(t, err)
 	require.Equal(t, SQLiteBackend, dbType)
-	require.Equal(t, filepath.Join(dir, "garm.db?_journal_mode=WAL&_foreign_keys=ON"), uri)
+	require.Equal(t, filepath.Join(dir, "garm.db?_journal_mode=WAL&_foreign_keys=ON&_txlock=immediate"), uri)
 
 	cfg.SQLite.BusyTimeoutSeconds = 5
 	dbType, uri, err = cfg.GormParams()
 	require.Nil(t, err)
 	require.Equal(t, SQLiteBackend, dbType)
-	require.Equal(t, filepath.Join(dir, "garm.db?_journal_mode=WAL&_foreign_keys=ON&_busy_timeout=5000"), uri)
+	require.Equal(t, filepath.Join(dir, "garm.db?_journal_mode=WAL&_foreign_keys=ON&_txlock=immediate&_busy_timeout=5000"), uri)
 
 	cfg.DbBackend = MySQLBackend
 	cfg.MySQL = getMySQLDefaultConfig()

--- a/database/sql/pools_test.go
+++ b/database/sql/pools_test.go
@@ -221,6 +221,7 @@ func (s *PoolsTestSuite) TestEntityPoolOperations() {
 
 	createPoolParams := params.CreatePoolParams{
 		ProviderName: "test-provider",
+		MaxRunners:   5,
 		Image:        "test-image",
 		Flavor:       "test-flavor",
 		OSType:       commonParams.Linux,
@@ -301,6 +302,7 @@ func (s *PoolsTestSuite) TestListEntityInstances() {
 
 	createPoolParams := params.CreatePoolParams{
 		ProviderName: "test-provider",
+		MaxRunners:   5,
 		Image:        "test-image",
 		Flavor:       "test-flavor",
 		OSType:       commonParams.Linux,

--- a/database/sql/sql.go
+++ b/database/sql/sql.go
@@ -71,6 +71,7 @@ func newDBConn(dbCfg config.Database) (conn *gorm.DB, err error) {
 	if dbCfg.Debug {
 		conn = conn.Debug()
 	}
+
 	return conn, nil
 }
 

--- a/database/watcher/filters.go
+++ b/database/watcher/filters.go
@@ -183,25 +183,22 @@ func WithEntityJobFilter(ghEntity params.ForgeEntity) dbCommon.PayloadFilterFunc
 
 			switch ghEntity.EntityType {
 			case params.ForgeEntityTypeRepository:
-				if job.RepoID != nil && job.RepoID.String() != ghEntity.ID {
-					return false
+				if job.RepoID != nil && job.RepoID.String() == ghEntity.ID {
+					return true
 				}
 			case params.ForgeEntityTypeOrganization:
-				if job.OrgID != nil && job.OrgID.String() != ghEntity.ID {
-					return false
+				if job.OrgID != nil && job.OrgID.String() == ghEntity.ID {
+					return true
 				}
 			case params.ForgeEntityTypeEnterprise:
-				if job.EnterpriseID != nil && job.EnterpriseID.String() != ghEntity.ID {
-					return false
+				if job.EnterpriseID != nil && job.EnterpriseID.String() == ghEntity.ID {
+					return true
 				}
-			default:
-				return false
 			}
-
-			return true
 		default:
 			return false
 		}
+		return false
 	}
 }
 

--- a/database/watcher/watcher_store_test.go
+++ b/database/watcher/watcher_store_test.go
@@ -179,6 +179,7 @@ func (s *WatcherStoreTestSuite) TestInstanceWatcher() {
 
 	createPoolParams := params.CreatePoolParams{
 		ProviderName: "test-provider",
+		MaxRunners:   5,
 		Image:        "test-image",
 		Flavor:       "test-flavor",
 		OSType:       commonParams.Linux,
@@ -393,6 +394,7 @@ func (s *WatcherStoreTestSuite) TestPoolWatcher() {
 
 	createPoolParams := params.CreatePoolParams{
 		ProviderName: "test-provider",
+		MaxRunners:   5,
 		Image:        "test-image",
 		Flavor:       "test-flavor",
 		OSType:       commonParams.Linux,

--- a/internal/testing/testing.go
+++ b/internal/testing/testing.go
@@ -205,7 +205,8 @@ func GetTestSqliteDBConfig(t *testing.T) config.Database {
 		DbBackend:  config.SQLiteBackend,
 		Passphrase: encryptionPassphrase,
 		SQLite: config.SQLite{
-			DBFile: filepath.Join(dir, "garm.db"),
+			DBFile:             filepath.Join(dir, "garm.db"),
+			BusyTimeoutSeconds: 30, // 30 second timeout for concurrent transactions
 		},
 	}
 }

--- a/params/params.go
+++ b/params/params.go
@@ -1121,6 +1121,26 @@ type Job struct {
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
+func (j Job) BelongsTo(entity ForgeEntity) bool {
+	switch entity.EntityType {
+	case ForgeEntityTypeRepository:
+		if j.RepoID != nil {
+			return entity.ID == j.RepoID.String()
+		}
+	case ForgeEntityTypeEnterprise:
+		if j.EnterpriseID != nil {
+			return entity.ID == j.EnterpriseID.String()
+		}
+	case ForgeEntityTypeOrganization:
+		if j.OrgID != nil {
+			return entity.ID == j.OrgID.String()
+		}
+	default:
+		return false
+	}
+	return false
+}
+
 // swagger:model Jobs
 // used by swagger client generated code
 type Jobs []Job
@@ -1144,13 +1164,13 @@ type CertificateBundle struct {
 	RootCertificates map[string][]byte `json:"root_certificates,omitempty"`
 }
 
-// swagger:model ForgeEntity
 type UpdateSystemInfoParams struct {
 	OSName    string `json:"os_name,omitempty"`
 	OSVersion string `json:"os_version,omitempty"`
 	AgentID   *int64 `json:"agent_id,omitempty"`
 }
 
+// swagger:model ForgeEntity
 type ForgeEntity struct {
 	Owner            string           `json:"owner,omitempty"`
 	Name             string           `json:"name,omitempty"`


### PR DESCRIPTION
This change caches jobs meant for an entity in the pool manager. This allows us to avoid querying the db as much and allows us to better determine when we should scale down.

There are also some changes to the database connection params. We how set `_txlock=immediate`.