### PR TITLE
Add CloudStack provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN set -ex; \
       cloudbase/garm-provider-gcp \
       cloudbase/garm-provider-equinix \
       flatcar/garm-provider-linode \
-      mercedes-benz/garm-provider-k8s; \
+      mercedes-benz/garm-provider-k8s \
+      nexthop-ai/garm-provider-cloudstack; \
     do \
         export PROVIDER_NAME="$(basename $repo)"; \
         export PROVIDER_SUBDIR=""; \
@@ -72,6 +73,7 @@ COPY --from=builder /opt/garm/providers.d/garm-provider-gcp /opt/garm/providers.
 COPY --from=builder /opt/garm/providers.d/garm-provider-equinix /opt/garm/providers.d/garm-provider-equinix
 
 COPY --from=builder /opt/garm/providers.d/garm-provider-k8s /opt/garm/providers.d/garm-provider-k8s
+COPY --from=builder /opt/garm/providers.d/garm-provider-cloudstack /opt/garm/providers.d/garm-provider-cloudstack
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 ENTRYPOINT ["/bin/garm", "-config", "/etc/garm/config.toml"]

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ External providers are binaries that GARM calls into to create runners in a part
 * [Akamai/Linode](https://github.com/flatcar/garm-provider-linode) - Experimental
 * [Amazon EC2](https://github.com/cloudbase/garm-provider-aws)
 * [Azure](https://github.com/cloudbase/garm-provider-azure)
+* [CloudStack](https://github.com/nexthop-ai/garm-provider-cloudstack)
 * [Equinix Metal](https://github.com/cloudbase/garm-provider-equinix)
 * [Google Cloud Platform (GCP)](https://github.com/cloudbase/garm-provider-gcp)
 * [Incus](https://github.com/cloudbase/garm-provider-incus)

--- a/doc/config.md
+++ b/doc/config.md
@@ -292,14 +292,15 @@ If you want to implement an external provider, you can use this file for anythin
 
 For non-testing purposes, these are the external providers currently available:
 
-* [OpenStack](https://github.com/cloudbase/garm-provider-openstack)
+* [Amazon EC2](https://github.com/cloudbase/garm-provider-aws)
 * [Azure](https://github.com/cloudbase/garm-provider-azure)
+* [CloudStack](https://github.com/nexthop-ai/garm-provider-cloudstack)
+* [Equinix Metal](https://github.com/cloudbase/garm-provider-equinix)
+* [Google Cloud Platform (GCP)](https://github.com/cloudbase/garm-provider-gcp)
+* [Incus](https://github.com/cloudbase/garm-provider-incus)
 * [Kubernetes](https://github.com/mercedes-benz/garm-provider-k8s) - Thanks to the amazing folks at @mercedes-benz for sharing their awesome provider!
 * [LXD](https://github.com/cloudbase/garm-provider-lxd)
-* [Incus](https://github.com/cloudbase/garm-provider-incus)
-* [Equinix Metal](https://github.com/cloudbase/garm-provider-equinix)
-* [Amazon EC2](https://github.com/cloudbase/garm-provider-aws)
-* [Google Cloud Platform (GCP)](https://github.com/cloudbase/garm-provider-gcp)
+* [OpenStack](https://github.com/cloudbase/garm-provider-openstack)
 * [Oracle Cloud Infrastructure (OCI)](https://github.com/cloudbase/garm-provider-oci)
 
 Details on how to install and configure them are available in their respective repositories.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -90,14 +90,15 @@ At this point, we have a valid config file, but we still need to add the `provid
 
 This is where you have a decision to make. GARM has a number of providers you can leverage. At the time of this writing, we have support for:
 
-* [OpenStack](https://github.com/cloudbase/garm-provider-openstack)
+* [Amazon EC2](https://github.com/cloudbase/garm-provider-aws)
 * [Azure](https://github.com/cloudbase/garm-provider-azure)
+* [CloudStack](https://github.com/nexthop-ai/garm-provider-cloudstack)
+* [Equinix Metal](https://github.com/cloudbase/garm-provider-equinix)
+* [Google Cloud Platform (GCP)](https://github.com/cloudbase/garm-provider-gcp)
+* [Incus](https://github.com/cloudbase/garm-provider-incus)
 * [Kubernetes](https://github.com/mercedes-benz/garm-provider-k8s) - Thanks to the amazing folks at @mercedes-benz for sharing their awesome provider!
 * [LXD](https://github.com/cloudbase/garm-provider-lxd)
-* [Incus](https://github.com/cloudbase/garm-provider-incus)
-* [Equinix Metal](https://github.com/cloudbase/garm-provider-equinix)
-* [Amazon EC2](https://github.com/cloudbase/garm-provider-aws)
-* [Google Cloud Platform (GCP)](https://github.com/cloudbase/garm-provider-gcp)
+* [OpenStack](https://github.com/cloudbase/garm-provider-openstack)
 * [Oracle Cloud Infrastructure (OCI)](https://github.com/cloudbase/garm-provider-oci)
 
 The easiest provider to set up is probably the LXD or Incus provider. Incus is a fork of LXD so the functionality is identical (for now). For the purpose of this document, we'll continue with LXD. You don't need an account on an external cloud. You can just use your machine.

--- a/doc/using_garm.md
+++ b/doc/using_garm.md
@@ -137,6 +137,8 @@ ubuntu@garm:~$ garm-cli provider list
 +--------------+---------------------------------+----------+
 | equinix      | Equinix Metal                   | external |
 +--------------+---------------------------------+----------+
+| cloudstack   | CloudStack external provider    | external |
++--------------+---------------------------------+----------+
 ```
 
 Each of these providers can be used to set up a runner pool for a repository, organization or enterprise.


### PR DESCRIPTION
We've been running this provider for a few weeks now and we've done thousands of builds with it.

- Add [nexthop-ai/garm-provider-cloudstack](https://github.com/nexthop-ai/garm-provider-cloudstack) to `Dockerfile` provider build
- Add CloudStack to the list of supported providers in `README.md`
- Add CloudStack to provider lists in docs, also sort them alphabetically