### PR TITLE
Use the repository name for jobs

### DIFF
--- a/runner/metrics/jobs.go
+++ b/runner/metrics/jobs.go
@@ -40,7 +40,7 @@ func CollectJobMetric(ctx context.Context, r *runner.Runner) error {
 			job.Status,                    // label: status
 			job.Conclusion,                // label: conclusion
 			job.RunnerName,                // label: runner_name
-			job.RepoID.String(),           // label: repository
+			job.RepositoryName,            // label: repository
 			strings.Join(job.Labels, " "), // label: requested_labels
 		).Set(1)
 	}


### PR DESCRIPTION
The RepoID, OrgID and EnterpriseID are the entities that generated the webhook which notified us of the job running in the repo. The RepositoryName is the actual repository that started the job.

Fixes #614