### PR TITLE
Make runner names lowercase

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -874,7 +874,7 @@ func (r *basePoolManager) AddRunner(ctx context.Context, poolID string, aditiona
 		return fmt.Errorf("unknown provider %s for pool %s", pool.ProviderName, pool.ID)
 	}
 
-	name := fmt.Sprintf("%s-%s", pool.GetRunnerPrefix(), util.NewID())
+	name := strings.ToLower(fmt.Sprintf("%s-%s", pool.GetRunnerPrefix(), util.NewID()))
 	labels := r.getLabelsForInstance(pool)
 
 	jitConfig := make(map[string]string)

--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -814,7 +815,7 @@ func (w *Worker) handleScaleUp() {
 		return
 	}
 	for i := w.runnerCount(); i < w.targetRunners(); i++ {
-		newRunnerName := fmt.Sprintf("%s-%s", w.scaleSet.GetRunnerPrefix(), util.NewID())
+		newRunnerName := strings.ToLower(fmt.Sprintf("%s-%s", w.scaleSet.GetRunnerPrefix(), util.NewID()))
 		jitConfig, err := scaleSetCli.GenerateJitRunnerConfig(w.ctx, newRunnerName, w.scaleSet.ScaleSetID)
 		if err != nil {
 			slog.ErrorContext(w.ctx, "error generating jit config", "error", err)


### PR DESCRIPTION
It seems that on some systems like k8s, rfc 1123 is a hard requirement and validation fails if hostnames have any uppercase letters, leading to nodes not being able to join.

This change makes all runner names lowercase, hopefully fixing this.