### PR TITLE
Fix scaleset listener after crash

### DIFF
--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -764,9 +764,8 @@ Loop:
 			w.mux.Unlock()
 			for {
 				w.mux.Lock()
-				if err := w.listener.Stop(); err != nil {
-					slog.ErrorContext(w.ctx, "failed to stop listener", "error", err)
-				}
+				// In case the scaleset was disabled while we were in the
+				// backoff sleep.
 				if !w.scaleSet.Enabled {
 					w.mux.Unlock()
 					continue Loop
@@ -774,15 +773,12 @@ Loop:
 				slog.DebugContext(w.ctx, "attempting to restart")
 				if err := w.listener.Start(); err != nil {
 					w.mux.Unlock()
-					slog.ErrorContext(w.ctx, "error restarting listener", "error", err)
-					switch {
-					case backoff > 60*time.Second:
-						backoff = 60 * time.Second
-					case backoff == 0:
+					switch backoff {
+					case 0:
 						backoff = 5 * time.Second
 						slog.InfoContext(w.ctx, "backing off restart attempt", "backoff", backoff)
 					default:
-						backoff = time.Duration(float64(backoff) * 1.5)
+						backoff = min(time.Duration(float64(backoff)*1.5), 60*time.Second)
 					}
 					slog.ErrorContext(w.ctx, "error restarting listener", "error", err, "backoff", backoff)
 					if canceled := w.sleepWithCancel(backoff); canceled {
@@ -791,6 +787,7 @@ Loop:
 					}
 					continue
 				}
+				backoff = 0
 				w.mux.Unlock()
 				continue Loop
 			}

--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -145,8 +145,7 @@ func (w *Worker) ensureScaleSetInGitHub() error {
 		return fmt.Errorf("failed to update scale set: %w", err)
 	}
 
-	// The scale set was recreated. We need to reset the last message ID we recorded previously,
-	// otherwise we'll ignore every message we get from the queue.
+	// The scale set was recreated. We need to reset the last message ID we recorded previously.
 	if err := w.SetLastMessageID(0); err != nil {
 		return fmt.Errorf("failed to reset last message id: %w", err)
 	}
@@ -324,15 +323,6 @@ func (w *Worker) Start() (err error) {
 
 	slog.DebugContext(w.ctx, "creating scale set listener")
 	listener := newListener(w.ctx, w)
-
-	if w.scaleSet.Enabled {
-		slog.DebugContext(w.ctx, "starting scale set listener")
-		if err := listener.Start(); err != nil {
-			return fmt.Errorf("error starting listener: %w", err)
-		}
-	} else {
-		slog.InfoContext(w.ctx, "scale set is disabled; not starting listener")
-	}
 
 	w.listener = listener
 	w.consumer = consumer

--- a/workers/scaleset/scaleset_listener.go
+++ b/workers/scaleset/scaleset_listener.go
@@ -152,11 +152,6 @@ func (l *scaleSetListener) handleSessionMessage(msg params.RunnerScaleSetMessage
 		slog.ErrorContext(l.ctx, "getting jobs from body", "error", err)
 	}
 
-	if msg.MessageID < l.lastMessageID {
-		slog.InfoContext(l.ctx, "message is older than last message, ignoring", "received_msg_id", fmt.Sprintf("%d", msg.MessageID), "recorded_msg_id", fmt.Sprintf("%d", l.lastMessageID))
-		return
-	}
-
 	var completedJobs []params.ScaleSetJobMessage
 	var availableJobs []params.ScaleSetJobMessage
 	var startedJobs []params.ScaleSetJobMessage


### PR DESCRIPTION
After a crash or an unclean shutdown, we may have a lingering scaleset message session. Only one autoscaler may listen on a scaleset message session. This change removes a call to `listener.Start()` in the scaleset Start() method, and allows the keepListenerAlove() method to attempt to start the message session until it succeeds or the scaleset is disabled.

GitHub eventually cleans up the stale message session and the keep alive method manages to bring up a new listener.

This also allows all the scaleset loops to start regardless of listener status.

Fixes #700