### PR TITLE
Drop empty/redundant components from runner service name

### DIFF
--- a/runner/metadata.go
+++ b/runner/metadata.go
@@ -91,11 +91,11 @@ func validateInstanceState(ctx context.Context) (params.Instance, error) {
 func (r *Runner) getServiceNameForEntity(entity params.ForgeEntity) (string, error) {
 	switch entity.EntityType {
 	case params.ForgeEntityTypeEnterprise:
-		return fmt.Sprintf("actions.runner.%s.%s", entity.Owner, entity.Name), nil
+		return fmt.Sprintf("actions.runner.%s", entity.Owner), nil
 	case params.ForgeEntityTypeOrganization:
-		return fmt.Sprintf("actions.runner.%s.%s", entity.Owner, entity.Name), nil
+		return fmt.Sprintf("actions.runner.%s", entity.Owner), nil
 	case params.ForgeEntityTypeRepository:
-		return fmt.Sprintf("actions.runner.%s-%s.%s", entity.Owner, entity.Name, entity.Name), nil
+		return fmt.Sprintf("actions.runner.%s.%s", entity.Owner, entity.Name), nil
 	default:
 		return "", errors.New("unknown entity type")
 	}

--- a/runner/metadata_test.go
+++ b/runner/metadata_test.go
@@ -200,10 +200,9 @@ func (s *MetadataTestSuite) TestGetServiceNameForEntity() {
 			name: "Organization entity",
 			entity: params.ForgeEntity{
 				EntityType: params.ForgeEntityTypeOrganization,
-				Owner:      "test-owner",
-				Name:       "test-name",
+				Owner:      "test-name",
 			},
-			expected: "actions.runner.test-owner.test-name",
+			expected: "actions.runner.test-name",
 			hasError: false,
 		},
 		{
@@ -213,7 +212,7 @@ func (s *MetadataTestSuite) TestGetServiceNameForEntity() {
 				Owner:      "test-owner",
 				Name:       "test-repo",
 			},
-			expected: "actions.runner.test-owner-test-repo.test-repo",
+			expected: "actions.runner.test-owner.test-repo",
 			hasError: false,
 		},
 		{
@@ -221,9 +220,8 @@ func (s *MetadataTestSuite) TestGetServiceNameForEntity() {
 			entity: params.ForgeEntity{
 				EntityType: params.ForgeEntityTypeEnterprise,
 				Owner:      "test-enterprise",
-				Name:       "test-name",
 			},
-			expected: "actions.runner.test-enterprise.test-name",
+			expected: "actions.runner.test-enterprise",
 			hasError: false,
 		},
 		{
@@ -256,7 +254,7 @@ func (s *MetadataTestSuite) TestGetRunnerServiceName() {
 	serviceName, err := s.Runner.GetRunnerServiceName(s.instanceCtx)
 
 	s.Require().Nil(err)
-	s.Require().Equal("actions.runner.test-org.test-org", serviceName)
+	s.Require().Equal("actions.runner.test-org", serviceName)
 }
 
 func (s *MetadataTestSuite) TestGetRunnerServiceNameUnauthorized() {


### PR DESCRIPTION
I have observed unit names like `actions.runner.myorg..service`. Is far as I understand, for enterprises and organizations, `Owner` will simultaneously be the entity name while `Name` will be remain empty.