### PR TITLE
fix: remove invalid Unlock calls in scaleset worker

### DIFF
--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -566,7 +566,7 @@ func (w *Worker) consolidateRunnerState(runners []params.RunnerReference) error 
 			slog.DebugContext(w.ctx, "runner is locked; skipping", "runner_name", runner.Name)
 			continue
 		}
-		defer locking.Unlock(runner.Name, false)
+		locking.Unlock(runner.Name, false)
 
 		if _, ok := providerRunnersByName[runner.Name]; !ok {
 			// The runner is not in the provider anymore. Remove it from the DB.
@@ -893,7 +893,6 @@ func (w *Worker) handleScaleDown() {
 			switch runner.RunnerStatus {
 			case params.RunnerTerminated, params.RunnerActive:
 				slog.DebugContext(w.ctx, "runner is not in a valid state; skipping", "runner_name", runner.Name, "runner_status", runner.RunnerStatus)
-				locking.Unlock(runner.Name, false)
 				continue
 			}
 			locked := locking.TryLock(runner.Name, w.consumerID)


### PR DESCRIPTION
## Summary

Fixes invalid mutex unlock calls in the scaleset worker that could cause panics.

## Changes

- Remove `Unlock` call in `handleScaleDown` that was called before any lock was acquired
- Change `defer Unlock` to immediate `Unlock` in `consolidateRunnerState` loop to avoid holding locks until function exit

## Testing

Tested in production environment.

---
This PR is part of a stack of changes:
1. #598 ← you are here
2. #599
3. #600
4. #601