### PR TITLE
Add runner rotate ability to CLI

### DIFF
--- a/apiserver/controllers/instances.go
+++ b/apiserver/controllers/instances.go
@@ -38,6 +38,12 @@ import (
 //	    in: path
 //	    required: true
 //
+//	  + name: outdatedOnly
+//	    description: List only instances that were created prior to a pool update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
+//	    type: boolean
+//	    in: query
+//	    required: false
+//
 //	Responses:
 //	  200: Instances
 //	  default: APIErrorResponse
@@ -56,7 +62,8 @@ func (a *APIController) ListPoolInstancesHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	instances, err := a.r.ListPoolInstances(ctx, poolID)
+	filterByOutdated, _ := strconv.ParseBool(r.URL.Query().Get("outdatedOnly"))
+	instances, err := a.r.ListPoolInstances(ctx, poolID, filterByOutdated)
 	if err != nil {
 		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pool instances")
 		handleError(ctx, w, err)
@@ -79,6 +86,12 @@ func (a *APIController) ListPoolInstancesHandler(w http.ResponseWriter, r *http.
 //	    type: string
 //	    in: path
 //	    required: true
+//
+//	  + name: outdatedOnly
+//	    description: List only instances that were created prior to a scaleset update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
+//	    type: boolean
+//	    in: query
+//	    required: false
 //
 //	Responses:
 //	  200: Instances
@@ -104,7 +117,8 @@ func (a *APIController) ListScaleSetInstancesHandler(w http.ResponseWriter, r *h
 		return
 	}
 
-	instances, err := a.r.ListScaleSetInstances(ctx, uint(id))
+	filterByOutdated, _ := strconv.ParseBool(r.URL.Query().Get("outdatedOnly"))
+	instances, err := a.r.ListScaleSetInstances(ctx, uint(id), filterByOutdated)
 	if err != nil {
 		slog.With(slog.Any("error", err)).ErrorContext(ctx, "listing pool instances")
 		handleError(ctx, w, err)

--- a/apiserver/swagger.yaml
+++ b/apiserver/swagger.yaml
@@ -1940,6 +1940,10 @@ paths:
                   name: poolID
                   required: true
                   type: string
+                - description: List only instances that were created prior to a pool update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
+                  in: query
+                  name: outdatedOnly
+                  type: boolean
             responses:
                 "200":
                     description: Instances
@@ -2453,6 +2457,10 @@ paths:
                   name: scalesetID
                   required: true
                   type: string
+                - description: List only instances that were created prior to a scaleset update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
+                  in: query
+                  name: outdatedOnly
+                  type: boolean
             responses:
                 "200":
                     description: Instances

--- a/client/instances/list_pool_instances_parameters.go
+++ b/client/instances/list_pool_instances_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewListPoolInstancesParams creates a new ListPoolInstancesParams object,
@@ -60,6 +61,12 @@ ListPoolInstancesParams contains all the parameters to send to the API endpoint
 	Typically these are written to a http.Request.
 */
 type ListPoolInstancesParams struct {
+
+	/* OutdatedOnly.
+
+	   List only instances that were created prior to a pool update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
+	*/
+	OutdatedOnly *bool
 
 	/* PoolID.
 
@@ -120,6 +127,17 @@ func (o *ListPoolInstancesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithOutdatedOnly adds the outdatedOnly to the list pool instances params
+func (o *ListPoolInstancesParams) WithOutdatedOnly(outdatedOnly *bool) *ListPoolInstancesParams {
+	o.SetOutdatedOnly(outdatedOnly)
+	return o
+}
+
+// SetOutdatedOnly adds the outdatedOnly to the list pool instances params
+func (o *ListPoolInstancesParams) SetOutdatedOnly(outdatedOnly *bool) {
+	o.OutdatedOnly = outdatedOnly
+}
+
 // WithPoolID adds the poolID to the list pool instances params
 func (o *ListPoolInstancesParams) WithPoolID(poolID string) *ListPoolInstancesParams {
 	o.SetPoolID(poolID)
@@ -138,6 +156,23 @@ func (o *ListPoolInstancesParams) WriteToRequest(r runtime.ClientRequest, reg st
 		return err
 	}
 	var res []error
+
+	if o.OutdatedOnly != nil {
+
+		// query param outdatedOnly
+		var qrOutdatedOnly bool
+
+		if o.OutdatedOnly != nil {
+			qrOutdatedOnly = *o.OutdatedOnly
+		}
+		qOutdatedOnly := swag.FormatBool(qrOutdatedOnly)
+		if qOutdatedOnly != "" {
+
+			if err := r.SetQueryParam("outdatedOnly", qOutdatedOnly); err != nil {
+				return err
+			}
+		}
+	}
 
 	// path param poolID
 	if err := r.SetPathParam("poolID", o.PoolID); err != nil {

--- a/client/instances/list_scale_set_instances_parameters.go
+++ b/client/instances/list_scale_set_instances_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewListScaleSetInstancesParams creates a new ListScaleSetInstancesParams object,
@@ -60,6 +61,12 @@ ListScaleSetInstancesParams contains all the parameters to send to the API endpo
 	Typically these are written to a http.Request.
 */
 type ListScaleSetInstancesParams struct {
+
+	/* OutdatedOnly.
+
+	   List only instances that were created prior to a scaleset update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
+	*/
+	OutdatedOnly *bool
 
 	/* ScalesetID.
 
@@ -120,6 +127,17 @@ func (o *ListScaleSetInstancesParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithOutdatedOnly adds the outdatedOnly to the list scale set instances params
+func (o *ListScaleSetInstancesParams) WithOutdatedOnly(outdatedOnly *bool) *ListScaleSetInstancesParams {
+	o.SetOutdatedOnly(outdatedOnly)
+	return o
+}
+
+// SetOutdatedOnly adds the outdatedOnly to the list scale set instances params
+func (o *ListScaleSetInstancesParams) SetOutdatedOnly(outdatedOnly *bool) {
+	o.OutdatedOnly = outdatedOnly
+}
+
 // WithScalesetID adds the scalesetID to the list scale set instances params
 func (o *ListScaleSetInstancesParams) WithScalesetID(scalesetID string) *ListScaleSetInstancesParams {
 	o.SetScalesetID(scalesetID)
@@ -138,6 +156,23 @@ func (o *ListScaleSetInstancesParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
+
+	if o.OutdatedOnly != nil {
+
+		// query param outdatedOnly
+		var qrOutdatedOnly bool
+
+		if o.OutdatedOnly != nil {
+			qrOutdatedOnly = *o.OutdatedOnly
+		}
+		qOutdatedOnly := swag.FormatBool(qrOutdatedOnly)
+		if qOutdatedOnly != "" {
+
+			if err := r.SetQueryParam("outdatedOnly", qOutdatedOnly); err != nil {
+				return err
+			}
+		}
+	}
 
 	// path param scalesetID
 	if err := r.SetPathParam("scalesetID", o.ScalesetID); err != nil {

--- a/database/common/mocks/Store.go
+++ b/database/common/mocks/Store.go
@@ -4445,9 +4445,9 @@ func (_c *Store_ListOrganizations_Call) RunAndReturn(run func(context.Context, p
 	return _c
 }
 
-// ListPoolInstances provides a mock function with given fields: ctx, poolID
-func (_m *Store) ListPoolInstances(ctx context.Context, poolID string) ([]params.Instance, error) {
-	ret := _m.Called(ctx, poolID)
+// ListPoolInstances provides a mock function with given fields: ctx, poolID, oudatedOnly
+func (_m *Store) ListPoolInstances(ctx context.Context, poolID string, oudatedOnly bool) ([]params.Instance, error) {
+	ret := _m.Called(ctx, poolID, oudatedOnly)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListPoolInstances")
@@ -4455,19 +4455,19 @@ func (_m *Store) ListPoolInstances(ctx context.Context, poolID string) ([]params
 
 	var r0 []params.Instance
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) ([]params.Instance, error)); ok {
-		return rf(ctx, poolID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool) ([]params.Instance, error)); ok {
+		return rf(ctx, poolID, oudatedOnly)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) []params.Instance); ok {
-		r0 = rf(ctx, poolID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool) []params.Instance); ok {
+		r0 = rf(ctx, poolID, oudatedOnly)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]params.Instance)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, poolID)
+	if rf, ok := ret.Get(1).(func(context.Context, string, bool) error); ok {
+		r1 = rf(ctx, poolID, oudatedOnly)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -4483,13 +4483,14 @@ type Store_ListPoolInstances_Call struct {
 // ListPoolInstances is a helper method to define mock.On call
 //   - ctx context.Context
 //   - poolID string
-func (_e *Store_Expecter) ListPoolInstances(ctx interface{}, poolID interface{}) *Store_ListPoolInstances_Call {
-	return &Store_ListPoolInstances_Call{Call: _e.mock.On("ListPoolInstances", ctx, poolID)}
+//   - oudatedOnly bool
+func (_e *Store_Expecter) ListPoolInstances(ctx interface{}, poolID interface{}, oudatedOnly interface{}) *Store_ListPoolInstances_Call {
+	return &Store_ListPoolInstances_Call{Call: _e.mock.On("ListPoolInstances", ctx, poolID, oudatedOnly)}
 }
 
-func (_c *Store_ListPoolInstances_Call) Run(run func(ctx context.Context, poolID string)) *Store_ListPoolInstances_Call {
+func (_c *Store_ListPoolInstances_Call) Run(run func(ctx context.Context, poolID string, oudatedOnly bool)) *Store_ListPoolInstances_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(bool))
 	})
 	return _c
 }
@@ -4499,7 +4500,7 @@ func (_c *Store_ListPoolInstances_Call) Return(_a0 []params.Instance, _a1 error)
 	return _c
 }
 
-func (_c *Store_ListPoolInstances_Call) RunAndReturn(run func(context.Context, string) ([]params.Instance, error)) *Store_ListPoolInstances_Call {
+func (_c *Store_ListPoolInstances_Call) RunAndReturn(run func(context.Context, string, bool) ([]params.Instance, error)) *Store_ListPoolInstances_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4563,9 +4564,9 @@ func (_c *Store_ListRepositories_Call) RunAndReturn(run func(context.Context, pa
 	return _c
 }
 
-// ListScaleSetInstances provides a mock function with given fields: _a0, scalesetID
-func (_m *Store) ListScaleSetInstances(_a0 context.Context, scalesetID uint) ([]params.Instance, error) {
-	ret := _m.Called(_a0, scalesetID)
+// ListScaleSetInstances provides a mock function with given fields: _a0, scalesetID, outdatedOnly
+func (_m *Store) ListScaleSetInstances(_a0 context.Context, scalesetID uint, outdatedOnly bool) ([]params.Instance, error) {
+	ret := _m.Called(_a0, scalesetID, outdatedOnly)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListScaleSetInstances")
@@ -4573,19 +4574,19 @@ func (_m *Store) ListScaleSetInstances(_a0 context.Context, scalesetID uint) ([]
 
 	var r0 []params.Instance
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint) ([]params.Instance, error)); ok {
-		return rf(_a0, scalesetID)
+	if rf, ok := ret.Get(0).(func(context.Context, uint, bool) ([]params.Instance, error)); ok {
+		return rf(_a0, scalesetID, outdatedOnly)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint) []params.Instance); ok {
-		r0 = rf(_a0, scalesetID)
+	if rf, ok := ret.Get(0).(func(context.Context, uint, bool) []params.Instance); ok {
+		r0 = rf(_a0, scalesetID, outdatedOnly)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]params.Instance)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint) error); ok {
-		r1 = rf(_a0, scalesetID)
+	if rf, ok := ret.Get(1).(func(context.Context, uint, bool) error); ok {
+		r1 = rf(_a0, scalesetID, outdatedOnly)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -4601,13 +4602,14 @@ type Store_ListScaleSetInstances_Call struct {
 // ListScaleSetInstances is a helper method to define mock.On call
 //   - _a0 context.Context
 //   - scalesetID uint
-func (_e *Store_Expecter) ListScaleSetInstances(_a0 interface{}, scalesetID interface{}) *Store_ListScaleSetInstances_Call {
-	return &Store_ListScaleSetInstances_Call{Call: _e.mock.On("ListScaleSetInstances", _a0, scalesetID)}
+//   - outdatedOnly bool
+func (_e *Store_Expecter) ListScaleSetInstances(_a0 interface{}, scalesetID interface{}, outdatedOnly interface{}) *Store_ListScaleSetInstances_Call {
+	return &Store_ListScaleSetInstances_Call{Call: _e.mock.On("ListScaleSetInstances", _a0, scalesetID, outdatedOnly)}
 }
 
-func (_c *Store_ListScaleSetInstances_Call) Run(run func(_a0 context.Context, scalesetID uint)) *Store_ListScaleSetInstances_Call {
+func (_c *Store_ListScaleSetInstances_Call) Run(run func(_a0 context.Context, scalesetID uint, outdatedOnly bool)) *Store_ListScaleSetInstances_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(uint))
+		run(args[0].(context.Context), args[1].(uint), args[2].(bool))
 	})
 	return _c
 }
@@ -4617,7 +4619,7 @@ func (_c *Store_ListScaleSetInstances_Call) Return(_a0 []params.Instance, _a1 er
 	return _c
 }
 
-func (_c *Store_ListScaleSetInstances_Call) RunAndReturn(run func(context.Context, uint) ([]params.Instance, error)) *Store_ListScaleSetInstances_Call {
+func (_c *Store_ListScaleSetInstances_Call) RunAndReturn(run func(context.Context, uint, bool) ([]params.Instance, error)) *Store_ListScaleSetInstances_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/database/common/store.go
+++ b/database/common/store.go
@@ -75,7 +75,7 @@ type PoolStore interface {
 	GetPoolByID(ctx context.Context, poolID string) (params.Pool, error)
 	DeletePoolByID(ctx context.Context, poolID string) error
 
-	ListPoolInstances(ctx context.Context, poolID string) ([]params.Instance, error)
+	ListPoolInstances(ctx context.Context, poolID string, oudatedOnly bool) ([]params.Instance, error)
 
 	PoolInstanceCount(ctx context.Context, poolID string) (int64, error)
 	FindPoolsMatchingAllTags(ctx context.Context, entityType params.ForgeEntityType, entityID string, tags []string) ([]params.Pool, error)
@@ -152,7 +152,7 @@ type ScaleSetsStore interface {
 }
 
 type ScaleSetInstanceStore interface {
-	ListScaleSetInstances(_ context.Context, scalesetID uint) ([]params.Instance, error)
+	ListScaleSetInstances(_ context.Context, scalesetID uint, outdatedOnly bool) ([]params.Instance, error)
 	CreateScaleSetInstance(_ context.Context, scaleSetID uint, param params.CreateInstanceParams) (instance params.Instance, err error)
 }
 

--- a/database/sql/instances_test.go
+++ b/database/sql/instances_test.go
@@ -668,14 +668,14 @@ func (s *InstancesTestSuite) TestUpdateInstanceDBUpdateAddressErr() {
 }
 
 func (s *InstancesTestSuite) TestListPoolInstances() {
-	instances, err := s.Store.ListPoolInstances(s.adminCtx, s.Fixtures.Pool.ID)
+	instances, err := s.Store.ListPoolInstances(s.adminCtx, s.Fixtures.Pool.ID, false)
 
 	s.Require().Nil(err)
 	s.equalInstancesByName(s.Fixtures.Instances, instances)
 }
 
 func (s *InstancesTestSuite) TestListPoolInstancesInvalidPoolID() {
-	_, err := s.Store.ListPoolInstances(s.adminCtx, "dummy-pool-id")
+	_, err := s.Store.ListPoolInstances(s.adminCtx, "dummy-pool-id", false)
 
 	s.Require().Equal("error parsing id: invalid request", err.Error())
 }

--- a/database/sql/models.go
+++ b/database/sql/models.go
@@ -121,6 +121,14 @@ type Pool struct {
 	GitHubRunnerGroup string
 	EnableShell       bool
 
+	// Generation holds the numeric generation of the pool. This number
+	// will be incremented, every time certain settings of the pool, which
+	// may influence how runners are created (flavor, specs, image) are changed.
+	// When a runner is created, this generation will be copied to the runners as
+	// well. That way if some settings diverge, we can target those runners
+	// to be recreated.
+	Generation uint64
+
 	RepoID     *uuid.UUID `gorm:"index"`
 	Repository Repository `gorm:"foreignKey:RepoID;"`
 
@@ -177,6 +185,13 @@ type ScaleSet struct {
 	// any kind of data needed by providers.
 	ExtraSpecs  datatypes.JSON
 	EnableShell bool
+
+	// Generation is the scaleset generation at the time of creating this instance.
+	// This field is to track a divergence between when the instance was created
+	// and the settings currently set on a scaleset. We can then use this field to know
+	// if the instance is out of date with the scaleset, allowing us to remove it if we
+	// need to.
+	Generation uint64
 
 	RepoID     *uuid.UUID `gorm:"index"`
 	Repository Repository `gorm:"foreignKey:RepoID;"`
@@ -336,6 +351,12 @@ type Instance struct {
 	GitHubRunnerGroup string
 	AditionalLabels   datatypes.JSON
 	Capabilities      datatypes.JSON
+	// Generation is the pool generation at the time of creating this instance.
+	// This field is to track a divergence between when the instance was created
+	// and the settings currently set on a pool. We can then use this field to know
+	// if the instance is out of date with the pool, allowing us to remove it if we
+	// need to.
+	Generation uint64
 
 	PoolID *uuid.UUID
 	Pool   Pool `gorm:"foreignKey:PoolID"`

--- a/database/sql/pools_test.go
+++ b/database/sql/pools_test.go
@@ -150,7 +150,7 @@ func (s *PoolsTestSuite) TestListAllPools() {
 
 func (s *PoolsTestSuite) TestListAllPoolsDBFetchErr() {
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT `pools`.`id`,`pools`.`created_at`,`pools`.`updated_at`,`pools`.`deleted_at`,`pools`.`provider_name`,`pools`.`runner_prefix`,`pools`.`max_runners`,`pools`.`min_idle_runners`,`pools`.`runner_bootstrap_timeout`,`pools`.`image`,`pools`.`flavor`,`pools`.`os_type`,`pools`.`os_arch`,`pools`.`enabled`,`pools`.`git_hub_runner_group`,`pools`.`enable_shell`,`pools`.`repo_id`,`pools`.`org_id`,`pools`.`enterprise_id`,`pools`.`template_id`,`pools`.`priority` FROM `pools` WHERE `pools`.`deleted_at` IS NULL")).
+		ExpectQuery(regexp.QuoteMeta("SELECT `pools`.`id`,`pools`.`created_at`,`pools`.`updated_at`,`pools`.`deleted_at`,`pools`.`provider_name`,`pools`.`runner_prefix`,`pools`.`max_runners`,`pools`.`min_idle_runners`,`pools`.`runner_bootstrap_timeout`,`pools`.`image`,`pools`.`flavor`,`pools`.`os_type`,`pools`.`os_arch`,`pools`.`enabled`,`pools`.`git_hub_runner_group`,`pools`.`enable_shell`,`pools`.`generation`,`pools`.`repo_id`,`pools`.`org_id`,`pools`.`enterprise_id`,`pools`.`template_id`,`pools`.`priority` FROM `pools` WHERE `pools`.`deleted_at` IS NULL")).
 		WillReturnError(fmt.Errorf("mocked fetching all pools error"))
 
 	_, err := s.StoreSQLMocked.ListAllPools(s.adminCtx)

--- a/database/sql/scalesets.go
+++ b/database/sql/scalesets.go
@@ -284,6 +284,7 @@ func (s *sqlDatabase) getEntityScaleSet(tx *gorm.DB, entityType params.ForgeEnti
 }
 
 func (s *sqlDatabase) updateScaleSet(tx *gorm.DB, scaleSet ScaleSet, param params.UpdateScaleSetParams) (params.ScaleSet, error) {
+	incrementGeneration := false
 	if param.Enabled != nil && scaleSet.Enabled != *param.Enabled {
 		scaleSet.Enabled = *param.Enabled
 	}
@@ -306,6 +307,7 @@ func (s *sqlDatabase) updateScaleSet(tx *gorm.DB, scaleSet ScaleSet, param param
 
 	if param.EnableShell != nil {
 		scaleSet.EnableShell = *param.EnableShell
+		incrementGeneration = true
 	}
 
 	if param.Name != "" {
@@ -314,14 +316,17 @@ func (s *sqlDatabase) updateScaleSet(tx *gorm.DB, scaleSet ScaleSet, param param
 
 	if param.GitHubRunnerGroup != nil && *param.GitHubRunnerGroup != "" {
 		scaleSet.GitHubRunnerGroup = *param.GitHubRunnerGroup
+		incrementGeneration = true
 	}
 
 	if param.Flavor != "" {
 		scaleSet.Flavor = param.Flavor
+		incrementGeneration = true
 	}
 
 	if param.Image != "" {
 		scaleSet.Image = param.Image
+		incrementGeneration = true
 	}
 
 	if param.Prefix != "" {
@@ -338,22 +343,25 @@ func (s *sqlDatabase) updateScaleSet(tx *gorm.DB, scaleSet ScaleSet, param param
 
 	if param.OSArch != "" {
 		scaleSet.OSArch = param.OSArch
+		incrementGeneration = true
 	}
 
 	if param.OSType != "" {
 		scaleSet.OSType = param.OSType
+		incrementGeneration = true
 	}
 
 	if param.ExtraSpecs != nil {
 		scaleSet.ExtraSpecs = datatypes.JSON(param.ExtraSpecs)
+		incrementGeneration = true
 	}
 
 	if param.RunnerBootstrapTimeout != nil && *param.RunnerBootstrapTimeout > 0 {
 		scaleSet.RunnerBootstrapTimeout = *param.RunnerBootstrapTimeout
 	}
 
-	if param.GitHubRunnerGroup != nil {
-		scaleSet.GitHubRunnerGroup = *param.GitHubRunnerGroup
+	if incrementGeneration {
+		scaleSet.Generation++
 	}
 
 	if q := tx.Save(&scaleSet); q.Error != nil {

--- a/database/sql/scalesets_test.go
+++ b/database/sql/scalesets_test.go
@@ -356,7 +356,7 @@ func (s *ScaleSetsTestSuite) TestScaleSetOperations() {
 	})
 
 	s.T().Run("List repo scale set instances", func(_ *testing.T) {
-		instances, err := s.Store.ListScaleSetInstances(s.adminCtx, repoScaleSet.ID)
+		instances, err := s.Store.ListScaleSetInstances(s.adminCtx, repoScaleSet.ID, false)
 		s.Require().NoError(err)
 		s.Require().NotEmpty(instances)
 		s.Require().Len(instances, 1)

--- a/params/params.go
+++ b/params/params.go
@@ -364,6 +364,13 @@ type Instance struct {
 	Heartbeat    time.Time         `json:"heartbeat"`
 	Capabilities AgentCapabilities `json:"capabilities"`
 
+	// Generation is the pool generation at the time of creating this instance.
+	// This field is to track a divergence between when the instance was created
+	// and the settings currently set on a pool. We can then use this field to know
+	// if the instance is out of date with the pool, allowing us to remove it if we
+	// need to.
+	Generation uint64 `json:"generation"`
+
 	// Do not serialize sensitive info.
 	CallbackURL      string            `json:"-"`
 	MetadataURL      string            `json:"-"`
@@ -473,6 +480,14 @@ type Pool struct {
 	Enabled        bool                `json:"enabled,omitempty"`
 	Instances      []Instance          `json:"instances,omitempty"`
 	EnableShell    bool                `json:"enable_shell"`
+
+	// Generation holds the numeric generation of the pool. This number
+	// will be incremented, every time certain settings of the pool, which
+	// may influence how runners are created (flavor, specs, image) are changed.
+	// When a runner is created, this generation will be copied to the runners as
+	// well. That way if some settings diverge, we can target those runners
+	// to be recreated.
+	Generation uint64 `json:"generation"`
 
 	RepoID   string `json:"repo_id,omitempty"`
 	RepoName string `json:"repo_name,omitempty"`
@@ -629,6 +644,14 @@ type ScaleSet struct {
 	Instances          []Instance          `json:"instances,omitempty"`
 	DesiredRunnerCount int                 `json:"desired_runner_count,omitempty"`
 	EnableShell        bool                `json:"enable_shell"`
+
+	// Generation holds the numeric generation of the scaleset. This number
+	// will be incremented, every time certain settings of the scaleset, which
+	// may influence how runners are created (flavor, specs, image) are changed.
+	// When a runner is created, this generation will be copied to the runners as
+	// well. That way if some settings diverge, we can target those runners
+	// to be recreated.
+	Generation uint64 `json:"generation"`
 
 	Endpoint ForgeEndpoint `json:"endpoint,omitempty"`
 

--- a/params/requests.go
+++ b/params/requests.go
@@ -196,6 +196,7 @@ type CreateInstanceParams struct {
 	AgentID           int64             `json:"-"`
 	AditionalLabels   []string          `json:"aditional_labels,omitempty"`
 	JitConfiguration  map[string]string `json:"jit_configuration,omitempty"`
+	Generation        uint64            `json:"generation"`
 }
 
 // swagger:model CreatePoolParams

--- a/runner/garm_tools_test.go
+++ b/runner/garm_tools_test.go
@@ -166,7 +166,6 @@ func (s *GARMToolsTestSuite) TestCreateGARMToolSuccess() {
 	s.Equal(param.Description, tool.Description)
 	s.Equal(int64(len(content)), tool.Size)
 
-	// Verify tags (should include origin=manual)
 	expectedTags := []string{
 		"category=garm-agent",
 		"os_type=linux",

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -798,6 +798,7 @@ func (r *basePoolManager) AddRunner(ctx context.Context, poolID string, aditiona
 		GitHubRunnerGroup: pool.GitHubRunnerGroup,
 		AditionalLabels:   aditionalLabels,
 		JitConfiguration:  jitConfig,
+		Generation:        pool.Generation,
 	}
 
 	if runner != nil {
@@ -1050,7 +1051,7 @@ func (r *basePoolManager) scaleDownOnePool(ctx context.Context, pool params.Pool
 		return nil
 	}
 
-	existingInstances, err := r.store.ListPoolInstances(r.ctx, pool.ID)
+	existingInstances, err := r.store.ListPoolInstances(r.ctx, pool.ID, false)
 	if err != nil {
 		return fmt.Errorf("failed to ensure minimum idle workers for pool %s: %w", pool.ID, err)
 	}
@@ -1156,7 +1157,7 @@ func (r *basePoolManager) ensureIdleRunnersForOnePool(pool params.Pool) error {
 		return nil
 	}
 
-	existingInstances, err := r.store.ListPoolInstances(r.ctx, pool.ID)
+	existingInstances, err := r.store.ListPoolInstances(r.ctx, pool.ID, false)
 	if err != nil {
 		return fmt.Errorf("failed to ensure minimum idle workers for pool %s: %w", pool.ID, err)
 	}
@@ -1213,7 +1214,7 @@ func (r *basePoolManager) retryFailedInstancesForOnePool(ctx context.Context, po
 		ctx, "running retry failed instances for pool",
 		"pool_id", pool.ID)
 
-	existingInstances, err := r.store.ListPoolInstances(r.ctx, pool.ID)
+	existingInstances, err := r.store.ListPoolInstances(r.ctx, pool.ID, false)
 	if err != nil {
 		return fmt.Errorf("failed to list instances for pool %s: %w", pool.ID, err)
 	}

--- a/runner/repositories.go
+++ b/runner/repositories.go
@@ -364,12 +364,12 @@ func (r *Runner) ListRepoPools(ctx context.Context, repoID string) ([]params.Poo
 	return pools, nil
 }
 
-func (r *Runner) ListPoolInstances(ctx context.Context, poolID string) ([]params.Instance, error) {
+func (r *Runner) ListPoolInstances(ctx context.Context, poolID string, outdatedOnly bool) ([]params.Instance, error) {
 	if !auth.IsAdmin(ctx) {
 		return nil, runnerErrors.ErrUnauthorized
 	}
 
-	instances, err := r.store.ListPoolInstances(ctx, poolID)
+	instances, err := r.store.ListPoolInstances(ctx, poolID, outdatedOnly)
 	if err != nil {
 		return []params.Instance{}, fmt.Errorf("error fetching instances: %w", err)
 	}

--- a/runner/repositories_test.go
+++ b/runner/repositories_test.go
@@ -605,14 +605,14 @@ func (s *RepoTestSuite) TestListPoolInstances() {
 		poolInstances = append(poolInstances, instance)
 	}
 
-	instances, err := s.Runner.ListPoolInstances(s.Fixtures.AdminContext, pool.ID)
+	instances, err := s.Runner.ListPoolInstances(s.Fixtures.AdminContext, pool.ID, false)
 
 	s.Require().Nil(err)
 	garmTesting.EqualDBEntityID(s.T(), poolInstances, instances)
 }
 
 func (s *RepoTestSuite) TestListPoolInstancesErrUnauthorized() {
-	_, err := s.Runner.ListPoolInstances(context.Background(), "dummy-pool-id")
+	_, err := s.Runner.ListPoolInstances(context.Background(), "dummy-pool-id", false)
 
 	s.Require().Equal(runnerErrors.ErrUnauthorized, err)
 }

--- a/runner/scalesets.go
+++ b/runner/scalesets.go
@@ -288,12 +288,12 @@ func (r *Runner) CreateEntityScaleSet(ctx context.Context, entityType params.For
 	return scaleSet, nil
 }
 
-func (r *Runner) ListScaleSetInstances(ctx context.Context, scalesetID uint) ([]params.Instance, error) {
+func (r *Runner) ListScaleSetInstances(ctx context.Context, scalesetID uint, outdatedOnly bool) ([]params.Instance, error) {
 	if !auth.IsAdmin(ctx) {
 		return nil, runnerErrors.ErrUnauthorized
 	}
 
-	instances, err := r.store.ListScaleSetInstances(ctx, scalesetID)
+	instances, err := r.store.ListScaleSetInstances(ctx, scalesetID, outdatedOnly)
 	if err != nil {
 		return []params.Instance{}, fmt.Errorf("error fetching instances: %w", err)
 	}

--- a/webapp/src/lib/api/generated/api.ts
+++ b/webapp/src/lib/api/generated/api.ts
@@ -1392,6 +1392,12 @@ export interface GARMAgentTool {
      */
     'size'?: number;
     /**
+     * Source indicates where this tool is currently stored. \"local\" means the tool is stored in the internal object store. \"upstream\" means the tool is only available from the upstream cached release and has not been downloaded locally.
+     * @type {string}
+     * @memberof GARMAgentTool
+     */
+    'source'?: string;
+    /**
      * 
      * @type {string}
      * @memberof GARMAgentTool
@@ -1519,6 +1525,12 @@ export interface GARMAgentToolsPaginatedResponseResultsInner {
      * @memberof GARMAgentToolsPaginatedResponseResultsInner
      */
     'size'?: number;
+    /**
+     * Source indicates where this tool is currently stored. \"local\" means the tool is stored in the internal object store. \"upstream\" means the tool is only available from the upstream cached release and has not been downloaded locally.
+     * @type {string}
+     * @memberof GARMAgentToolsPaginatedResponseResultsInner
+     */
+    'source'?: string;
     /**
      * 
      * @type {string}
@@ -1687,6 +1699,12 @@ export interface Instance {
      * @memberof Instance
      */
     'created_at'?: string;
+    /**
+     * Generation is the pool generation at the time of creating this instance. This field is to track a divergence between when the instance was created and the settings currently set on a pool. We can then use this field to know if the instance is out of date with the pool, allowing us to remove it if we need to.
+     * @type {number}
+     * @memberof Instance
+     */
+    'generation'?: number;
     /**
      * GithubRunnerGroup is the github runner group to which the runner belongs. The runner group must be created by someone with access to the enterprise.
      * @type {string}
@@ -2254,6 +2272,12 @@ export interface Pool {
      */
     'flavor'?: string;
     /**
+     * Generation holds the numeric generation of the pool. This number will be incremented, every time certain settings of the pool, which may influence how runners are created (flavor, specs, image) are changed. When a runner is created, this generation will be copied to the runners as well. That way if some settings diverge, we can target those runners to be recreated.
+     * @type {number}
+     * @memberof Pool
+     */
+    'generation'?: number;
+    /**
      * GithubRunnerGroup is the github runner group in which the runners will be added. The runner group must be created by someone with access to the enterprise.
      * @type {string}
      * @memberof Pool
@@ -2662,6 +2686,12 @@ export interface ScaleSet {
      * @memberof ScaleSet
      */
     'flavor'?: string;
+    /**
+     * Generation holds the numeric generation of the scaleset. This number will be incremented, every time certain settings of the scaleset, which may influence how runners are created (flavor, specs, image) are changed. When a runner is created, this generation will be copied to the runners as well. That way if some settings diverge, we can target those runners to be recreated.
+     * @type {number}
+     * @memberof ScaleSet
+     */
+    'generation'?: number;
     /**
      * GithubRunnerGroup is the github runner group in which the runners will be added. The runner group must be created by someone with access to the enterprise.
      * @type {string}
@@ -7082,10 +7112,11 @@ export const InstancesApiAxiosParamCreator = function (configuration?: Configura
          * 
          * @summary List runner instances in a pool.
          * @param {string} poolID Runner pool ID.
+         * @param {boolean} [outdatedOnly] List only instances that were created prior to a pool update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listPoolInstances: async (poolID: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listPoolInstances: async (poolID: string, outdatedOnly?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'poolID' is not null or undefined
             assertParamExists('listPoolInstances', 'poolID', poolID)
             const localVarPath = `/pools/{poolID}/instances`
@@ -7103,6 +7134,10 @@ export const InstancesApiAxiosParamCreator = function (configuration?: Configura
 
             // authentication Bearer required
             await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            if (outdatedOnly !== undefined) {
+                localVarQueryParameter['outdatedOnly'] = outdatedOnly;
+            }
 
 
     
@@ -7156,10 +7191,11 @@ export const InstancesApiAxiosParamCreator = function (configuration?: Configura
          * 
          * @summary List runner instances in a scale set.
          * @param {string} scalesetID Runner scale set ID.
+         * @param {boolean} [outdatedOnly] List only instances that were created prior to a scaleset update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listScaleSetInstances: async (scalesetID: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        listScaleSetInstances: async (scalesetID: string, outdatedOnly?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'scalesetID' is not null or undefined
             assertParamExists('listScaleSetInstances', 'scalesetID', scalesetID)
             const localVarPath = `/scalesets/{scalesetID}/instances`
@@ -7177,6 +7213,10 @@ export const InstancesApiAxiosParamCreator = function (configuration?: Configura
 
             // authentication Bearer required
             await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            if (outdatedOnly !== undefined) {
+                localVarQueryParameter['outdatedOnly'] = outdatedOnly;
+            }
 
 
     
@@ -7269,11 +7309,12 @@ export const InstancesApiFp = function(configuration?: Configuration) {
          * 
          * @summary List runner instances in a pool.
          * @param {string} poolID Runner pool ID.
+         * @param {boolean} [outdatedOnly] List only instances that were created prior to a pool update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listPoolInstances(poolID: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Instance>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listPoolInstances(poolID, options);
+        async listPoolInstances(poolID: string, outdatedOnly?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Instance>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listPoolInstances(poolID, outdatedOnly, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['InstancesApi.listPoolInstances']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -7295,11 +7336,12 @@ export const InstancesApiFp = function(configuration?: Configuration) {
          * 
          * @summary List runner instances in a scale set.
          * @param {string} scalesetID Runner scale set ID.
+         * @param {boolean} [outdatedOnly] List only instances that were created prior to a scaleset update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async listScaleSetInstances(scalesetID: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Instance>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.listScaleSetInstances(scalesetID, options);
+        async listScaleSetInstances(scalesetID: string, outdatedOnly?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<Instance>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.listScaleSetInstances(scalesetID, outdatedOnly, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['InstancesApi.listScaleSetInstances']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -7369,11 +7411,12 @@ export const InstancesApiFactory = function (configuration?: Configuration, base
          * 
          * @summary List runner instances in a pool.
          * @param {string} poolID Runner pool ID.
+         * @param {boolean} [outdatedOnly] List only instances that were created prior to a pool update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listPoolInstances(poolID: string, options?: RawAxiosRequestConfig): AxiosPromise<Array<Instance>> {
-            return localVarFp.listPoolInstances(poolID, options).then((request) => request(axios, basePath));
+        listPoolInstances(poolID: string, outdatedOnly?: boolean, options?: RawAxiosRequestConfig): AxiosPromise<Array<Instance>> {
+            return localVarFp.listPoolInstances(poolID, outdatedOnly, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -7389,11 +7432,12 @@ export const InstancesApiFactory = function (configuration?: Configuration, base
          * 
          * @summary List runner instances in a scale set.
          * @param {string} scalesetID Runner scale set ID.
+         * @param {boolean} [outdatedOnly] List only instances that were created prior to a scaleset update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        listScaleSetInstances(scalesetID: string, options?: RawAxiosRequestConfig): AxiosPromise<Array<Instance>> {
-            return localVarFp.listScaleSetInstances(scalesetID, options).then((request) => request(axios, basePath));
+        listScaleSetInstances(scalesetID: string, outdatedOnly?: boolean, options?: RawAxiosRequestConfig): AxiosPromise<Array<Instance>> {
+            return localVarFp.listScaleSetInstances(scalesetID, outdatedOnly, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -7470,12 +7514,13 @@ export class InstancesApi extends BaseAPI {
      * 
      * @summary List runner instances in a pool.
      * @param {string} poolID Runner pool ID.
+     * @param {boolean} [outdatedOnly] List only instances that were created prior to a pool update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof InstancesApi
      */
-    public listPoolInstances(poolID: string, options?: RawAxiosRequestConfig) {
-        return InstancesApiFp(this.configuration).listPoolInstances(poolID, options).then((request) => request(this.axios, this.basePath));
+    public listPoolInstances(poolID: string, outdatedOnly?: boolean, options?: RawAxiosRequestConfig) {
+        return InstancesApiFp(this.configuration).listPoolInstances(poolID, outdatedOnly, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -7494,12 +7539,13 @@ export class InstancesApi extends BaseAPI {
      * 
      * @summary List runner instances in a scale set.
      * @param {string} scalesetID Runner scale set ID.
+     * @param {boolean} [outdatedOnly] List only instances that were created prior to a scaleset update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof InstancesApi
      */
-    public listScaleSetInstances(scalesetID: string, options?: RawAxiosRequestConfig) {
-        return InstancesApiFp(this.configuration).listScaleSetInstances(scalesetID, options).then((request) => request(this.axios, this.basePath));
+    public listScaleSetInstances(scalesetID: string, outdatedOnly?: boolean, options?: RawAxiosRequestConfig) {
+        return InstancesApiFp(this.configuration).listScaleSetInstances(scalesetID, outdatedOnly, options).then((request) => request(this.axios, this.basePath));
     }
 }
 
@@ -13658,13 +13704,14 @@ export const ToolsApiAxiosParamCreator = function (configuration?: Configuration
     return {
         /**
          * 
-         * @summary List GARM agent tools.
+         * @summary List GARM agent tools for admin users.
          * @param {number} [page] The page at which to list.
          * @param {number} [pageSize] Number of items per page.
+         * @param {boolean} [upstream] If true, list tools from the upstream cached release instead of the local object store.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        garmAgentList: async (page?: number, pageSize?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        adminGarmAgentList: async (page?: number, pageSize?: number, upstream?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/tools/garm-agent`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -13686,6 +13733,10 @@ export const ToolsApiAxiosParamCreator = function (configuration?: Configuration
 
             if (pageSize !== undefined) {
                 localVarQueryParameter['pageSize'] = pageSize;
+            }
+
+            if (upstream !== undefined) {
+                localVarQueryParameter['upstream'] = upstream;
             }
 
 
@@ -13744,16 +13795,17 @@ export const ToolsApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
-         * @summary List GARM agent tools.
+         * @summary List GARM agent tools for admin users.
          * @param {number} [page] The page at which to list.
          * @param {number} [pageSize] Number of items per page.
+         * @param {boolean} [upstream] If true, list tools from the upstream cached release instead of the local object store.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async garmAgentList(page?: number, pageSize?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GARMAgentToolsPaginatedResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.garmAgentList(page, pageSize, options);
+        async adminGarmAgentList(page?: number, pageSize?: number, upstream?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GARMAgentToolsPaginatedResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.adminGarmAgentList(page, pageSize, upstream, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['ToolsApi.garmAgentList']?.[localVarOperationServerIndex]?.url;
+            const localVarOperationServerBasePath = operationServerMap['ToolsApi.adminGarmAgentList']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -13780,14 +13832,15 @@ export const ToolsApiFactory = function (configuration?: Configuration, basePath
     return {
         /**
          * 
-         * @summary List GARM agent tools.
+         * @summary List GARM agent tools for admin users.
          * @param {number} [page] The page at which to list.
          * @param {number} [pageSize] Number of items per page.
+         * @param {boolean} [upstream] If true, list tools from the upstream cached release instead of the local object store.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        garmAgentList(page?: number, pageSize?: number, options?: RawAxiosRequestConfig): AxiosPromise<GARMAgentToolsPaginatedResponse> {
-            return localVarFp.garmAgentList(page, pageSize, options).then((request) => request(axios, basePath));
+        adminGarmAgentList(page?: number, pageSize?: number, upstream?: boolean, options?: RawAxiosRequestConfig): AxiosPromise<GARMAgentToolsPaginatedResponse> {
+            return localVarFp.adminGarmAgentList(page, pageSize, upstream, options).then((request) => request(axios, basePath));
         },
         /**
          * Uploads a GARM agent tool for a specific OS and architecture. This will automatically replace any existing tool for the same OS/architecture combination.  Uses custom headers for metadata:  X-Tool-Name: Name of the tool  X-Tool-Description: Description  X-Tool-OS-Type: OS type (linux or windows)  X-Tool-OS-Arch: Architecture (amd64 or arm64)  X-Tool-Version: Version string
@@ -13810,15 +13863,16 @@ export const ToolsApiFactory = function (configuration?: Configuration, basePath
 export class ToolsApi extends BaseAPI {
     /**
      * 
-     * @summary List GARM agent tools.
+     * @summary List GARM agent tools for admin users.
      * @param {number} [page] The page at which to list.
      * @param {number} [pageSize] Number of items per page.
+     * @param {boolean} [upstream] If true, list tools from the upstream cached release instead of the local object store.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof ToolsApi
      */
-    public garmAgentList(page?: number, pageSize?: number, options?: RawAxiosRequestConfig) {
-        return ToolsApiFp(this.configuration).garmAgentList(page, pageSize, options).then((request) => request(this.axios, this.basePath));
+    public adminGarmAgentList(page?: number, pageSize?: number, upstream?: boolean, options?: RawAxiosRequestConfig) {
+        return ToolsApiFp(this.configuration).adminGarmAgentList(page, pageSize, upstream, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/webapp/swagger.yaml
+++ b/webapp/swagger.yaml
@@ -840,6 +840,14 @@ definitions:
                 format: int64
                 type: integer
                 x-go-name: Size
+            source:
+                description: |-
+                    Source indicates where this tool is currently stored.
+                    "local" means the tool is stored in the internal object store.
+                    "upstream" means the tool is only available from the upstream
+                    cached release and has not been downloaded locally.
+                type: string
+                x-go-name: Source
             updated_at:
                 format: date-time
                 type: string
@@ -911,6 +919,14 @@ definitions:
                             format: int64
                             type: integer
                             x-go-name: Size
+                        source:
+                            description: |-
+                                Source indicates where this tool is currently stored.
+                                "local" means the tool is stored in the internal object store.
+                                "upstream" means the tool is only available from the upstream
+                                cached release and has not been downloaded locally.
+                            type: string
+                            x-go-name: Source
                         updated_at:
                             format: date-time
                             type: string
@@ -1025,6 +1041,16 @@ definitions:
                 format: date-time
                 type: string
                 x-go-name: CreatedAt
+            generation:
+                description: |-
+                    Generation is the pool generation at the time of creating this instance.
+                    This field is to track a divergence between when the instance was created
+                    and the settings currently set on a pool. We can then use this field to know
+                    if the instance is out of date with the pool, allowing us to remove it if we
+                    need to.
+                format: uint64
+                type: integer
+                x-go-name: Generation
             github-runner-group:
                 description: |-
                     GithubRunnerGroup is the github runner group to which the runner belongs.
@@ -1441,6 +1467,17 @@ definitions:
             flavor:
                 type: string
                 x-go-name: Flavor
+            generation:
+                description: |-
+                    Generation holds the numeric generation of the pool. This number
+                    will be incremented, every time certain settings of the pool, which
+                    may influence how runners are created (flavor, specs, image) are changed.
+                    When a runner is created, this generation will be copied to the runners as
+                    well. That way if some settings diverge, we can target those runners
+                    to be recreated.
+                format: uint64
+                type: integer
+                x-go-name: Generation
             github-runner-group:
                 description: |-
                     GithubRunnerGroup is the github runner group in which the runners will be added.
@@ -1710,6 +1747,17 @@ definitions:
             flavor:
                 type: string
                 x-go-name: Flavor
+            generation:
+                description: |-
+                    Generation holds the numeric generation of the scaleset. This number
+                    will be incremented, every time certain settings of the scaleset, which
+                    may influence how runners are created (flavor, specs, image) are changed.
+                    When a runner is created, this generation will be copied to the runners as
+                    well. That way if some settings diverge, we can target those runners
+                    to be recreated.
+                format: uint64
+                type: integer
+                x-go-name: Generation
             github-runner-group:
                 description: |-
                     GithubRunnerGroup is the github runner group in which the runners will be added.
@@ -3675,6 +3723,10 @@ paths:
                   name: poolID
                   required: true
                   type: string
+                - description: List only instances that were created prior to a pool update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
+                  in: query
+                  name: outdatedOnly
+                  type: boolean
             responses:
                 "200":
                     description: Instances
@@ -4188,6 +4240,10 @@ paths:
                   name: scalesetID
                   required: true
                   type: string
+                - description: List only instances that were created prior to a scaleset update that changed a setting which influences how instances are created (image, flavor, runner group, etc).
+                  in: query
+                  name: outdatedOnly
+                  type: boolean
             responses:
                 "200":
                     description: Instances
@@ -4338,7 +4394,7 @@ paths:
                 - templates
     /tools/garm-agent:
         get:
-            operationId: GarmAgentList
+            operationId: AdminGarmAgentList
             parameters:
                 - description: The page at which to list.
                   in: query
@@ -4348,6 +4404,10 @@ paths:
                   in: query
                   name: pageSize
                   type: integer
+                - description: If true, list tools from the upstream cached release instead of the local object store.
+                  in: query
+                  name: upstream
+                  type: boolean
             responses:
                 "200":
                     description: GARMAgentToolsPaginatedResponse
@@ -4357,7 +4417,7 @@ paths:
                     description: APIErrorResponse
                     schema:
                         $ref: '#/definitions/APIErrorResponse'
-            summary: List GARM agent tools.
+            summary: List GARM agent tools for admin users.
             tags:
                 - tools
         post:

--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -176,7 +176,7 @@ func (w *Worker) Start() (err error) {
 		return nil
 	}
 
-	instances, err := w.store.ListScaleSetInstances(w.ctx, w.scaleSet.ID)
+	instances, err := w.store.ListScaleSetInstances(w.ctx, w.scaleSet.ID, false)
 	if err != nil {
 		return fmt.Errorf("listing scale set instances: %w", err)
 	}


### PR DESCRIPTION
This change adds a new "generation" field to pools, scalesets and runners. The generation field is inherited by runners from scale sets or pools at the time of creation.

The generation field on scalesets and pools is incremented when the pool or scale set is updated in a way that might influence how runners are created (flavor, image, specs, runner groups, etc).

Using this new field, we can determine if existing runners have diverged from the settings of the pool/scale set that spawned them.

In the CLI we now have a new set of commands available for both pools and scalesets that lists runners, with an optional --outdated flag and a new "rotate" flag that removes all idle runners. Optionally the --outdated flag can be passed to the rotate command to only remove outdated runners.

Fixes #379

![runner-rotate](https://github.com/user-attachments/assets/c06f121c-d507-41ea-81bf-c852c76d1a8d)