### PR TITLE
Add metadata urls

### DIFF
--- a/apiserver/controllers/metadata.go
+++ b/apiserver/controllers/metadata.go
@@ -26,6 +26,21 @@ import (
 	"github.com/cloudbase/garm/apiserver/params"
 )
 
+func (a *APIController) InstanceMetadataHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	metadata, err := a.r.GetInstanceMetadata(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to get instance metadata", "error", err)
+		handleError(ctx, w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(metadata); err != nil {
+		slog.With(slog.Any("error", err)).ErrorContext(ctx, "failed to encode response")
+	}
+}
+
 func (a *APIController) InstanceGARMToolsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/apiserver/routers/routers.go
+++ b/apiserver/routers/routers.go
@@ -159,6 +159,9 @@ func NewAPIRouter(han *controllers.APIController, authMiddleware, initMiddleware
 	metadataRouter := apiSubRouter.PathPrefix("/metadata").Subrouter()
 	metadataRouter.Use(instanceMiddleware.Middleware)
 
+	// Instance metadata
+	metadataRouter.Handle("/runner-metadata/", http.HandlerFunc(han.InstanceMetadataHandler)).Methods("GET", "OPTIONS")
+	metadataRouter.Handle("/runner-metadata", http.HandlerFunc(han.InstanceMetadataHandler)).Methods("GET", "OPTIONS")
 	// Registration token
 	metadataRouter.Handle("/runner-registration-token/", http.HandlerFunc(han.InstanceGithubRegistrationTokenHandler)).Methods("GET", "OPTIONS")
 	metadataRouter.Handle("/runner-registration-token", http.HandlerFunc(han.InstanceGithubRegistrationTokenHandler)).Methods("GET", "OPTIONS")
@@ -241,10 +244,11 @@ func NewAPIRouter(han *controllers.APIController, authMiddleware, initMiddleware
 	apiRouter.Handle("/objects/{objectID}/", http.HandlerFunc(han.UpdateFileObject)).Methods("PUT", "OPTIONS")
 	apiRouter.Handle("/objects/{objectID}", http.HandlerFunc(han.UpdateFileObject)).Methods("PUT", "OPTIONS")
 
-	// DELETEME //
-	// Tools
-	apiRouter.Handle("/tools/garm/", http.HandlerFunc(han.InstanceGARMToolsHandler)).Methods("GET", "OPTIONS")
-	apiRouter.Handle("/tools/garm", http.HandlerFunc(han.InstanceGARMToolsHandler)).Methods("GET", "OPTIONS")
+	///////////////////////////////////////////////////////
+	// Tools URLs (garm agent, cached gitea runner, etc) //
+	///////////////////////////////////////////////////////
+	apiRouter.Handle("/tools/garm-agent/", http.HandlerFunc(han.InstanceGARMToolsHandler)).Methods("GET", "OPTIONS")
+	apiRouter.Handle("/tools/garm-agent", http.HandlerFunc(han.InstanceGARMToolsHandler)).Methods("GET", "OPTIONS")
 
 	//////////
 	// Jobs //

--- a/params/params.go
+++ b/params/params.go
@@ -1350,3 +1350,30 @@ type GARMAgentTool struct {
 
 // swagger:model GARMAgentToolsPaginatedResponse
 type GARMAgentToolsPaginatedResponse = PaginatedResponse[GARMAgentTool]
+
+// swagger:model MetadataServiceAccessDetails
+type MetadataServiceAccessDetails struct {
+	CallbackURL string `json:"callback_url"`
+	MetadataURL string `json:"metadata_url"`
+}
+
+// swagger:model InstanceMetadata
+type InstanceMetadata struct {
+	MetadataAccess MetadataServiceAccessDetails `json:"metadata_access"`
+	ForgeType      EndpointType                 `json:"forge_type"`
+	// RunnerRegistrationURL is the URL the runner needs to configure itself
+	// against. This can be a repository, organization, enterprise (github)
+	// or system (gitea)
+	RunnerRegistrationURL string            `json:"runner_registration_url"`
+	RunnerName            string            `json:"runner_name"`
+	RunnerLabels          []string          `json:"runner_labels,omitempty"`
+	CABundle              map[string][]byte `json:"ca_bundles,omitempty"`
+	// ExtraSpecs represents the extra specs set on the pool or scale set. No secrets should
+	// be set in extra specs.
+	// Also, the instance metadata should never be saved to disk, and the metadata URL is only
+	// accessible during setup of the runner. The API returns unauthorized once the runner
+	// transitions to failed/idle.
+	ExtraSpecs  map[string]any                         `json:"extra_specs,omitempty"`
+	JITEnabled  bool                                   `json:"jit_enabled"`
+	RunnerTools commonParams.RunnerApplicationDownload `json:"runner_tools"`
+}


### PR DESCRIPTION
This change adds 2 new metadata URLs:

* Agent tools download URL (incomplete; WiP) - This will build on the object storage feature to offer a future garm-agent binary during the runner install process.
* Runner metadata - almost the same metadata that providers get via `InstallRunnerParams{}`. This is meant to make it easier to expand the runner install context, without having to change various projects. The metadata is available to runners during installation. After installation, an attempt to fetch metadata will return a 401 error.