### PR TITLE
Force transition instances in inconsistent state

### DIFF
--- a/database/common/store.go
+++ b/database/common/store.go
@@ -96,6 +96,15 @@ type InstanceStore interface {
 	DeleteInstance(ctx context.Context, poolID string, instanceNameOrID string) error
 	DeleteInstanceByName(ctx context.Context, instanceName string) error
 	UpdateInstance(ctx context.Context, instanceNameOrID string, param params.UpdateInstanceParams) (params.Instance, error)
+	// ForceUpdateInstance functions identically to UpdateInstance with one important distinction. It does not
+	// validate the agent ID or instance status or runner status transitions. This function must only be used in
+	// recovery scenarios, where GARM crashed or was restarted while runners were going through a transitory
+	// state like "creating", "deleting", etc. In such cases, we cannot simply pick up where we left off, and
+	// we must set the instance in "pending_delete" or some other state that allows us to recover.
+	// An instance in "creating" state is currently being serviced by a call by GARM to the external provider.
+	// If GARM is just starting up and we see one in "creating", it means that the process that was creating it
+	// was most likely interrupted before it finished and we must clean it up.
+	ForceUpdateInstance(ctx context.Context, instanceName string, param params.UpdateInstanceParams) (params.Instance, error)
 
 	// Probably a bad idea without some king of filter or at least pagination
 	//


### PR DESCRIPTION
If GARM is killed or restarted while creating a runner, there is a chance that runners remain in creating or deleting state. We've started checking state transitions in GARM and allow a transition when the new state makes sense in normal circumstances. However, when recovering from a crash, we may be in an inconsisten state from which we need to recover.

This change added a ForceUpdateInstance() function that ignores state transition inconsistencies. For now, we only use it when spinning up a scale set and check for instance states.

This change also fixes a locking issue.

Fixes: #610
Includes: #598