### PR TITLE
Add resiliency for all workers

### DIFF
--- a/cmd/garm/main.go
+++ b/cmd/garm/main.go
@@ -272,20 +272,22 @@ func main() {
 		log.Fatalf("loading providers: %+v", err)
 	}
 
-	entityController, err := entity.NewController(ctx, db, providers)
-	if err != nil {
-		log.Fatalf("failed to create entity controller: %+v", err)
-	}
-	if err := entityController.Start(); err != nil {
-		log.Fatalf("failed to start entity controller: %+v", err)
-	}
-
+	// Provider worker must start first — its watcher consumer must be
+	// registered before entity/scaleset workers create instances.
 	providerWorker, err := provider.NewWorker(ctx, db, providers, instanceTokenGetter)
 	if err != nil {
 		log.Fatalf("failed to create provider worker: %+v", err)
 	}
 	if err := providerWorker.Start(); err != nil {
 		log.Fatalf("failed to start provider worker: %+v", err)
+	}
+
+	entityController, err := entity.NewController(ctx, db, providers)
+	if err != nil {
+		log.Fatalf("failed to create entity controller: %+v", err)
+	}
+	if err := entityController.Start(); err != nil {
+		log.Fatalf("failed to start entity controller: %+v", err)
 	}
 
 	// If there are many repos/pools, this may take a long time.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -45,7 +45,15 @@ import (
 	"github.com/cloudbase/garm/runner/providers"
 	"github.com/cloudbase/garm/util/github"
 	"github.com/cloudbase/garm/util/github/scalesets"
+	workersCommon "github.com/cloudbase/garm/workers/common"
 )
+
+const poolManagerRetryInterval = 5 * time.Second
+
+type failedEntity struct {
+	entityType params.ForgeEntityType
+	id         string
+}
 
 func NewRunner(ctx context.Context, cfg config.Config, db dbCommon.Store, token auth.InstanceTokenGetter) (*Runner, error) {
 	ctrlID, err := db.ControllerInfo()
@@ -79,11 +87,11 @@ func NewRunner(ctx context.Context, cfg config.Config, db dbCommon.Store, token 
 		tokenGetter:     token,
 		poolManagerCtrl: poolManagerCtrl,
 		providers:       providers,
+		backoff:         workersCommon.NewBackoff(workersCommon.DefaultBackoffConfig()),
+		failedEntities:  make(map[string]failedEntity),
 	}
 
-	if err := runner.loadReposOrgsAndEnterprises(); err != nil {
-		return nil, fmt.Errorf("error loading pool managers: %w", err)
-	}
+	runner.loadReposOrgsAndEnterprises()
 
 	return runner, nil
 }
@@ -237,6 +245,14 @@ type Runner struct {
 	poolManagerCtrl PoolManagerController
 
 	providers map[string]common.Provider
+	backoff   *workersCommon.Backoff
+	quit      chan struct{}
+	running   bool
+
+	failedEntities    map[string]failedEntity
+	reposLoaded       bool
+	orgsLoaded        bool
+	enterprisesLoaded bool
 }
 
 // UpdateController will update the controller settings.
@@ -355,105 +371,49 @@ func (r *Runner) ListProviders(ctx context.Context) ([]params.Provider, error) {
 	return ret, nil
 }
 
-func (r *Runner) loadReposOrgsAndEnterprises() error {
+func (r *Runner) loadReposOrgsAndEnterprises() {
 	r.mux.Lock()
 	defer r.mux.Unlock()
 
 	repos, err := r.store.ListRepositories(r.ctx, params.RepositoryFilter{})
 	if err != nil {
-		return fmt.Errorf("error fetching repositories: %w", err)
+		slog.ErrorContext(r.ctx, "fetching repositories", "error", err)
+	} else {
+		r.reposLoaded = true
+	}
+	for _, repo := range repos {
+		r.createAndStartRepoPoolManager(repo)
 	}
 
 	orgs, err := r.store.ListOrganizations(r.ctx, params.OrganizationFilter{})
 	if err != nil {
-		return fmt.Errorf("error fetching organizations: %w", err)
+		slog.ErrorContext(r.ctx, "fetching organizations", "error", err)
+	} else {
+		r.orgsLoaded = true
+	}
+	for _, org := range orgs {
+		r.createAndStartOrgPoolManager(org)
 	}
 
 	enterprises, err := r.store.ListEnterprises(r.ctx, params.EnterpriseFilter{})
 	if err != nil {
-		return fmt.Errorf("error fetching enterprises: %w", err)
+		slog.ErrorContext(r.ctx, "fetching enterprises", "error", err)
+	} else {
+		r.enterprisesLoaded = true
 	}
-
-	g, _ := errgroup.WithContext(r.ctx)
-	for _, repo := range repos {
-		repo := repo
-		g.Go(func() error {
-			slog.InfoContext(
-				r.ctx, "creating pool manager for repo",
-				"repo_owner", repo.Owner, "repo_name", repo.Name)
-			_, err := r.poolManagerCtrl.CreateRepoPoolManager(r.ctx, repo, r.providers, r.store)
-			return err
-		})
-	}
-
-	for _, org := range orgs {
-		org := org
-		g.Go(func() error {
-			slog.InfoContext(r.ctx, "creating pool manager for organization", "org_name", org.Name)
-			_, err := r.poolManagerCtrl.CreateOrgPoolManager(r.ctx, org, r.providers, r.store)
-			return err
-		})
-	}
-
 	for _, enterprise := range enterprises {
-		enterprise := enterprise
-		g.Go(func() error {
-			slog.InfoContext(r.ctx, "creating pool manager for enterprise", "enterprise_name", enterprise.Name)
-			_, err := r.poolManagerCtrl.CreateEnterprisePoolManager(r.ctx, enterprise, r.providers, r.store)
-			return err
-		})
+		r.createAndStartEnterprisePoolManager(enterprise)
 	}
-
-	if err := r.waitForErrorGroupOrTimeout(g); err != nil {
-		return fmt.Errorf("failed to create pool managers: %w", err)
-	}
-	return nil
 }
 
 func (r *Runner) Start() error {
 	r.mux.Lock()
 	defer r.mux.Unlock()
 
-	repositories, err := r.poolManagerCtrl.GetRepoPoolManagers()
-	if err != nil {
-		return fmt.Errorf("error fetch repo pool managers: %w", err)
-	}
+	r.running = true
+	r.quit = make(chan struct{})
+	go workersCommon.RetryLoop(r.ctx, r.quit, poolManagerRetryInterval, r.retryFailedPoolManagers)
 
-	organizations, err := r.poolManagerCtrl.GetOrgPoolManagers()
-	if err != nil {
-		return fmt.Errorf("error fetch org pool managers: %w", err)
-	}
-
-	enterprises, err := r.poolManagerCtrl.GetEnterprisePoolManagers()
-	if err != nil {
-		return fmt.Errorf("error fetch enterprise pool managers: %w", err)
-	}
-
-	g, _ := errgroup.WithContext(r.ctx)
-	for _, repo := range repositories {
-		repo := repo
-		g.Go(func() error {
-			return repo.Start()
-		})
-	}
-
-	for _, org := range organizations {
-		org := org
-		g.Go(func() error {
-			return org.Start()
-		})
-	}
-
-	for _, enterprise := range enterprises {
-		enterprise := enterprise
-		g.Go(func() error {
-			return enterprise.Start()
-		})
-	}
-
-	if err := r.waitForErrorGroupOrTimeout(g); err != nil {
-		return fmt.Errorf("failed to start pool managers: %w", err)
-	}
 	return nil
 }
 
@@ -476,9 +436,211 @@ func (r *Runner) waitForErrorGroupOrTimeout(g *errgroup.Group) error {
 	}
 }
 
+func (r *Runner) createAndStartRepoPoolManager(repo params.Repository) {
+	slog.InfoContext(r.ctx, "creating pool manager for repo", "repo_owner", repo.Owner, "repo_name", repo.Name)
+	poolMgr, err := r.poolManagerCtrl.CreateRepoPoolManager(r.ctx, repo, r.providers, r.store)
+	if err != nil {
+		slog.ErrorContext(r.ctx, "creating repo pool manager", "repo_owner", repo.Owner, "repo_name", repo.Name, "error", err)
+		r.failedEntities[repo.ID] = failedEntity{entityType: params.ForgeEntityTypeRepository, id: repo.ID}
+		r.backoff.RecordFailure(repo.ID)
+		return
+	}
+	if err := poolMgr.Start(); err != nil {
+		slog.ErrorContext(r.ctx, "starting repo pool manager", "repo_owner", repo.Owner, "repo_name", repo.Name, "error", err)
+		if deleteErr := r.poolManagerCtrl.DeleteRepoPoolManager(repo); deleteErr != nil {
+			slog.ErrorContext(r.ctx, "cleaning up failed repo pool manager", "repo_id", repo.ID, "error", deleteErr)
+		}
+		r.failedEntities[repo.ID] = failedEntity{entityType: params.ForgeEntityTypeRepository, id: repo.ID}
+		r.backoff.RecordFailure(repo.ID)
+		return
+	}
+	delete(r.failedEntities, repo.ID)
+	r.backoff.RecordSuccess(repo.ID)
+}
+
+func (r *Runner) createAndStartOrgPoolManager(org params.Organization) {
+	slog.InfoContext(r.ctx, "creating pool manager for organization", "org_name", org.Name)
+	poolMgr, err := r.poolManagerCtrl.CreateOrgPoolManager(r.ctx, org, r.providers, r.store)
+	if err != nil {
+		slog.ErrorContext(r.ctx, "creating org pool manager", "org_name", org.Name, "error", err)
+		r.failedEntities[org.ID] = failedEntity{entityType: params.ForgeEntityTypeOrganization, id: org.ID}
+		r.backoff.RecordFailure(org.ID)
+		return
+	}
+	if err := poolMgr.Start(); err != nil {
+		slog.ErrorContext(r.ctx, "starting org pool manager", "org_name", org.Name, "error", err)
+		if deleteErr := r.poolManagerCtrl.DeleteOrgPoolManager(org); deleteErr != nil {
+			slog.ErrorContext(r.ctx, "cleaning up failed org pool manager", "org_id", org.ID, "error", deleteErr)
+		}
+		r.failedEntities[org.ID] = failedEntity{entityType: params.ForgeEntityTypeOrganization, id: org.ID}
+		r.backoff.RecordFailure(org.ID)
+		return
+	}
+	delete(r.failedEntities, org.ID)
+	r.backoff.RecordSuccess(org.ID)
+}
+
+func (r *Runner) createAndStartEnterprisePoolManager(enterprise params.Enterprise) {
+	slog.InfoContext(r.ctx, "creating pool manager for enterprise", "enterprise_name", enterprise.Name)
+	poolMgr, err := r.poolManagerCtrl.CreateEnterprisePoolManager(r.ctx, enterprise, r.providers, r.store)
+	if err != nil {
+		slog.ErrorContext(r.ctx, "creating enterprise pool manager", "enterprise_name", enterprise.Name, "error", err)
+		r.failedEntities[enterprise.ID] = failedEntity{entityType: params.ForgeEntityTypeEnterprise, id: enterprise.ID}
+		r.backoff.RecordFailure(enterprise.ID)
+		return
+	}
+	if err := poolMgr.Start(); err != nil {
+		slog.ErrorContext(r.ctx, "starting enterprise pool manager", "enterprise_name", enterprise.Name, "error", err)
+		if deleteErr := r.poolManagerCtrl.DeleteEnterprisePoolManager(enterprise); deleteErr != nil {
+			slog.ErrorContext(r.ctx, "cleaning up failed enterprise pool manager", "enterprise_id", enterprise.ID, "error", deleteErr)
+		}
+		r.failedEntities[enterprise.ID] = failedEntity{entityType: params.ForgeEntityTypeEnterprise, id: enterprise.ID}
+		r.backoff.RecordFailure(enterprise.ID)
+		return
+	}
+	delete(r.failedEntities, enterprise.ID)
+	r.backoff.RecordSuccess(enterprise.ID)
+}
+
+func (r *Runner) retryFailedPoolManagers() {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	if !r.running {
+		return
+	}
+
+	// Retry listing if initial list queries failed.
+	if !r.reposLoaded {
+		repos, err := r.store.ListRepositories(r.ctx, params.RepositoryFilter{})
+		if err != nil {
+			slog.ErrorContext(r.ctx, "retrying repository list", "error", err)
+		} else {
+			slog.InfoContext(r.ctx, "repositories loaded successfully after retry")
+			r.reposLoaded = true
+			for _, repo := range repos {
+				if _, err := r.poolManagerCtrl.GetRepoPoolManager(repo); err == nil {
+					continue
+				}
+				r.createAndStartRepoPoolManager(repo)
+			}
+		}
+	}
+
+	if !r.orgsLoaded {
+		orgs, err := r.store.ListOrganizations(r.ctx, params.OrganizationFilter{})
+		if err != nil {
+			slog.ErrorContext(r.ctx, "retrying organization list", "error", err)
+		} else {
+			slog.InfoContext(r.ctx, "organizations loaded successfully after retry")
+			r.orgsLoaded = true
+			for _, org := range orgs {
+				if _, err := r.poolManagerCtrl.GetOrgPoolManager(org); err == nil {
+					continue
+				}
+				r.createAndStartOrgPoolManager(org)
+			}
+		}
+	}
+
+	if !r.enterprisesLoaded {
+		enterprises, err := r.store.ListEnterprises(r.ctx, params.EnterpriseFilter{})
+		if err != nil {
+			slog.ErrorContext(r.ctx, "retrying enterprise list", "error", err)
+		} else {
+			slog.InfoContext(r.ctx, "enterprises loaded successfully after retry")
+			r.enterprisesLoaded = true
+			for _, enterprise := range enterprises {
+				if _, err := r.poolManagerCtrl.GetEnterprisePoolManager(enterprise); err == nil {
+					continue
+				}
+				r.createAndStartEnterprisePoolManager(enterprise)
+			}
+		}
+	}
+
+	// Retry individual failed entities.
+	for id, fe := range r.failedEntities {
+		if !r.backoff.ShouldRetry(id) {
+			continue
+		}
+		r.retryFailedEntity(fe)
+	}
+}
+
+func (r *Runner) retryFailedEntity(fe failedEntity) {
+	switch fe.entityType {
+	case params.ForgeEntityTypeRepository:
+		repo, err := r.store.GetRepositoryByID(r.ctx, fe.id)
+		if err != nil {
+			if errors.Is(err, runnerErrors.ErrNotFound) {
+				slog.InfoContext(r.ctx, "repository deleted, removing from retry set", "repo_id", fe.id)
+				delete(r.failedEntities, fe.id)
+				r.backoff.RecordSuccess(fe.id)
+				return
+			}
+			slog.ErrorContext(r.ctx, "fetching repository for retry", "repo_id", fe.id, "error", err)
+			r.backoff.RecordFailure(fe.id)
+			return
+		}
+		// Clean up any stale pool manager left from a previous failed attempt
+		// before recreating. Delete is a no-op if no pool manager exists.
+		if err := r.poolManagerCtrl.DeleteRepoPoolManager(repo); err != nil {
+			slog.ErrorContext(r.ctx, "cleaning up stale repo pool manager before retry", "repo_id", fe.id, "error", err)
+			r.backoff.RecordFailure(fe.id)
+			return
+		}
+		r.createAndStartRepoPoolManager(repo)
+	case params.ForgeEntityTypeOrganization:
+		org, err := r.store.GetOrganizationByID(r.ctx, fe.id)
+		if err != nil {
+			if errors.Is(err, runnerErrors.ErrNotFound) {
+				slog.InfoContext(r.ctx, "organization deleted, removing from retry set", "org_id", fe.id)
+				delete(r.failedEntities, fe.id)
+				r.backoff.RecordSuccess(fe.id)
+				return
+			}
+			slog.ErrorContext(r.ctx, "fetching organization for retry", "org_id", fe.id, "error", err)
+			r.backoff.RecordFailure(fe.id)
+			return
+		}
+		if err := r.poolManagerCtrl.DeleteOrgPoolManager(org); err != nil {
+			slog.ErrorContext(r.ctx, "cleaning up stale org pool manager before retry", "org_id", fe.id, "error", err)
+			r.backoff.RecordFailure(fe.id)
+			return
+		}
+		r.createAndStartOrgPoolManager(org)
+	case params.ForgeEntityTypeEnterprise:
+		enterprise, err := r.store.GetEnterpriseByID(r.ctx, fe.id)
+		if err != nil {
+			if errors.Is(err, runnerErrors.ErrNotFound) {
+				slog.InfoContext(r.ctx, "enterprise deleted, removing from retry set", "enterprise_id", fe.id)
+				delete(r.failedEntities, fe.id)
+				r.backoff.RecordSuccess(fe.id)
+				return
+			}
+			slog.ErrorContext(r.ctx, "fetching enterprise for retry", "enterprise_id", fe.id, "error", err)
+			r.backoff.RecordFailure(fe.id)
+			return
+		}
+		if err := r.poolManagerCtrl.DeleteEnterprisePoolManager(enterprise); err != nil {
+			slog.ErrorContext(r.ctx, "cleaning up stale enterprise pool manager before retry", "enterprise_id", fe.id, "error", err)
+			r.backoff.RecordFailure(fe.id)
+			return
+		}
+		r.createAndStartEnterprisePoolManager(enterprise)
+	}
+}
+
 func (r *Runner) Stop() error {
 	r.mux.Lock()
 	defer r.mux.Unlock()
+
+	r.running = false
+	if r.quit != nil {
+		close(r.quit)
+		r.quit = nil
+	}
 
 	repos, err := r.poolManagerCtrl.GetRepoPoolManagers()
 	if err != nil {

--- a/test/integration/endpoints_test.go
+++ b/test/integration/endpoints_test.go
@@ -47,7 +47,7 @@ func (suite *GarmSuite) TestGithubEndpointOperations() {
 	suite.Equal(endpoint.BaseURL, endpointParams.BaseURL, "Endpoint base URL mismatch")
 	suite.Equal(endpoint.APIBaseURL, endpointParams.APIBaseURL, "Endpoint API base URL mismatch")
 	suite.Equal(endpoint.UploadBaseURL, endpointParams.UploadBaseURL, "Endpoint upload base URL mismatch")
-	suite.Equal(string(endpoint.CACertBundle), string(caBundle), "Endpoint CA cert bundle mismatch")
+	suite.Equal(string(bytes.Trim(endpoint.CACertBundle, "\r\n")), string(bytes.Trim(caBundle, "\r\n")), "Endpoint CA cert bundle mismatch")
 
 	endpoint2 := suite.GetGithubEndpoint(endpointParams.Name)
 	suite.NotNil(endpoint, "endpoint is nil")

--- a/workers/common/backoff.go
+++ b/workers/common/backoff.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Cloudbase Solutions SRL
+//
+//	Licensed under the Apache License, Version 2.0 (the "License"); you may
+//	not use this file except in compliance with the License. You may obtain
+//	a copy of the License at
+//
+//	     http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//	WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//	License for the specific language governing permissions and limitations
+//	under the License.
+
+package common
+
+import (
+	"crypto/rand"
+	"math/big"
+	"sync"
+	"time"
+)
+
+// BackoffConfig configures the exponential backoff parameters.
+type BackoffConfig struct {
+	// Initial is the initial backoff duration after the first failure.
+	Initial time.Duration
+	// Multiplier is the geometric progression factor applied on each failure.
+	Multiplier float64
+	// Max is the maximum backoff duration.
+	Max time.Duration
+	// JitterFrac adds randomization to prevent thundering herd. A value of 0.2
+	// means the actual delay is within ±20% of the computed backoff.
+	JitterFrac float64
+}
+
+// DefaultBackoffConfig returns a BackoffConfig with sensible defaults:
+// 10s initial, 1.5x multiplier, 5m max, 20% jitter.
+func DefaultBackoffConfig() BackoffConfig {
+	return BackoffConfig{
+		Initial:    10 * time.Second,
+		Multiplier: 1.5,
+		Max:        5 * time.Minute,
+		JitterFrac: 0.2,
+	}
+}
+
+type backoffEntry struct {
+	backoff             time.Duration
+	lastRecordedFailure time.Time
+	mux                 sync.Mutex
+}
+
+// Backoff tracks per-key exponential backoff state. It is safe for concurrent use.
+type Backoff struct {
+	config BackoffConfig
+	// map[string]*backoffEntry
+	entries sync.Map
+}
+
+// NewBackoff creates a new Backoff tracker with the given configuration.
+func NewBackoff(config BackoffConfig) *Backoff {
+	return &Backoff{
+		config: config,
+	}
+}
+
+// ShouldRetry returns true if the key has no recorded failure or if the
+// backoff deadline has passed.
+func (b *Backoff) ShouldRetry(key string) bool {
+	val, ok := b.entries.Load(key)
+	if !ok {
+		return true
+	}
+
+	entry := val.(*backoffEntry)
+	entry.mux.Lock()
+	defer entry.mux.Unlock()
+
+	if entry.lastRecordedFailure.IsZero() || entry.backoff == 0 {
+		return true
+	}
+
+	deadline := entry.lastRecordedFailure.Add(entry.backoff)
+	return time.Now().UTC().After(deadline)
+}
+
+// RecordFailure records a failure for the given key, setting or increasing
+// the backoff duration with jitter.
+func (b *Backoff) RecordFailure(key string) {
+	val, _ := b.entries.LoadOrStore(key, &backoffEntry{})
+	entry := val.(*backoffEntry)
+	entry.mux.Lock()
+	defer entry.mux.Unlock()
+
+	entry.lastRecordedFailure = time.Now().UTC()
+	if entry.backoff == 0 {
+		entry.backoff = b.config.Initial
+	} else {
+		entry.backoff = time.Duration(float64(entry.backoff) * b.config.Multiplier)
+	}
+	if entry.backoff > b.config.Max {
+		entry.backoff = b.config.Max
+	}
+
+	// Apply jitter
+	if b.config.JitterFrac > 0 {
+		const precision = 1 << 16
+		n, err := rand.Int(rand.Reader, big.NewInt(precision))
+		if err == nil {
+			rnd := float64(n.Int64()) / precision
+			jitter := 1.0 + (rnd*2-1)*b.config.JitterFrac
+			entry.backoff = min(time.Duration(float64(entry.backoff)*jitter), b.config.Max)
+		}
+	}
+}
+
+// RecordSuccess clears the backoff state for the given key.
+func (b *Backoff) RecordSuccess(key string) {
+	b.entries.Delete(key)
+}

--- a/workers/common/retry.go
+++ b/workers/common/retry.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Cloudbase Solutions SRL
+//
+//	Licensed under the Apache License, Version 2.0 (the "License"); you may
+//	not use this file except in compliance with the License. You may obtain
+//	a copy of the License at
+//
+//	     http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//	WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//	License for the specific language governing permissions and limitations
+//	under the License.
+
+package common
+
+import (
+	"context"
+	"time"
+)
+
+// RetryLoop runs fn immediately and then on a fixed ticker until ctx is
+// cancelled or quit is closed. It is intended to be run as a goroutine.
+func RetryLoop(ctx context.Context, quit <-chan struct{}, interval time.Duration, fn func()) {
+	fn()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			fn()
+		case <-ctx.Done():
+			return
+		case <-quit:
+			return
+		}
+	}
+}

--- a/workers/common/unbounded_chan.go
+++ b/workers/common/unbounded_chan.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Cloudbase Solutions SRL
+//
+//	Licensed under the Apache License, Version 2.0 (the "License"); you may
+//	not use this file except in compliance with the License. You may obtain
+//	a copy of the License at
+//
+//	     http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//	WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//	License for the specific language governing permissions and limitations
+//	under the License.
+
+package common
+
+import "context"
+
+// UnboundedChan provides an unbounded FIFO channel backed by an internal
+// slice-based queue. A router goroutine absorbs sends into the queue
+// immediately and feeds them to the output one at a time. This ensures
+// the producer is never blocked (beyond a brief channel send), while
+// the consumer processes events sequentially.
+// In theory, this does have the potential to grow forever but in practice
+// it should not happen as we consume the queue and process it. Regardless
+// of result, the queue should shrink. The only way this never shrinks is if
+// the consumer is deadlocked for whatever reason.
+//
+// Use In() to send events and Out() to receive them.
+type UnboundedChan[T any] struct {
+	in   chan T
+	out  chan T
+	ctx  context.Context
+	quit <-chan struct{}
+}
+
+// NewUnboundedChan creates and starts an UnboundedChan. The router goroutine
+// runs until ctx is cancelled or quit is closed.
+func NewUnboundedChan[T any](ctx context.Context, quit <-chan struct{}) *UnboundedChan[T] {
+	u := &UnboundedChan[T]{
+		in:   make(chan T),
+		out:  make(chan T),
+		ctx:  ctx,
+		quit: quit,
+	}
+	go u.run()
+	return u
+}
+
+// In returns the send side of the channel.
+func (u *UnboundedChan[T]) In() chan<- T {
+	return u.in
+}
+
+// Out returns the receive side of the channel.
+func (u *UnboundedChan[T]) Out() <-chan T {
+	return u.out
+}
+
+// Process reads from the output channel and calls handler for each item
+// sequentially. It blocks until ctx is cancelled or quit is closed.
+func (u *UnboundedChan[T]) Process(handler func(T)) {
+	for {
+		select {
+		case item := <-u.out:
+			handler(item)
+		case <-u.ctx.Done():
+			return
+		case <-u.quit:
+			return
+		}
+	}
+}
+
+func (u *UnboundedChan[T]) run() {
+	var queue []T
+
+	for {
+		if len(queue) == 0 {
+			select {
+			case item := <-u.in:
+				queue = append(queue, item)
+			case <-u.ctx.Done():
+				return
+			case <-u.quit:
+				return
+			}
+			continue
+		}
+
+		select {
+		case item := <-u.in:
+			queue = append(queue, item)
+		case u.out <- queue[0]:
+			queue = queue[1:]
+		case <-u.ctx.Done():
+			return
+		case <-u.quit:
+			return
+		}
+	}
+}

--- a/workers/entity/controller.go
+++ b/workers/entity/controller.go
@@ -18,8 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-
-	"golang.org/x/sync/errgroup"
+	"time"
 
 	"github.com/cloudbase/garm/auth"
 	dbCommon "github.com/cloudbase/garm/database/common"
@@ -27,7 +26,10 @@ import (
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
 	garmUtil "github.com/cloudbase/garm/util"
+	workersCommon "github.com/cloudbase/garm/workers/common"
 )
+
+const retryLoopInterval = 5 * time.Second
 
 func NewController(ctx context.Context, store dbCommon.Store, providers map[string]common.Provider) (*Controller, error) {
 	consumerID := "entity-controller"
@@ -41,6 +43,7 @@ func NewController(ctx context.Context, store dbCommon.Store, providers map[stri
 		ctx:        ctx,
 		store:      store,
 		providers:  providers,
+		backoff:    workersCommon.NewBackoff(workersCommon.DefaultBackoffConfig()),
 	}, nil
 }
 
@@ -55,136 +58,89 @@ type Controller struct {
 	// sync.Map[string]*Worker
 	Entities sync.Map
 
+	eventQueue *workersCommon.UnboundedChan[dbCommon.ChangePayload]
+	backoff    *workersCommon.Backoff
+
 	running bool
 	quit    chan struct{}
 
 	mux sync.Mutex
 }
 
-func (c *Controller) loadAllRepositories() error {
+func (c *Controller) loadAllRepositories() {
 	repos, err := c.store.ListRepositories(c.ctx, params.RepositoryFilter{})
 	if err != nil {
-		return fmt.Errorf("fetching repositories: %w", err)
+		slog.ErrorContext(c.ctx, "fetching repositories", "error", err)
+		return
 	}
 
-	g, _ := errgroup.WithContext(c.ctx)
 	for _, repo := range repos {
-		g.Go(func() error {
-			entity, err := repo.GetEntity()
-			if err != nil {
-				return fmt.Errorf("getting entity: %w", err)
-			}
-			worker, err := NewWorker(c.ctx, c.store, entity, c.providers)
-			if err != nil {
-				return fmt.Errorf("creating worker: %w", err)
-			}
-			if err := worker.Start(); err != nil {
-				return fmt.Errorf("starting worker: %w", err)
-			}
-			c.Entities.Store(entity.ID, worker)
-			return nil
-		})
+		entity, err := repo.GetEntity()
+		if err != nil {
+			slog.ErrorContext(c.ctx, "getting entity from repository", "error", err)
+			continue
+		}
+		c.storeEntityWorker(entity)
 	}
-	if err := c.waitForErrorGroupOrContextCancelled(g); err != nil {
-		return fmt.Errorf("waiting for error group: %w", err)
-	}
-	return nil
 }
 
-func (c *Controller) loadAllOrganizations() error {
+func (c *Controller) loadAllOrganizations() {
 	orgs, err := c.store.ListOrganizations(c.ctx, params.OrganizationFilter{})
 	if err != nil {
-		return fmt.Errorf("fetching organizations: %w", err)
+		slog.ErrorContext(c.ctx, "fetching organizations", "error", err)
+		return
 	}
 
-	g, _ := errgroup.WithContext(c.ctx)
 	for _, org := range orgs {
-		g.Go(func() error {
-			entity, err := org.GetEntity()
-			if err != nil {
-				return fmt.Errorf("getting entity: %w", err)
-			}
-			worker, err := NewWorker(c.ctx, c.store, entity, c.providers)
-			if err != nil {
-				return fmt.Errorf("creating worker: %w", err)
-			}
-			if err := worker.Start(); err != nil {
-				return fmt.Errorf("starting worker: %w", err)
-			}
-			c.Entities.Store(entity.ID, worker)
-			return nil
-		})
+		entity, err := org.GetEntity()
+		if err != nil {
+			slog.ErrorContext(c.ctx, "getting entity from organization", "error", err)
+			continue
+		}
+		c.storeEntityWorker(entity)
 	}
-	if err := c.waitForErrorGroupOrContextCancelled(g); err != nil {
-		return fmt.Errorf("waiting for error group: %w", err)
-	}
-	return nil
 }
 
-func (c *Controller) loadAllEnterprises() error {
+func (c *Controller) loadAllEnterprises() {
 	enterprises, err := c.store.ListEnterprises(c.ctx, params.EnterpriseFilter{})
 	if err != nil {
-		return fmt.Errorf("fetching enterprises: %w", err)
+		slog.ErrorContext(c.ctx, "fetching enterprises", "error", err)
+		return
 	}
-
-	g, _ := errgroup.WithContext(c.ctx)
 
 	for _, enterprise := range enterprises {
-		g.Go(func() error {
-			entity, err := enterprise.GetEntity()
-			if err != nil {
-				return fmt.Errorf("getting entity: %w", err)
-			}
-			worker, err := NewWorker(c.ctx, c.store, entity, c.providers)
-			if err != nil {
-				return fmt.Errorf("creating worker: %w", err)
-			}
-			if err := worker.Start(); err != nil {
-				return fmt.Errorf("starting worker: %w", err)
-			}
-			c.Entities.Store(entity.ID, worker)
-			return nil
-		})
+		entity, err := enterprise.GetEntity()
+		if err != nil {
+			slog.ErrorContext(c.ctx, "getting entity from enterprise", "error", err)
+			continue
+		}
+		c.storeEntityWorker(entity)
 	}
-	if err := c.waitForErrorGroupOrContextCancelled(g); err != nil {
-		return fmt.Errorf("waiting for error group: %w", err)
+}
+
+// storeEntityWorker creates a worker for the entity and stores it.
+// The retry loop will start it.
+func (c *Controller) storeEntityWorker(entity params.ForgeEntity) {
+	worker, err := NewWorker(c.ctx, c.store, entity, c.providers)
+	if err != nil {
+		slog.ErrorContext(c.ctx, "creating worker", "entity_id", entity.ID, "error", err)
+		return
 	}
-	return nil
+	c.Entities.Store(entity.ID, worker)
 }
 
 func (c *Controller) Start() error {
 	c.mux.Lock()
+	defer c.mux.Unlock()
+
 	if c.running {
-		c.mux.Unlock()
 		return nil
 	}
-	c.mux.Unlock()
+	c.quit = nil
 
-	g, _ := errgroup.WithContext(c.ctx)
-	g.Go(func() error {
-		if err := c.loadAllEnterprises(); err != nil {
-			return fmt.Errorf("loading enterprises: %w", err)
-		}
-		return nil
-	})
-
-	g.Go(func() error {
-		if err := c.loadAllOrganizations(); err != nil {
-			return fmt.Errorf("loading organizations: %w", err)
-		}
-		return nil
-	})
-
-	g.Go(func() error {
-		if err := c.loadAllRepositories(); err != nil {
-			return fmt.Errorf("loading repositories: %w", err)
-		}
-		return nil
-	})
-
-	if err := c.waitForErrorGroupOrContextCancelled(g); err != nil {
-		return fmt.Errorf("waiting for error group: %w", err)
-	}
+	c.loadAllEnterprises()
+	c.loadAllOrganizations()
+	c.loadAllRepositories()
 
 	consumer, err := watcher.RegisterConsumer(
 		c.ctx, c.consumerID,
@@ -194,13 +150,14 @@ func (c *Controller) Start() error {
 		return fmt.Errorf("failed to create consumer for entity controller: %w", err)
 	}
 
-	c.mux.Lock()
 	c.consumer = consumer
 	c.running = true
 	c.quit = make(chan struct{})
-	c.mux.Unlock()
+	c.eventQueue = workersCommon.NewUnboundedChan[dbCommon.ChangePayload](c.ctx, c.quit)
 
 	go c.loop()
+	go c.eventQueue.Process(c.handleWatcherEvent)
+	go workersCommon.RetryLoop(c.ctx, c.quit, retryLoopInterval, c.retryFailedWorkers)
 
 	return nil
 }
@@ -230,13 +187,57 @@ func (c *Controller) Stop() error {
 	return nil
 }
 
+func (c *Controller) retryFailedWorkers() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if !c.running {
+		return
+	}
+
+	c.Entities.Range(func(key, value any) bool {
+		entityID := key.(string)
+		worker := value.(*Worker)
+
+		if worker.IsRunning() {
+			return true
+		}
+
+		if !c.backoff.ShouldRetry(entityID) {
+			return true
+		}
+
+		slog.InfoContext(c.ctx, "retrying failed worker", "entity_id", entityID)
+		if err := worker.Start(); err != nil {
+			slog.ErrorContext(c.ctx, "retry failed for worker", "entity_id", entityID, "error", err)
+			worker.addStatusEvent(fmt.Sprintf("retry failed for worker %s (%s): %s", entityID, worker.Entity.ForgeURL(), err.Error()), params.EventError)
+			c.backoff.RecordFailure(entityID)
+			return true
+		}
+
+		slog.InfoContext(c.ctx, "worker successfully started after retry", "entity_id", entityID)
+		worker.addStatusEvent(fmt.Sprintf("worker successfully started after retry for entity: %s (%s)", entityID, worker.Entity.ForgeURL()), params.EventInfo)
+		c.backoff.RecordSuccess(entityID)
+		return true
+	})
+}
+
+// loop drains the watcher consumer channel as fast as possible.
+// It exits when the context is cancelled or quit is closed, triggering
+// a controller stop.
 func (c *Controller) loop() {
 	defer c.Stop()
 	for {
 		select {
 		case payload := <-c.consumer.Watch():
-			slog.InfoContext(c.ctx, "received payload")
-			go c.handleWatcherEvent(payload)
+			slog.DebugContext(c.ctx, "received payload, queuing for processing")
+			select {
+			case c.eventQueue.In() <- payload:
+			case <-c.ctx.Done():
+				return
+			case <-c.quit:
+				return
+			}
 		case <-c.ctx.Done():
 			return
 		case <-c.quit:

--- a/workers/entity/controller_watcher.go
+++ b/workers/entity/controller_watcher.go
@@ -14,7 +14,6 @@
 package entity
 
 import (
-	"fmt"
 	"log/slog"
 
 	dbCommon "github.com/cloudbase/garm/database/common"
@@ -22,6 +21,21 @@ import (
 )
 
 func (c *Controller) handleWatcherEvent(event dbCommon.ChangePayload) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if !c.running {
+		// Controller was stopped.
+		return
+	}
+
+	switch event.EntityType {
+	case dbCommon.GithubCredentialsEntityType, dbCommon.GiteaCredentialsEntityType:
+		slog.DebugContext(c.ctx, "got credentials payload event", "entity_type", event.EntityType)
+		c.handleCredentialsUpdateEvent(event)
+		return
+	}
+
 	var entityGetter params.EntityGetter
 	switch event.EntityType {
 	case dbCommon.RepositoryEntityType:
@@ -75,6 +89,35 @@ func (c *Controller) handleWatcherEvent(event dbCommon.ChangePayload) {
 	}
 }
 
+// handleCredentialsUpdateEvent propagates credential updates to non-running workers.
+// Running workers handle credential updates themselves via their own watcher.
+func (c *Controller) handleCredentialsUpdateEvent(event dbCommon.ChangePayload) {
+	creds, ok := event.Payload.(params.ForgeCredentials)
+	if !ok {
+		slog.ErrorContext(c.ctx, "invalid payload for credentials event", "entity_type", event.EntityType, "payload", event.Payload)
+		return
+	}
+
+	c.Entities.Range(func(_, value any) bool {
+		worker := value.(*Worker)
+		if worker.IsRunning() {
+			// Running workers handle credential updates via their own watcher.
+			return true
+		}
+
+		worker.mux.Lock()
+		defer worker.mux.Unlock()
+		if worker.Entity.Credentials.GetID() != creds.GetID() {
+			return true
+		}
+		slog.InfoContext(c.ctx, "propagating credential update to non-running worker", "entity_id", worker.Entity.ID)
+		worker.Entity.Credentials = creds
+		// Clear backoff so the retry loop picks up the fix immediately.
+		c.backoff.RecordSuccess(worker.Entity.ID)
+		return true
+	})
+}
+
 func (c *Controller) handleWatcherUpdateOperation(entity params.ForgeEntity) {
 	val, ok := c.Entities.Load(entity.ID)
 	if !ok {
@@ -91,14 +134,13 @@ func (c *Controller) handleWatcherUpdateOperation(entity params.ForgeEntity) {
 	}
 
 	slog.InfoContext(c.ctx, "updating entity worker", "entity_id", entity.ID, "entity_type", entity.EntityType)
+	worker.mux.Lock()
 	worker.Entity = entity
-	if err := worker.Start(); err != nil {
-		slog.ErrorContext(c.ctx, "starting worker after update", "entity_id", entity.ID, "error", err)
-		worker.addStatusEvent(fmt.Sprintf("failed to start worker for %s (%s) after update: %s", entity.ID, entity.ForgeURL(), err.Error()), params.EventError)
-		return
-	}
-	slog.InfoContext(c.ctx, "entity worker updated and successfully started", "entity_id", entity.ID, "entity_type", entity.EntityType)
-	worker.addStatusEvent(fmt.Sprintf("worker updated and successfully started for entity: %s (%s)", entity.ID, entity.ForgeURL()), params.EventInfo)
+	worker.mux.Unlock()
+	// Clear any previous backoff so the retry loop starts the worker
+	// immediately. The user may have fixed the issue by updating the entity.
+	c.backoff.RecordSuccess(entity.ID)
+	// The retry loop will start the worker.
 }
 
 func (c *Controller) handleWatcherCreateOperation(entity params.ForgeEntity) {
@@ -108,17 +150,10 @@ func (c *Controller) handleWatcherCreateOperation(entity params.ForgeEntity) {
 		return
 	}
 
-	slog.InfoContext(c.ctx, "starting entity worker", "entity_id", entity.ID, "entity_type", entity.EntityType)
-	if err := worker.Start(); err != nil {
-		slog.ErrorContext(c.ctx, "starting worker", "entity_id", entity.ID, "error", err)
-		return
-	}
-
 	if _, loaded := c.Entities.LoadOrStore(entity.ID, worker); loaded {
-		// A worker already exists for this entity. Stop the one we just created.
-		slog.DebugContext(c.ctx, "entity worker already exists", "entity_id", entity.ID)
-		worker.Stop()
+		slog.DebugContext(c.ctx, "entity already exists in worker list", "entity_id", entity.ID)
 	}
+	// The retry loop will start the worker.
 }
 
 func (c *Controller) handleWatcherDeleteOperation(entity params.ForgeEntity) {
@@ -127,6 +162,7 @@ func (c *Controller) handleWatcherDeleteOperation(entity params.ForgeEntity) {
 		slog.InfoContext(c.ctx, "entity not found in worker list", "entity_id", entity.ID)
 		return
 	}
+	c.backoff.RecordSuccess(entity.ID)
 	worker := val.(*Worker)
 	slog.InfoContext(c.ctx, "stopping entity worker", "entity_id", entity.ID, "entity_type", entity.EntityType)
 	if err := worker.Stop(); err != nil {

--- a/workers/entity/util.go
+++ b/workers/entity/util.go
@@ -16,8 +16,6 @@ package entity
 import (
 	"strings"
 
-	"golang.org/x/sync/errgroup"
-
 	dbCommon "github.com/cloudbase/garm/database/common"
 	"github.com/cloudbase/garm/database/watcher"
 	"github.com/cloudbase/garm/params"
@@ -30,15 +28,25 @@ const (
 )
 
 func composeControllerWatcherFilters() dbCommon.PayloadFilterFunc {
-	return watcher.WithAll(
-		watcher.WithAny(
-			watcher.WithEntityTypeFilter(dbCommon.RepositoryEntityType),
-			watcher.WithEntityTypeFilter(dbCommon.OrganizationEntityType),
-			watcher.WithEntityTypeFilter(dbCommon.EnterpriseEntityType),
+	return watcher.WithAny(
+		watcher.WithAll(
+			watcher.WithAny(
+				watcher.WithEntityTypeFilter(dbCommon.RepositoryEntityType),
+				watcher.WithEntityTypeFilter(dbCommon.OrganizationEntityType),
+				watcher.WithEntityTypeFilter(dbCommon.EnterpriseEntityType),
+			),
+			watcher.WithAny(
+				watcher.WithOperationTypeFilter(dbCommon.CreateOperation),
+				watcher.WithOperationTypeFilter(dbCommon.DeleteOperation),
+				watcher.WithOperationTypeFilter(dbCommon.UpdateOperation),
+			),
 		),
-		watcher.WithAny(
-			watcher.WithOperationTypeFilter(dbCommon.CreateOperation),
-			watcher.WithOperationTypeFilter(dbCommon.DeleteOperation),
+		// Watch for credential updates so we can propagate them to non-running workers.
+		watcher.WithAll(
+			watcher.WithAny(
+				watcher.WithEntityTypeFilter(dbCommon.GithubCredentialsEntityType),
+				watcher.WithEntityTypeFilter(dbCommon.GiteaCredentialsEntityType),
+			),
 			watcher.WithOperationTypeFilter(dbCommon.UpdateOperation),
 		),
 	)
@@ -56,27 +64,6 @@ func composeWorkerWatcherFilters(entity params.ForgeEntity) dbCommon.PayloadFilt
 			watcher.WithOperationTypeFilter(dbCommon.UpdateOperation),
 		),
 	)
-}
-
-func (c *Controller) waitForErrorGroupOrContextCancelled(g *errgroup.Group) error {
-	if g == nil {
-		return nil
-	}
-
-	done := make(chan error, 1)
-	go func() {
-		waitErr := g.Wait()
-		done <- waitErr
-	}()
-
-	select {
-	case err := <-done:
-		return err
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	case <-c.quit:
-		return nil
-	}
 }
 
 func poolIDFromLabels(runner params.RunnerReference) string {

--- a/workers/entity/worker.go
+++ b/workers/entity/worker.go
@@ -30,6 +30,7 @@ import (
 	garmUtil "github.com/cloudbase/garm/util"
 	"github.com/cloudbase/garm/util/github"
 	"github.com/cloudbase/garm/util/github/scalesets"
+	workersCommon "github.com/cloudbase/garm/workers/common"
 	"github.com/cloudbase/garm/workers/scaleset"
 )
 
@@ -61,6 +62,8 @@ type Worker struct {
 	providers          map[string]common.Provider
 	scaleSetController *scaleset.Controller
 
+	eventQueue *workersCommon.UnboundedChan[dbCommon.ChangePayload]
+
 	mux     sync.Mutex
 	running bool
 	quit    chan struct{}
@@ -76,13 +79,19 @@ func (w *Worker) Stop() error {
 	}
 	slog.DebugContext(w.ctx, "stopping entity worker")
 
-	if err := w.scaleSetController.Stop(); err != nil {
-		return fmt.Errorf("stopping scale set controller: %w", err)
+	if w.scaleSetController != nil {
+		if err := w.scaleSetController.Stop(); err != nil {
+			return fmt.Errorf("stopping scale set controller: %w", err)
+		}
 	}
 
 	w.running = false
-	close(w.quit)
-	w.consumer.Close()
+	if w.quit != nil {
+		close(w.quit)
+	}
+	if w.consumer != nil {
+		w.consumer.Close()
+	}
 	slog.DebugContext(w.ctx, "entity worker stopped", "entity", w.consumerID)
 	return nil
 }
@@ -92,11 +101,20 @@ func (w *Worker) Start() (err error) {
 	w.mux.Lock()
 	defer w.mux.Unlock()
 
+	if w.running {
+		// already running
+		return nil
+	}
+
 	epType, err := w.Entity.GetForgeType()
 	if err != nil {
 		return fmt.Errorf("failed to get endpoint type: %w", err)
 	}
 	if epType != params.GithubEndpointType {
+		// For now, only scalesets are migrated to the new worker model. So we
+		// return early here.
+		// Mark as running so the retry loop doesn't keep calling Start().
+		w.running = true
 		return nil
 	}
 
@@ -134,8 +152,10 @@ func (w *Worker) Start() (err error) {
 
 	w.running = true
 	w.quit = make(chan struct{})
+	w.eventQueue = workersCommon.NewUnboundedChan[dbCommon.ChangePayload](w.ctx, w.quit)
 
 	go w.loop()
+	go w.eventQueue.Process(w.handleWorkerWatcherEvent)
 	go w.consolidateRunnerLoop()
 	return nil
 }
@@ -242,8 +262,14 @@ func (w *Worker) loop() {
 	for {
 		select {
 		case payload := <-w.consumer.Watch():
-			slog.InfoContext(w.ctx, "received payload")
-			w.handleWorkerWatcherEvent(payload)
+			slog.DebugContext(w.ctx, "received payload, queuing for processing")
+			select {
+			case w.eventQueue.In() <- payload:
+			case <-w.ctx.Done():
+				return
+			case <-w.quit:
+				return
+			}
 		case <-w.ctx.Done():
 			return
 		case <-w.quit:

--- a/workers/provider/provider.go
+++ b/workers/provider/provider.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	commonParams "github.com/cloudbase/garm-provider-common/params"
 	"github.com/cloudbase/garm/auth"
@@ -26,7 +27,37 @@ import (
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
 	garmUtil "github.com/cloudbase/garm/util"
+	workersCommon "github.com/cloudbase/garm/workers/common"
 )
+
+const retryLoopInterval = 5 * time.Second
+
+type runnerEntry struct {
+	instance params.Instance
+	manager  *instanceManager
+	mux      sync.Mutex
+}
+
+func (r *runnerEntry) SetManager(m *instanceManager) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	r.manager = m
+}
+
+func (r *runnerEntry) SetInstance(inst params.Instance) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	r.instance = inst
+}
+
+func (r *runnerEntry) Stop() error {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+	if r.manager == nil {
+		return nil
+	}
+	return r.manager.Stop()
+}
 
 func NewWorker(ctx context.Context, store dbCommon.Store, providers map[string]common.Provider, tokenGetter auth.InstanceTokenGetter) (*Provider, error) {
 	consumerID := "provider-worker"
@@ -41,6 +72,7 @@ func NewWorker(ctx context.Context, store dbCommon.Store, providers map[string]c
 		consumerID:  consumerID,
 		providers:   providers,
 		tokenGetter: tokenGetter,
+		backoff:     workersCommon.NewBackoff(workersCommon.DefaultBackoffConfig()),
 	}, nil
 }
 
@@ -62,8 +94,14 @@ type Provider struct {
 	// This helps us avoid a bunch of queries to the database.
 	// sync.Map[uint]params.ScaleSet
 	scaleSets sync.Map
-	// sync.Map[string]*instanceManager
+	// sync.Map[string]*runnerEntry
 	runners sync.Map
+
+	eventQueue *workersCommon.UnboundedChan[dbCommon.ChangePayload]
+	backoff    *workersCommon.Backoff
+
+	scaleSetsLoaded bool
+	runnersLoaded   bool
 
 	mux     sync.Mutex
 	running bool
@@ -79,7 +117,6 @@ func (p *Provider) loadAllScaleSets() error {
 	for _, scaleSet := range scaleSets {
 		p.scaleSets.Store(scaleSet.ID, scaleSet)
 	}
-
 	return nil
 }
 
@@ -111,29 +148,46 @@ func (p *Provider) loadAllRunners() error {
 			continue
 		}
 
+		// Skip runners that already have entries (idempotent on re-call).
+		if _, ok := p.runners.Load(runner.Name); ok {
+			continue
+		}
+
+		entry := &runnerEntry{instance: runner}
+
 		val, ok := p.scaleSets.Load(runner.ScaleSetID)
 		if !ok {
-			slog.ErrorContext(p.ctx, "scale set not found", "scale_set_id", runner.ScaleSetID)
+			slog.ErrorContext(p.ctx, "scale set not found", "scale_set_id", runner.ScaleSetID, "runner_name", runner.Name)
+			p.runners.Store(runner.Name, entry)
+			p.backoff.RecordFailure(runner.Name)
 			continue
 		}
 		scaleSet := val.(params.ScaleSet)
 		provider, ok := p.providers[scaleSet.ProviderName]
 		if !ok {
-			slog.ErrorContext(p.ctx, "provider not found", "provider_name", runner.ProviderName)
+			// The provider map is static — it only changes on app restart.
+			// No point storing an entry that will never succeed.
+			slog.ErrorContext(p.ctx, "provider not configured, skipping runner", "provider_name", scaleSet.ProviderName, "runner_name", runner.Name)
 			continue
 		}
-		instanceManager, err := newInstanceManager(
-			p.ctx, runner, scaleSet, provider, p)
+
+		manager, err := newInstanceManager(p.ctx, runner, scaleSet, provider, p)
 		if err != nil {
-			return fmt.Errorf("creating instance manager: %w", err)
+			slog.ErrorContext(p.ctx, "creating instance manager", "runner_name", runner.Name, "error", err)
+			p.runners.Store(runner.Name, entry)
+			p.backoff.RecordFailure(runner.Name)
+			continue
 		}
-		if err := instanceManager.Start(); err != nil {
-			return fmt.Errorf("starting instance manager: %w", err)
+		if err := manager.Start(); err != nil {
+			slog.ErrorContext(p.ctx, "starting instance manager", "runner_name", runner.Name, "error", err)
+			p.runners.Store(runner.Name, entry)
+			p.backoff.RecordFailure(runner.Name)
+			continue
 		}
 
-		p.runners.Store(runner.Name, instanceManager)
+		entry.SetManager(manager)
+		p.runners.Store(runner.Name, entry)
 	}
-
 	return nil
 }
 
@@ -145,24 +199,35 @@ func (p *Provider) Start() error {
 		return nil
 	}
 
-	if err := p.loadAllScaleSets(); err != nil {
-		return fmt.Errorf("loading all scale sets: %w", err)
-	}
-
-	if err := p.loadAllRunners(); err != nil {
-		return fmt.Errorf("loading all runners: %w", err)
-	}
-
+	// Register the consumer first. It must be watching before entity/scaleset
+	// workers start creating instances. This is the only fatal error.
 	consumer, err := watcher.RegisterConsumer(
 		p.ctx, p.consumerID, composeProviderWatcher())
 	if err != nil {
 		return fmt.Errorf("registering consumer: %w", err)
 	}
 	p.consumer = consumer
-
 	p.quit = make(chan struct{})
 	p.running = true
+	p.eventQueue = workersCommon.NewUnboundedChan[dbCommon.ChangePayload](p.ctx, p.quit)
+
+	// Best-effort initial DB load. The retry loop handles failures.
+	if err := p.loadAllScaleSets(); err != nil {
+		slog.ErrorContext(p.ctx, "initial scale set load failed, will retry", "error", err)
+	} else {
+		p.scaleSetsLoaded = true
+	}
+	if p.scaleSetsLoaded {
+		if err := p.loadAllRunners(); err != nil {
+			slog.ErrorContext(p.ctx, "initial runner load failed, will retry", "error", err)
+		} else {
+			p.runnersLoaded = true
+		}
+	}
+
 	go p.loop()
+	go p.eventQueue.Process(p.handleWatcherEvent)
+	go workersCommon.RetryLoop(p.ctx, p.quit, retryLoopInterval, p.retryFailedRunners)
 
 	return nil
 }
@@ -175,23 +240,130 @@ func (p *Provider) Stop() error {
 		return nil
 	}
 
-	p.consumer.Close()
-	close(p.quit)
+	p.runners.Range(func(key, value any) bool {
+		name := key.(string)
+		entry := value.(*runnerEntry)
+		if err := entry.Stop(); err != nil {
+			slog.ErrorContext(p.ctx, "stopping instance manager", "runner_name", name, "error", err)
+		}
+		return true
+	})
+
 	p.running = false
+	close(p.quit)
+	p.consumer.Close()
 	return nil
 }
 
+func (p *Provider) retryFailedRunners() {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	if !p.running {
+		return
+	}
+
+	// Retry DB load for scale sets if needed.
+	if !p.scaleSetsLoaded {
+		if err := p.loadAllScaleSets(); err != nil {
+			slog.ErrorContext(p.ctx, "retrying scale set load", "error", err)
+			return // Can't proceed without scale sets.
+		}
+		slog.InfoContext(p.ctx, "scale sets loaded successfully after retry")
+		p.scaleSetsLoaded = true
+	}
+
+	// Retry DB load for runners if needed.
+	if !p.runnersLoaded {
+		if err := p.loadAllRunners(); err != nil {
+			slog.ErrorContext(p.ctx, "retrying runner load", "error", err)
+		} else {
+			slog.InfoContext(p.ctx, "runners loaded successfully after retry")
+			p.runnersLoaded = true
+		}
+	}
+
+	// Retry individual failed instance managers.
+	p.runners.Range(func(key, value any) bool {
+		name := key.(string)
+		entry := value.(*runnerEntry)
+
+		entry.mux.Lock()
+		manager := entry.manager
+		instance := entry.instance
+		entry.mux.Unlock()
+
+		if manager != nil && manager.running.Load() {
+			return true
+		}
+
+		// Clean up terminated instances.
+		if instance.Status == commonParams.InstanceDeleted ||
+			instance.Status == commonParams.InstanceDeleting {
+			p.runners.Delete(name)
+			p.backoff.RecordSuccess(name)
+			return true
+		}
+
+		if !p.backoff.ShouldRetry(name) {
+			return true
+		}
+
+		val, ok := p.scaleSets.Load(instance.ScaleSetID)
+		if !ok {
+			slog.ErrorContext(p.ctx, "scale set not found for retry", "runner_name", name, "scale_set_id", instance.ScaleSetID)
+			p.backoff.RecordFailure(name)
+			return true
+		}
+		scaleSet := val.(params.ScaleSet)
+		provider, ok := p.providers[scaleSet.ProviderName]
+		if !ok {
+			// The provider map is static — retrying will never help.
+			// Remove the entry entirely.
+			slog.ErrorContext(p.ctx, "provider not configured, removing runner entry", "runner_name", name, "provider_name", scaleSet.ProviderName)
+			p.runners.Delete(name)
+			p.backoff.RecordSuccess(name)
+			return true
+		}
+
+		if manager == nil {
+			var err error
+			manager, err = newInstanceManager(p.ctx, instance, scaleSet, provider, p)
+			if err != nil {
+				slog.ErrorContext(p.ctx, "retry: creating instance manager", "runner_name", name, "error", err)
+				p.backoff.RecordFailure(name)
+				return true
+			}
+			entry.SetManager(manager)
+		}
+
+		if err := manager.Start(); err != nil {
+			slog.ErrorContext(p.ctx, "retry: starting instance manager", "runner_name", name, "error", err)
+			p.backoff.RecordFailure(name)
+			return true
+		}
+
+		slog.InfoContext(p.ctx, "instance manager started after retry", "runner_name", name)
+		p.backoff.RecordSuccess(name)
+		return true
+	})
+}
+
+// loop drains the watcher consumer channel as fast as possible into the
+// event queue. It exits when the context is cancelled or quit is closed.
 func (p *Provider) loop() {
 	defer p.Stop()
 	for {
 		select {
-		case payload, ok := <-p.consumer.Watch():
-			if !ok {
-				slog.ErrorContext(p.ctx, "watcher channel closed")
+		case payload := <-p.consumer.Watch():
+			slog.DebugContext(p.ctx, "received payload, queuing for processing")
+			select {
+			case p.eventQueue.In() <- payload:
+			case <-p.ctx.Done():
+				return
+			case <-p.quit:
 				return
 			}
-			slog.DebugContext(p.ctx, "received payload", "operation", payload.Operation, "entity_type", payload.EntityType)
-			go p.handleWatcherEvent(payload)
 		case <-p.ctx.Done():
 			return
 		case <-p.quit:
@@ -201,6 +373,13 @@ func (p *Provider) loop() {
 }
 
 func (p *Provider) handleWatcherEvent(payload dbCommon.ChangePayload) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	if !p.running {
+		return
+	}
+
 	switch payload.EntityType {
 	case dbCommon.ScaleSetEntityType:
 		p.handleScaleSetEvent(payload)
@@ -231,43 +410,77 @@ func (p *Provider) handleScaleSetEvent(event dbCommon.ChangePayload) {
 	}
 }
 
-func (p *Provider) handleInstanceAdded(instance params.Instance) error {
+func (p *Provider) handleInstanceAdded(instance params.Instance) {
+	// If an entry already exists, update its instance data and let the
+	// retry loop handle restarting it if needed.
+	if val, ok := p.runners.Load(instance.Name); ok {
+		entry := val.(*runnerEntry)
+		entry.mux.Lock()
+		running := entry.manager != nil && entry.manager.running.Load()
+		entry.mux.Unlock()
+
+		if running {
+			slog.DebugContext(p.ctx, "instance manager already running", "instance_name", instance.Name)
+			return
+		}
+		entry.SetInstance(instance)
+		p.backoff.RecordSuccess(instance.Name)
+		return
+	}
+
+	entry := &runnerEntry{instance: instance}
+
 	val, ok := p.scaleSets.Load(instance.ScaleSetID)
 	if !ok {
-		return fmt.Errorf("scale set not found for instance %s", instance.Name)
+		slog.ErrorContext(p.ctx, "scale set not found for instance", "instance_name", instance.Name, "scale_set_id", instance.ScaleSetID)
+		p.runners.Store(instance.Name, entry)
+		p.backoff.RecordFailure(instance.Name)
+		return
 	}
 	scaleSet := val.(params.ScaleSet)
-	instanceManager, err := newInstanceManager(
-		p.ctx, instance, scaleSet, p.providers[instance.ProviderName], p)
+
+	provider, ok := p.providers[scaleSet.ProviderName]
+	if !ok {
+		// The provider map is static — no point storing an entry that will never work.
+		slog.ErrorContext(p.ctx, "provider not configured, skipping instance", "instance_name", instance.Name, "provider_name", scaleSet.ProviderName)
+		return
+	}
+
+	manager, err := newInstanceManager(
+		p.ctx, instance, scaleSet, provider, p)
 	if err != nil {
-		return fmt.Errorf("creating instance manager: %w", err)
+		slog.ErrorContext(p.ctx, "creating instance manager", "instance_name", instance.Name, "error", err)
+		p.runners.Store(instance.Name, entry)
+		p.backoff.RecordFailure(instance.Name)
+		return
 	}
-	if err := instanceManager.Start(); err != nil {
-		return fmt.Errorf("starting instance manager: %w", err)
+	if err := manager.Start(); err != nil {
+		slog.ErrorContext(p.ctx, "starting instance manager", "instance_name", instance.Name, "error", err)
+		p.runners.Store(instance.Name, entry)
+		p.backoff.RecordFailure(instance.Name)
+		return
 	}
-	if _, loaded := p.runners.LoadOrStore(instance.Name, instanceManager); loaded {
-		// A manager already exists for this instance. Stop the one we just created.
-		slog.DebugContext(p.ctx, "instance manager already exists", "instance_name", instance.Name)
-		instanceManager.Stop()
-	}
-	return nil
+
+	entry.SetManager(manager)
+	p.runners.Store(instance.Name, entry)
 }
 
-func (p *Provider) stopAndDeleteInstance(instance params.Instance) error {
+func (p *Provider) stopAndDeleteInstance(instance params.Instance) {
 	if instance.Status != commonParams.InstanceDeleted {
-		return nil
+		return
 	}
 	val, loaded := p.runners.LoadAndDelete(instance.Name)
 	if !loaded {
-		return nil
+		return
 	}
-	existingInstance := val.(*instanceManager)
-	if err := existingInstance.Stop(); err != nil {
-		// Re-store the manager so it can be retried.
-		p.runners.Store(instance.Name, existingInstance)
-		return fmt.Errorf("failed to stop instance manager: %w", err)
+	entry := val.(*runnerEntry)
+	if err := entry.Stop(); err != nil {
+		// Re-store the entry so it can be retried.
+		p.runners.Store(instance.Name, entry)
+		slog.ErrorContext(p.ctx, "failed to stop instance manager", "runner_name", instance.Name, "error", err)
+		return
 	}
-	return nil
+	p.backoff.RecordSuccess(instance.Name)
 }
 
 func (p *Provider) handleInstanceEvent(event dbCommon.ChangePayload) {
@@ -286,45 +499,47 @@ func (p *Provider) handleInstanceEvent(event dbCommon.ChangePayload) {
 	switch event.Operation {
 	case dbCommon.CreateOperation:
 		slog.DebugContext(p.ctx, "got create operation")
-		if err := p.handleInstanceAdded(instance); err != nil {
-			slog.ErrorContext(p.ctx, "failed to handle instance added", "error", err)
-			return
-		}
+		p.handleInstanceAdded(instance)
 	case dbCommon.UpdateOperation:
 		slog.DebugContext(p.ctx, "got update operation")
 
 		val, ok := p.runners.Load(instance.Name)
-
 		if !ok {
 			if instance.Status == commonParams.InstanceDeleted {
-				// No manager running for this instance and it's already deleted.
+				// No entry for this instance and it's already deleted.
 				return
 			}
 			slog.DebugContext(p.ctx, "instance not found, creating new instance", "instance_name", instance.Name)
-			if err := p.handleInstanceAdded(instance); err != nil {
-				slog.ErrorContext(p.ctx, "failed to handle instance added", "error", err)
-				return
+			p.handleInstanceAdded(instance)
+			return
+		}
+
+		entry := val.(*runnerEntry)
+		slog.DebugContext(p.ctx, "updating instance", "instance_name", instance.Name)
+
+		if instance.Status == commonParams.InstanceDeleted {
+			p.stopAndDeleteInstance(instance)
+			return
+		}
+
+		entry.SetInstance(instance)
+
+		entry.mux.Lock()
+		manager := entry.manager
+		entry.mux.Unlock()
+
+		if manager != nil && manager.running.Load() {
+			if err := manager.Update(event); err != nil {
+				slog.ErrorContext(p.ctx, "failed to update instance", "error", err, "instance_name", instance.Name)
 			}
 		} else {
-			existingInstance := val.(*instanceManager)
-			slog.DebugContext(p.ctx, "updating instance", "instance_name", instance.Name)
-			if instance.Status == commonParams.InstanceDeleted {
-				if err := p.stopAndDeleteInstance(instance); err != nil {
-					slog.ErrorContext(p.ctx, "failed to clean up instance manager", "error", err)
-				}
-				return
-			}
-			if err := existingInstance.Update(event); err != nil {
-				slog.ErrorContext(p.ctx, "failed to update instance", "error", err, "instance_name", instance.Name, "payload", event.Payload)
-				return
-			}
+			// Manager not running. Clear backoff so the retry loop
+			// picks up the updated instance data immediately.
+			p.backoff.RecordSuccess(instance.Name)
 		}
 	case dbCommon.DeleteOperation:
 		slog.DebugContext(p.ctx, "got delete operation", "instance_name", instance.Name)
-		if err := p.stopAndDeleteInstance(instance); err != nil {
-			slog.ErrorContext(p.ctx, "failed to clean up instance manager", "error", err)
-			return
-		}
+		p.stopAndDeleteInstance(instance)
 	default:
 		slog.ErrorContext(p.ctx, "invalid operation type", "operation_type", event.Operation)
 		return

--- a/workers/scaleset/controller.go
+++ b/workers/scaleset/controller.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -26,7 +27,10 @@ import (
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
 	garmUtil "github.com/cloudbase/garm/util"
+	workersCommon "github.com/cloudbase/garm/workers/common"
 )
+
+const scaleSetRetryLoopInterval = 5 * time.Second
 
 func NewController(ctx context.Context, store dbCommon.Store, entity params.ForgeEntity, providers map[string]common.Provider) (*Controller, error) {
 	consumerID := fmt.Sprintf("scaleset-controller-%s", entity.ID)
@@ -44,6 +48,7 @@ func NewController(ctx context.Context, store dbCommon.Store, entity params.Forg
 		Entity:     entity,
 		providers:  providers,
 		store:      store,
+		backoff:    workersCommon.NewBackoff(workersCommon.DefaultBackoffConfig()),
 	}, nil
 }
 
@@ -90,6 +95,9 @@ type Controller struct {
 	consumer  dbCommon.Consumer
 	store     dbCommon.Store
 	providers map[string]common.Provider
+	backoff   *workersCommon.Backoff
+
+	eventQueue *workersCommon.UnboundedChan[dbCommon.ChangePayload]
 
 	mux     sync.Mutex
 	running bool
@@ -145,9 +153,12 @@ func (c *Controller) Start() (err error) {
 	c.consumer = consumer
 	c.running = true
 	c.quit = make(chan struct{})
+	c.eventQueue = workersCommon.NewUnboundedChan[dbCommon.ChangePayload](c.ctx, c.quit)
 	c.mux.Unlock()
 
 	go c.loop()
+	go c.eventQueue.Process(c.handleWatcherEvent)
+	go workersCommon.RetryLoop(c.ctx, c.quit, scaleSetRetryLoopInterval, c.retryFailedScaleSets)
 	return nil
 }
 
@@ -187,6 +198,9 @@ func (c *Controller) ConsolidateRunnerState(byScaleSetID map[int][]params.Runner
 	g, ctx := errgroup.WithContext(c.ctx)
 	c.ScaleSets.Range(func(_, value any) bool {
 		set := value.(*scaleSet)
+		if set.worker == nil || !set.worker.IsRunning() {
+			return true
+		}
 		runners := byScaleSetID[set.scaleSet.ScaleSetID]
 		g.Go(func() error {
 			slog.DebugContext(ctx, "consolidating runners for scale set", "scale_set_id", set.scaleSet.ScaleSetID, "runners", runners)
@@ -224,6 +238,56 @@ func (c *Controller) waitForErrorGroupOrContextCancelled(g *errgroup.Group) erro
 	}
 }
 
+func (c *Controller) retryFailedScaleSets() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if !c.running {
+		return
+	}
+
+	c.ScaleSets.Range(func(key, value any) bool {
+		scaleSetID := key.(uint)
+		set := value.(*scaleSet)
+		backoffKey := scaleSetBackoffKey(set.scaleSet)
+
+		if set.worker != nil && set.worker.IsRunning() {
+			return true
+		}
+
+		if !c.backoff.ShouldRetry(backoffKey) {
+			return true
+		}
+
+		slog.InfoContext(c.ctx, "retrying failed scale set", "scale_set_id", scaleSetID)
+
+		set.mux.Lock()
+		worker := set.worker
+		set.mux.Unlock()
+
+		if worker == nil {
+			var err error
+			worker, err = c.createScaleSetWorker(set.scaleSet)
+			if err != nil {
+				slog.ErrorContext(c.ctx, "retry failed: creating scale set worker", "scale_set_id", scaleSetID, "error", err)
+				c.backoff.RecordFailure(backoffKey)
+				return true
+			}
+			set.SetWorker(worker)
+		}
+
+		if err := worker.Start(); err != nil {
+			slog.ErrorContext(c.ctx, "retry failed: starting scale set worker", "scale_set_id", scaleSetID, "error", err)
+			c.backoff.RecordFailure(backoffKey)
+			return true
+		}
+
+		slog.InfoContext(c.ctx, "scale set worker successfully started after retry", "scale_set_id", scaleSetID)
+		c.backoff.RecordSuccess(backoffKey)
+		return true
+	})
+}
+
 func (c *Controller) loop() {
 	defer c.Stop()
 
@@ -234,8 +298,14 @@ func (c *Controller) loop() {
 				slog.InfoContext(c.ctx, "consumer channel closed")
 				return
 			}
-			slog.InfoContext(c.ctx, "received payload")
-			c.handleWatcherEvent(payload)
+			slog.DebugContext(c.ctx, "received payload, queuing for processing")
+			select {
+			case c.eventQueue.In() <- payload:
+			case <-c.ctx.Done():
+				return
+			case <-c.quit:
+				return
+			}
 		case <-c.ctx.Done():
 			return
 		case <-c.quit:

--- a/workers/scaleset/controller_watcher.go
+++ b/workers/scaleset/controller_watcher.go
@@ -22,6 +22,13 @@ import (
 )
 
 func (c *Controller) handleWatcherEvent(event dbCommon.ChangePayload) {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if !c.running {
+		return
+	}
+
 	entityType := dbCommon.DatabaseEntityType(c.Entity.EntityType)
 	switch event.EntityType {
 	case dbCommon.ScaleSetEntityType:
@@ -65,6 +72,14 @@ func (c *Controller) handleScaleSet(event dbCommon.ChangePayload) {
 	}
 }
 
+func scaleSetBackoffKey(sSet params.ScaleSet) string {
+	runnerGroup := sSet.GitHubRunnerGroup
+	if runnerGroup == "" {
+		runnerGroup = "Default"
+	}
+	return fmt.Sprintf("%s:%d", runnerGroup, sSet.ID)
+}
+
 func (c *Controller) createScaleSetWorker(scaleSet params.ScaleSet) (*Worker, error) {
 	provider, ok := c.providers[scaleSet.ProviderName]
 	if !ok {
@@ -87,22 +102,18 @@ func (c *Controller) handleScaleSetCreateOperation(sSet params.ScaleSet) error {
 		return nil
 	}
 
+	entry := &scaleSet{scaleSet: sSet}
+
 	worker, err := c.createScaleSetWorker(sSet)
 	if err != nil {
+		// Store the entry so the retry loop can pick it up.
+		c.ScaleSets.Store(sSet.ID, entry)
+		c.backoff.RecordFailure(scaleSetBackoffKey(sSet))
 		return fmt.Errorf("error creating scale set worker: %w", err)
 	}
-	if err := worker.Start(); err != nil {
-		// The Start() function should only return an error if an unrecoverable error occurs.
-		// For transient errors, it should mark the scale set as being in error, but continue
-		// to retry fixing the condition. For example, not being able to retrieve tools due to bad
-		// credentials should not stop the worker. The credentials can be fixed and the worker
-		// can continue to work.
-		return fmt.Errorf("error starting scale set worker: %w", err)
-	}
-	c.ScaleSets.Store(sSet.ID, &scaleSet{
-		scaleSet: sSet,
-		worker:   worker,
-	})
+	entry.worker = worker
+	c.ScaleSets.Store(sSet.ID, entry)
+	// The retry loop will start the worker.
 	return nil
 }
 
@@ -115,10 +126,11 @@ func (c *Controller) handleScaleSetDeleteOperation(sSet params.ScaleSet) error {
 	set := val.(*scaleSet)
 
 	slog.DebugContext(c.ctx, "stopping scale set worker", "scale_set_id", sSet.ID)
-	if err := set.worker.Stop(); err != nil {
+	if err := set.Stop(); err != nil {
 		return fmt.Errorf("stopping scale set worker: %w", err)
 	}
 	c.ScaleSets.Delete(sSet.ID)
+	c.backoff.RecordSuccess(scaleSetBackoffKey(sSet))
 	return nil
 }
 
@@ -131,17 +143,19 @@ func (c *Controller) handleScaleSetUpdateOperation(sSet params.ScaleSet) error {
 		return c.handleScaleSetCreateOperation(sSet)
 	}
 	set := val.(*scaleSet)
-	if set.worker != nil && !set.worker.IsRunning() {
+	backoffKey := scaleSetBackoffKey(sSet)
+
+	if set.worker == nil || !set.worker.IsRunning() {
 		worker, err := c.createScaleSetWorker(sSet)
 		if err != nil {
+			c.backoff.RecordFailure(backoffKey)
 			return fmt.Errorf("creating scale set worker: %w", err)
 		}
 		set.SetWorker(worker)
-		defer func() {
-			if err := worker.Start(); err != nil {
-				slog.ErrorContext(c.ctx, "failed to start worker", "error", err, "scaleset", sSet.Name)
-			}
-		}()
+		// Clear any previous backoff so the retry loop starts the worker
+		// immediately. The user may have fixed the issue by updating the
+		// scale set.
+		c.backoff.RecordSuccess(backoffKey)
 	}
 
 	set.SetScaleSet(sSet)
@@ -175,9 +189,8 @@ func (c *Controller) handleEntityEvent(event dbCommon.ChangePayload) {
 	switch event.Operation {
 	case dbCommon.UpdateOperation:
 		slog.DebugContext(c.ctx, "got update operation")
-		c.mux.Lock()
+		// c.mux is already held by handleWatcherEvent.
 		c.Entity = entity
-		c.mux.Unlock()
 	default:
 		slog.ErrorContext(c.ctx, "invalid operation type", "operation_type", event.Operation)
 		return


### PR DESCRIPTION
This change adds resiliency when starting workers. Pools, Entity workers, scaleset workers and provider worker now implement a loop that retries to start individul workers that fail, rather than prevent GARM itself from starting at all.

This change also adds a new unbound channel consumer that implements a FIFO queue on the DB watcher consumer side. This moves away from handling the event in a couroutine, limiting the potential for deadlocks and ensuring that events are handled in order. A Delete() operation will not be attempted if a Create() didn't complete beforehand.


Fixes: #418