### PR TITLE
Fix leaky jit config

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -536,6 +536,7 @@ func (r *basePoolManager) reapTimedOutRunners(runners []*github.Runner) error {
 func (r *basePoolManager) cleanupOrphanedGithubRunners(runners []*github.Runner) error {
 	poolInstanceCache := map[string][]commonParams.ProviderInstance{}
 	g, ctx := errgroup.WithContext(r.ctx)
+	g.SetLimit(10)
 	for _, runner := range runners {
 		if !isManagedRunner(labelsFromRunner(runner), r.controllerInfo.ControllerID.String()) {
 			slog.DebugContext(


### PR DESCRIPTION
The check for max runners was added to CreateInstance(), but we crete the JIT runners before we run the function to add a runner to the DB. The defer function to clean up the JIT runner was being run after the error return generated by CreateInstance. So the cleanup code never ran. Additionally we would know that max runners was reached only after creating the JIT runner. Which kills rate limits.