### PR TITLE
Make runner names lowercase

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -752,7 +752,7 @@ func (r *basePoolManager) AddRunner(ctx context.Context, poolID string, aditiona
 		return fmt.Errorf("unknown provider %s for pool %s", pool.ProviderName, pool.ID)
 	}
 
-	name := fmt.Sprintf("%s-%s", pool.GetRunnerPrefix(), util.NewID())
+	name := strings.ToLower(fmt.Sprintf("%s-%s", pool.GetRunnerPrefix(), util.NewID()))
 	labels := r.getLabelsForInstance(pool)
 
 	jitConfig := make(map[string]string)


### PR DESCRIPTION
It seems that on some systems like k8s, rfc 1123 is a hard requirement and validation fails if hostnames have any uppercase letters, leading to nodes not being able to join.

RFC 1123 allows upper case, but the way k8s implemented it, makes things fail.

This change makes all runner names lowercase, hopefully fixing this.