### PR TITLE
Do not gate DB writes based on internal map

### DIFF
--- a/workers/entity/controller_watcher.go
+++ b/workers/entity/controller_watcher.go
@@ -114,20 +114,24 @@ func (c *Controller) handleWatcherCreateOperation(entity params.ForgeEntity) {
 		return
 	}
 
-	c.Entities.Store(entity.ID, worker)
+	if _, loaded := c.Entities.LoadOrStore(entity.ID, worker); loaded {
+		// A worker already exists for this entity. Stop the one we just created.
+		slog.DebugContext(c.ctx, "entity worker already exists", "entity_id", entity.ID)
+		worker.Stop()
+	}
 }
 
 func (c *Controller) handleWatcherDeleteOperation(entity params.ForgeEntity) {
-	val, ok := c.Entities.Load(entity.ID)
-	if !ok {
+	val, loaded := c.Entities.LoadAndDelete(entity.ID)
+	if !loaded {
 		slog.InfoContext(c.ctx, "entity not found in worker list", "entity_id", entity.ID)
 		return
 	}
 	worker := val.(*Worker)
 	slog.InfoContext(c.ctx, "stopping entity worker", "entity_id", entity.ID, "entity_type", entity.EntityType)
 	if err := worker.Stop(); err != nil {
+		// Re-store the worker so it can be retried.
+		c.Entities.Store(entity.ID, worker)
 		slog.ErrorContext(c.ctx, "stopping worker", "entity_id", entity.ID, "error", err)
-		return
 	}
-	c.Entities.Delete(entity.ID)
 }

--- a/workers/provider/instance_manager.go
+++ b/workers/provider/instance_manager.go
@@ -404,8 +404,6 @@ func (i *instanceManager) Update(instance dbCommon.ChangePayload) error {
 
 func (i *instanceManager) updatesLoop() {
 	defer i.Stop()
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
 	for {
 		select {
 		case <-i.quit:

--- a/workers/provider/provider.go
+++ b/workers/provider/provider.go
@@ -245,7 +245,11 @@ func (p *Provider) handleInstanceAdded(instance params.Instance) error {
 	if err := instanceManager.Start(); err != nil {
 		return fmt.Errorf("starting instance manager: %w", err)
 	}
-	p.runners.Store(instance.Name, instanceManager)
+	if _, loaded := p.runners.LoadOrStore(instance.Name, instanceManager); loaded {
+		// A manager already exists for this instance. Stop the one we just created.
+		slog.DebugContext(p.ctx, "instance manager already exists", "instance_name", instance.Name)
+		instanceManager.Stop()
+	}
 	return nil
 }
 
@@ -253,15 +257,16 @@ func (p *Provider) stopAndDeleteInstance(instance params.Instance) error {
 	if instance.Status != commonParams.InstanceDeleted {
 		return nil
 	}
-	val, ok := p.runners.Load(instance.Name)
-	if !ok {
+	val, loaded := p.runners.LoadAndDelete(instance.Name)
+	if !loaded {
 		return nil
 	}
 	existingInstance := val.(*instanceManager)
 	if err := existingInstance.Stop(); err != nil {
+		// Re-store the manager so it can be retried.
+		p.runners.Store(instance.Name, existingInstance)
 		return fmt.Errorf("failed to stop instance manager: %w", err)
 	}
-	p.runners.Delete(instance.Name)
 	return nil
 }
 

--- a/workers/provider/provider_helper.go
+++ b/workers/provider/provider_helper.go
@@ -16,7 +16,6 @@ package provider
 import (
 	"fmt"
 
-	"github.com/cloudbase/garm-provider-common/errors"
 	commonParams "github.com/cloudbase/garm-provider-common/params"
 	"github.com/cloudbase/garm/auth"
 	"github.com/cloudbase/garm/params"
@@ -57,10 +56,6 @@ func (p *Provider) GetControllerInfo() (params.ControllerInfo, error) {
 }
 
 func (p *Provider) SetInstanceStatus(instanceName string, status commonParams.InstanceStatus, providerFault []byte, force bool) error {
-	if _, ok := p.runners.Load(instanceName); !ok {
-		return errors.ErrNotFound
-	}
-
 	updateParams := params.UpdateInstanceParams{
 		Status:        status,
 		ProviderFault: providerFault,


### PR DESCRIPTION
This change removes the check for the runner in the internal provider state before setting the DB instance status. We should not gate DB writes based on worker status. If the runner was removed from the DB, then the DB layer will return a not found error on anything other than create or delete.