### PR TITLE
Add #ps1_sysnative and fix integration tests

### DIFF
--- a/cmd/garm-cli/cmd/init.go
+++ b/cmd/garm-cli/cmd/init.go
@@ -114,6 +114,7 @@ garm-cli init --name=dev --url=https://runner.example.com --username=admin --pas
 			MetadataURL: &metadataURL,
 			CallbackURL: &callbackURL,
 			WebhookURL:  &webhookURL,
+			AgentURL:    &agentURL,
 		}
 
 		controllerInfoResponse, err := apiCli.Controller.UpdateController(updateUrlsReq, authToken)

--- a/internal/templates/userdata/windows_wrapper.tmpl
+++ b/internal/templates/userdata/windows_wrapper.tmpl
@@ -1,3 +1,5 @@
+#ps1_sysnative
+
 $ErrorActionPreference="Stop"
 Set-ExecutionPolicy RemoteSigned
 

--- a/test/integration/client_utils.go
+++ b/test/integration/client_utils.go
@@ -15,9 +15,12 @@
 package integration
 
 import (
+	"net/url"
+
 	"github.com/go-openapi/runtime"
 
 	"github.com/cloudbase/garm/client"
+	apiClientController "github.com/cloudbase/garm/client/controller"
 	clientControllerInfo "github.com/cloudbase/garm/client/controller_info"
 	clientCredentials "github.com/cloudbase/garm/client/credentials"
 	clientEndpoints "github.com/cloudbase/garm/client/endpoints"
@@ -42,6 +45,37 @@ func firstRun(apiCli *client.GarmAPI, newUser params.NewUserParams) (params.User
 		return params.User{}, err
 	}
 	return firstRunResponse.Payload, nil
+}
+
+func setControllerURLs(apiCli *client.GarmAPI, apiAuthToken runtime.ClientAuthInfoWriter, baseURL string) error {
+	metadataURL, err := url.JoinPath(baseURL, "api/v1/metadata")
+	if err != nil {
+		return err
+	}
+	callbackURL, err := url.JoinPath(baseURL, "api/v1/callbacks")
+	if err != nil {
+		return err
+	}
+	webhookURL, err := url.JoinPath(baseURL, "webhooks")
+	if err != nil {
+		return err
+	}
+	agentURL, err := url.JoinPath(baseURL, "agent")
+	if err != nil {
+		return err
+	}
+	updateUrlsReq := apiClientController.NewUpdateControllerParams()
+	updateUrlsReq.Body = params.UpdateControllerParams{
+		MetadataURL: &metadataURL,
+		CallbackURL: &callbackURL,
+		WebhookURL:  &webhookURL,
+		AgentURL:    &agentURL,
+	}
+	_, err = apiCli.Controller.UpdateController(updateUrlsReq, apiAuthToken)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func login(apiCli *client.GarmAPI, params params.PasswordLoginParams) (string, error) {

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -90,6 +90,9 @@ func (suite *GarmSuite) SetupSuite() {
 	suite.authToken = openapiRuntimeClient.BearerToken(token)
 	t.Log("Log in successful")
 
+	err = setControllerURLs(suite.cli, suite.authToken, baseURL)
+	suite.NoError(err, "error setting controller URLs")
+
 	suite.credentialsName = os.Getenv("CREDENTIALS_NAME")
 	suite.EnsureTestCredentials(suite.credentialsName, suite.ghToken, "github.com")
 


### PR DESCRIPTION
This change adds the `#ps1_sysnative` header to the windows userdata wrapper and initializes the controller URL in the integration tests.

Fixes #587 