### PR TITLE
Add version display to navigation sidebar

### DIFF
--- a/webapp/src/lib/components/Navigation.svelte
+++ b/webapp/src/lib/components/Navigation.svelte
@@ -4,6 +4,7 @@
 	import { auth, authStore } from '$lib/stores/auth.js';
 	import { websocketStore } from '$lib/stores/websocket.js';
 	import { themeStore } from '$lib/stores/theme.js';
+	import { eagerCache } from '$lib/stores/eager-cache.js';
 	import { onMount } from 'svelte';
 
 	let mobileMenuOpen = false;
@@ -12,6 +13,7 @@
 	// WebSocket connection status
 	$: wsState = $websocketStore;
 	$: darkMode = $themeStore;
+	$: serverVersion = $eagerCache.controllerInfo?.version || '';
 
 	// Close mobile menu when route changes  
 	$: $page.url.pathname && (mobileMenuOpen = false);
@@ -237,6 +239,15 @@
 					Logout
 				</button>
 			</div>
+
+			<!-- Version section -->
+			{#if serverVersion}
+				<div class="border-t border-gray-200 dark:border-gray-600 mt-4 pt-4 px-2">
+					<div class="text-xs text-gray-500 dark:text-gray-400">
+						<span class="font-medium">GARM</span> {serverVersion}
+					</div>
+				</div>
+			{/if}
 		</nav>
 
 	</div>
@@ -383,6 +394,15 @@
 								Logout
 							</button>
 						</div>
+
+						<!-- Version section -->
+						{#if serverVersion}
+							<div class="border-t border-gray-200 dark:border-gray-600 mt-4 pt-4 px-2">
+								<div class="text-xs text-gray-500 dark:text-gray-400">
+									<span class="font-medium">GARM</span> {serverVersion}
+								</div>
+							</div>
+						{/if}
 					</nav>
 				</div>
 


### PR DESCRIPTION
## Summary

Displays the GARM version in the webapp navigation sidebar, making it easy to identify which version is running.

## Changes

- Fetch version from `/api/v1/controller-info` endpoint
- Display version at the bottom of the navigation sidebar
- Rebuild webapp with version display

## Screenshot

The version is displayed at the bottom of the left navigation sidebar.

## Testing

Tested in staging and production environments.
