### PR TITLE
fix: windows ExecutionPolicy in wrapper

### DIFF
--- a/internal/templates/userdata/windows_wrapper.tmpl
+++ b/internal/templates/userdata/windows_wrapper.tmpl
@@ -1,7 +1,7 @@
 #ps1_sysnative
 
+Set-ExecutionPolicy RemoteSigned -Force -ErrorAction SilentlyContinue
 $ErrorActionPreference="Stop"
-Set-ExecutionPolicy RemoteSigned
 
 function Start-ExecuteWithRetry {
     [CmdletBinding()]


### PR DESCRIPTION
   ### Summary

   Previously, this userdata wrapper could fail when `Set-ExecutionPolicy` was run in an environment where the effective policy was already more permissive.

   ### Change

   Use:

   ```powershell
   Set-ExecutionPolicy RemoteSigned -Force -ErrorAction SilentlyContinue
 ```

 instead of a plain Set-ExecutionPolicy RemoteSigned.

 ### Why

 This avoids the warning/error path that could stop userdata execution before the install script runs.