### PR TITLE
Check for pool max runners in CreateInstance tx

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -569,7 +569,7 @@ func (s *SQLite) Validate() error {
 }
 
 func (s *SQLite) ConnectionString() (string, error) {
-	connectionString := fmt.Sprintf("%s?_journal_mode=WAL&_foreign_keys=ON", s.DBFile)
+	connectionString := fmt.Sprintf("%s?_journal_mode=WAL&_foreign_keys=ON&_txlock=immediate", s.DBFile)
 	if s.BusyTimeoutSeconds > 0 {
 		timeout := s.BusyTimeoutSeconds * 1000
 		connectionString = fmt.Sprintf("%s&_busy_timeout=%d", connectionString, timeout)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -387,13 +387,13 @@ func TestGormParams(t *testing.T) {
 	dbType, uri, err := cfg.GormParams()
 	require.Nil(t, err)
 	require.Equal(t, SQLiteBackend, dbType)
-	require.Equal(t, filepath.Join(dir, "garm.db?_journal_mode=WAL&_foreign_keys=ON"), uri)
+	require.Equal(t, filepath.Join(dir, "garm.db?_journal_mode=WAL&_foreign_keys=ON&_txlock=immediate"), uri)
 
 	cfg.SQLite.BusyTimeoutSeconds = 5
 	dbType, uri, err = cfg.GormParams()
 	require.Nil(t, err)
 	require.Equal(t, SQLiteBackend, dbType)
-	require.Equal(t, filepath.Join(dir, "garm.db?_journal_mode=WAL&_foreign_keys=ON&_busy_timeout=5000"), uri)
+	require.Equal(t, filepath.Join(dir, "garm.db?_journal_mode=WAL&_foreign_keys=ON&_txlock=immediate&_busy_timeout=5000"), uri)
 
 	cfg.DbBackend = MySQLBackend
 	cfg.MySQL = getMySQLDefaultConfig()

--- a/database/watcher/watcher_store_test.go
+++ b/database/watcher/watcher_store_test.go
@@ -167,6 +167,7 @@ func (s *WatcherStoreTestSuite) TestInstanceWatcher() {
 		ProviderName: "test-provider",
 		Image:        "test-image",
 		Flavor:       "test-flavor",
+		MaxRunners:   100,
 		OSType:       commonParams.Linux,
 		OSArch:       commonParams.Amd64,
 		Tags:         []string{"test-tag"},

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -1118,15 +1118,6 @@ func (r *basePoolManager) addRunnerToPool(pool params.Pool, aditionalLabels []st
 		return fmt.Errorf("pool %s is disabled", pool.ID)
 	}
 
-	poolInstanceCount, err := r.store.PoolInstanceCount(r.ctx, pool.ID)
-	if err != nil {
-		return fmt.Errorf("failed to list pool instances: %w", err)
-	}
-
-	if poolInstanceCount >= int64(pool.MaxRunners) {
-		return fmt.Errorf("max workers (%d) reached for pool %s", pool.MaxRunners, pool.ID)
-	}
-
 	if err := r.AddRunner(r.ctx, pool.ID, aditionalLabels); err != nil {
 		return fmt.Errorf("failed to add new instance for pool %s: %s", pool.ID, err)
 	}


### PR DESCRIPTION
This change moves the check for max runners within the `CreateInstance` function, which will check that the pool max runners is not yet reached within a transaction before creating a new instance.
