### PR TITLE
Fix dpkg lock file conflicts during runner install

### DIFF
--- a/internal/templates/userdata/github_linux_userdata.tmpl
+++ b/internal/templates/userdata/github_linux_userdata.tmpl
@@ -71,7 +71,16 @@ if [ ! -d "$RUN_HOME" ];then
 	downloadAndExtractRunner
 	sendStatus "installing dependencies"
 	cd "$RUN_HOME"
-	sudo ./bin/installdependencies.sh || fail "failed to install dependencies"
+	attempt=1
+	while true; do
+		sudo ./bin/installdependencies.sh && break
+		if [ $attempt -gt 5 ];then
+			fail "failed to install dependencies after $attempt attempts"
+		fi
+		sendStatus "failed to install dependencies (attempt $attempt): (retrying in 15 seconds)"
+		attempt=$((attempt+1))
+		sleep 15
+	done
 else
 	sendStatus "using cached runner found in $RUN_HOME"
 	cd "$RUN_HOME"


### PR DESCRIPTION
Added a loop over installdependencies.sh call so that if a parallel process is using dpkg, we can wait and try again.

The timeout between attempts is set at 15sec, and the max number of attempts is 5.