### PR TITLE
fix: Add support for agent mode in nginx config

### DIFF
--- a/testdata/nginx-server.conf
+++ b/testdata/nginx-server.conf
@@ -5,7 +5,7 @@ upstream garm_backend {
 server {
     server_name garm.example.com;
 
-    location /api/v1/ws {
+    location ~ ^(/api/v1/ws|/agent) {
         proxy_pass http://garm_backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
Agent mode also requires a websocket, so we need to take that into account in the nginx config.