### PR TITLE
refactor(db): make SQL layer portable and concurrency-safe

### DIFF
--- a/database/sql/controller.go
+++ b/database/sql/controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/database/common"
@@ -165,7 +166,7 @@ func (s *sqlDatabase) UpdateController(info params.UpdateControllerParams) (para
 	}()
 	var dbInfo ControllerInfo
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		q := tx.Model(&ControllerInfo{}).First(&dbInfo)
+		q := tx.Model(&ControllerInfo{}).Clauses(clause.Locking{Strength: "UPDATE"}).First(&dbInfo)
 		if q.Error != nil {
 			if errors.Is(q.Error, gorm.ErrRecordNotFound) {
 				return fmt.Errorf("error fetching controller info: %w", runnerErrors.ErrNotFound)
@@ -243,7 +244,7 @@ func (s *sqlDatabase) UpdateCachedGARMAgentRelease(releaseData []byte, fetchedAt
 	var dbInfo ControllerInfo
 	var rowsAffected int64
 	err := s.conn.Transaction(func(tx *gorm.DB) error {
-		q := tx.Model(&ControllerInfo{}).First(&dbInfo)
+		q := tx.Model(&ControllerInfo{}).Clauses(clause.Locking{Strength: "UPDATE"}).First(&dbInfo)
 		if q.Error != nil {
 			if errors.Is(q.Error, gorm.ErrRecordNotFound) {
 				return fmt.Errorf("error fetching controller info: %w", runnerErrors.ErrNotFound)

--- a/database/sql/enterprise.go
+++ b/database/sql/enterprise.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm-provider-common/util"
@@ -177,7 +178,7 @@ func (s *sqlDatabase) UpdateEnterprise(ctx context.Context, enterpriseID string,
 	var enterprise Enterprise
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
 		var err error
-		enterprise, err = s.getEnterpriseByID(ctx, tx, enterpriseID, "Endpoint")
+		enterprise, err = s.getEnterpriseByID(ctx, tx.Clauses(clause.Locking{Strength: "UPDATE"}), enterpriseID, "Endpoint")
 		if err != nil {
 			return fmt.Errorf("error fetching enterprise: %w", err)
 		}
@@ -253,7 +254,7 @@ func (s *sqlDatabase) UpdateEnterprise(ctx context.Context, enterpriseID string,
 func (s *sqlDatabase) getEnterprise(_ context.Context, name, endpointName string) (Enterprise, error) {
 	var enterprise Enterprise
 
-	q := s.conn.Where("name = ? COLLATE NOCASE and endpoint_name = ? COLLATE NOCASE", name, endpointName).
+	q := s.conn.Where("LOWER(name) = LOWER(?) and LOWER(endpoint_name) = LOWER(?)", name, endpointName).
 		Preload("Credentials").
 		Preload("Credentials.Endpoint").
 		Preload("Endpoint").

--- a/database/sql/enterprise_test.go
+++ b/database/sql/enterprise_test.go
@@ -278,7 +278,7 @@ func (s *EnterpriseTestSuite) TestGetEnterpriseNotFound() {
 
 func (s *EnterpriseTestSuite) TestGetEnterpriseDBDecryptingErr() {
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE (name = ? COLLATE NOCASE and endpoint_name = ? COLLATE NOCASE) AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `enterprises` WHERE (LOWER(name) = LOWER(?) and LOWER(endpoint_name) = LOWER(?)) AND `enterprises`.`deleted_at` IS NULL ORDER BY `enterprises`.`id` LIMIT ?")).
 		WithArgs(s.Fixtures.Enterprises[0].Name, s.Fixtures.Enterprises[0].Endpoint.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow(s.Fixtures.Enterprises[0].Name))
 
@@ -448,7 +448,7 @@ func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBEncryptErr() {
 			AddRow(s.Fixtures.Enterprises[0].Endpoint.Name, s.Fixtures.Enterprises[0].Endpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -480,7 +480,7 @@ func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBSaveErr() {
 			AddRow(s.Fixtures.Enterprises[0].Endpoint.Name, s.Fixtures.Enterprises[0].Endpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -517,7 +517,7 @@ func (s *EnterpriseTestSuite) TestUpdateEnterpriseDBDecryptingErr() {
 			AddRow(s.Fixtures.Enterprises[0].Endpoint.Name, s.Fixtures.Enterprises[0].Endpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -616,7 +616,7 @@ func (s *EnterpriseTestSuite) TestCreateEnterprisePoolDBFetchTagErr() {
 		WithArgs(s.Fixtures.Enterprises[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnError(fmt.Errorf("mocked fetching tag error"))
 
 	entity, err := s.Fixtures.Enterprises[0].GetEntity()
@@ -636,7 +636,7 @@ func (s *EnterpriseTestSuite) TestCreateEnterprisePoolDBAddingPoolErr() {
 		WithArgs(s.Fixtures.Enterprises[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).
@@ -664,7 +664,7 @@ func (s *EnterpriseTestSuite) TestCreateEnterprisePoolDBSaveTagErr() {
 		WithArgs(s.Fixtures.Enterprises[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).
@@ -695,7 +695,7 @@ func (s *EnterpriseTestSuite) TestCreateEnterprisePoolDBFetchPoolErr() {
 		WithArgs(s.Fixtures.Enterprises[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Enterprises[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).

--- a/database/sql/gitea.go
+++ b/database/sql/gitea.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/auth"
@@ -39,7 +40,7 @@ func (s *sqlDatabase) CreateGiteaEndpoint(_ context.Context, param params.Create
 	}()
 	var endpoint GithubEndpoint
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("name = ?", param.Name).First(&endpoint).Error; err == nil {
+		if err := tx.Where("LOWER(name) = LOWER(?)", param.Name).First(&endpoint).Error; err == nil {
 			return fmt.Errorf("gitea endpoint already exists: %w", runnerErrors.ErrDuplicateEntity)
 		}
 		endpoint = GithubEndpoint{
@@ -97,7 +98,7 @@ func (s *sqlDatabase) UpdateGiteaEndpoint(_ context.Context, name string, param 
 	}()
 	var endpoint GithubEndpoint
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("name = ? and endpoint_type = ?", name, params.GiteaEndpointType).First(&endpoint).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("LOWER(name) = LOWER(?) and endpoint_type = ?", name, params.GiteaEndpointType).First(&endpoint).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return runnerErrors.NewNotFoundError("gitea endpoint %q not found", name)
 			}
@@ -166,7 +167,7 @@ func (s *sqlDatabase) UpdateGiteaEndpoint(_ context.Context, name string, param 
 
 func (s *sqlDatabase) GetGiteaEndpoint(_ context.Context, name string) (params.ForgeEndpoint, error) {
 	var endpoint GithubEndpoint
-	err := s.conn.Where("name = ? and endpoint_type = ?", name, params.GiteaEndpointType).First(&endpoint).Error
+	err := s.conn.Where("LOWER(name) = LOWER(?) and endpoint_type = ?", name, params.GiteaEndpointType).First(&endpoint).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return params.ForgeEndpoint{}, runnerErrors.NewNotFoundError("gitea endpoint %q not found", name)
@@ -185,7 +186,7 @@ func (s *sqlDatabase) DeleteGiteaEndpoint(_ context.Context, name string) (err e
 	}()
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
 		var endpoint GithubEndpoint
-		if err := tx.Where("name = ? and endpoint_type = ?", name, params.GiteaEndpointType).First(&endpoint).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("LOWER(name) = LOWER(?) and endpoint_type = ?", name, params.GiteaEndpointType).First(&endpoint).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil
 			}
@@ -245,14 +246,14 @@ func (s *sqlDatabase) CreateGiteaCredentials(ctx context.Context, param params.C
 	var creds GiteaCredentials
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
 		var endpoint GithubEndpoint
-		if err := tx.Where("name = ? and endpoint_type = ?", param.Endpoint, params.GiteaEndpointType).First(&endpoint).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("LOWER(name) = LOWER(?) and endpoint_type = ?", param.Endpoint, params.GiteaEndpointType).First(&endpoint).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return runnerErrors.NewNotFoundError("gitea endpoint %q not found", param.Endpoint)
 			}
 			return fmt.Errorf("error fetching gitea endpoint: %w", err)
 		}
 
-		if err := tx.Where("name = ? and user_id = ?", param.Name, userID).First(&creds).Error; err == nil {
+		if err := tx.Where("LOWER(name) = LOWER(?) and user_id = ?", param.Name, userID).First(&creds).Error; err == nil {
 			return fmt.Errorf("gitea credentials already exists: %w", runnerErrors.ErrDuplicateEntity)
 		}
 
@@ -315,7 +316,7 @@ func (s *sqlDatabase) getGiteaCredentialsByName(ctx context.Context, tx *gorm.DB
 	}
 	q = q.Where("user_id = ?", userID)
 
-	err = q.Where("name = ?", name).First(&creds).Error
+	err = q.Where("LOWER(name) = LOWER(?)", name).First(&creds).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return GiteaCredentials{}, runnerErrors.NewNotFoundError("gitea credentials %q not found", name)
@@ -404,7 +405,7 @@ func (s *sqlDatabase) UpdateGiteaCredentials(ctx context.Context, id uint, param
 	}()
 	var creds GiteaCredentials
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		q := tx.Preload("Endpoint")
+		q := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Preload("Endpoint")
 		if !auth.IsAdmin(ctx) {
 			userID, err := getUIDFromContext(ctx)
 			if err != nil {
@@ -478,7 +479,7 @@ func (s *sqlDatabase) DeleteGiteaCredentials(ctx context.Context, id uint) (err 
 		}
 	}()
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		q := tx.Where("id = ?", id).
+		q := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", id).
 			Preload("Repositories").
 			Preload("Organizations")
 		if !auth.IsAdmin(ctx) {

--- a/database/sql/github.go
+++ b/database/sql/github.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/auth"
@@ -35,7 +36,7 @@ func (s *sqlDatabase) CreateGithubEndpoint(_ context.Context, param params.Creat
 	}()
 	var endpoint GithubEndpoint
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("name = ?", param.Name).First(&endpoint).Error; err == nil {
+		if err := tx.Where("LOWER(name) = LOWER(?)", param.Name).First(&endpoint).Error; err == nil {
 			return fmt.Errorf("error github endpoint already exists: %w", runnerErrors.ErrDuplicateEntity)
 		}
 		endpoint = GithubEndpoint{
@@ -90,7 +91,7 @@ func (s *sqlDatabase) UpdateGithubEndpoint(_ context.Context, name string, param
 	}()
 	var endpoint GithubEndpoint
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("name = ? and endpoint_type = ?", name, params.GithubEndpointType).First(&endpoint).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("LOWER(name) = LOWER(?) and endpoint_type = ?", name, params.GithubEndpointType).First(&endpoint).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return fmt.Errorf("error github endpoint not found: %w", runnerErrors.ErrNotFound)
 			}
@@ -161,7 +162,7 @@ func (s *sqlDatabase) UpdateGithubEndpoint(_ context.Context, name string, param
 func (s *sqlDatabase) GetGithubEndpoint(_ context.Context, name string) (params.ForgeEndpoint, error) {
 	var endpoint GithubEndpoint
 
-	err := s.conn.Where("name = ? and endpoint_type = ?", name, params.GithubEndpointType).First(&endpoint).Error
+	err := s.conn.Where("LOWER(name) = LOWER(?) and endpoint_type = ?", name, params.GithubEndpointType).First(&endpoint).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return params.ForgeEndpoint{}, fmt.Errorf("github endpoint not found: %w", runnerErrors.ErrNotFound)
@@ -180,7 +181,7 @@ func (s *sqlDatabase) DeleteGithubEndpoint(_ context.Context, name string) (err 
 	}()
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
 		var endpoint GithubEndpoint
-		if err := tx.Where("name = ? and endpoint_type = ?", name, params.GithubEndpointType).First(&endpoint).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("LOWER(name) = LOWER(?) and endpoint_type = ?", name, params.GithubEndpointType).First(&endpoint).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil
 			}
@@ -247,14 +248,14 @@ func (s *sqlDatabase) CreateGithubCredentials(ctx context.Context, param params.
 	var creds GithubCredentials
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
 		var endpoint GithubEndpoint
-		if err := tx.Where("name = ? and endpoint_type = ?", param.Endpoint, params.GithubEndpointType).First(&endpoint).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("LOWER(name) = LOWER(?) and endpoint_type = ?", param.Endpoint, params.GithubEndpointType).First(&endpoint).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return fmt.Errorf("github endpoint not found: %w", runnerErrors.ErrNotFound)
 			}
 			return fmt.Errorf("error fetching github endpoint: %w", err)
 		}
 
-		if err := tx.Where("name = ? and user_id = ?", param.Name, userID).First(&creds).Error; err == nil {
+		if err := tx.Where("LOWER(name) = LOWER(?) and user_id = ?", param.Name, userID).First(&creds).Error; err == nil {
 			return fmt.Errorf("github credentials already exists: %w", runnerErrors.ErrDuplicateEntity)
 		}
 
@@ -319,7 +320,7 @@ func (s *sqlDatabase) getGithubCredentialsByName(ctx context.Context, tx *gorm.D
 	}
 	q = q.Where("user_id = ?", userID)
 
-	err = q.Where("name = ?", name).First(&creds).Error
+	err = q.Where("LOWER(name) = LOWER(?)", name).First(&creds).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return GithubCredentials{}, fmt.Errorf("github credentials not found: %w", runnerErrors.ErrNotFound)
@@ -407,7 +408,7 @@ func (s *sqlDatabase) UpdateGithubCredentials(ctx context.Context, id uint, para
 	}()
 	var creds GithubCredentials
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		q := tx.Preload("Endpoint")
+		q := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Preload("Endpoint")
 		if !auth.IsAdmin(ctx) {
 			userID, err := getUIDFromContext(ctx)
 			if err != nil {
@@ -492,7 +493,7 @@ func (s *sqlDatabase) DeleteGithubCredentials(ctx context.Context, id uint) (err
 		}
 	}()
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		q := tx.Where("id = ?", id).
+		q := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", id).
 			Preload("Repositories").
 			Preload("Organizations").
 			Preload("Enterprises")

--- a/database/sql/instances.go
+++ b/database/sql/instances.go
@@ -42,7 +42,7 @@ func (s *sqlDatabase) CreateInstance(ctx context.Context, poolID string, param p
 	}()
 
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		pool, err := s.getPoolByID(tx, poolID)
+		pool, err := s.getPoolByID(tx.Clauses(clause.Locking{Strength: "UPDATE"}), poolID)
 		if err != nil {
 			return fmt.Errorf("error fetching pool: %w", err)
 		}
@@ -406,7 +406,7 @@ func (s *sqlDatabase) UpdateInstance(ctx context.Context, instanceName string, p
 func (s *sqlDatabase) updateInstance(ctx context.Context, instanceName string, param params.UpdateInstanceParams, force bool) (params.Instance, error) {
 	var rowsAffected int64
 	err := s.conn.Transaction(func(tx *gorm.DB) error {
-		instance, err := s.getInstance(ctx, tx, instanceName, "Pool", "ScaleSet")
+		instance, err := s.getInstance(ctx, tx.Clauses(clause.Locking{Strength: "UPDATE"}), instanceName, "Pool", "ScaleSet")
 		if err != nil {
 			return fmt.Errorf("error updating instance: %w", err)
 		}

--- a/database/sql/jobs.go
+++ b/database/sql/jobs.go
@@ -165,7 +165,7 @@ func (s *sqlDatabase) LockJob(_ context.Context, jobID int64, entityID string) e
 
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
 		var workflowJob WorkflowJob
-		q := tx.Preload("Instance").Where("workflow_job_id = ?", jobID).First(&workflowJob)
+		q := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Preload("Instance").Where("workflow_job_id = ?", jobID).First(&workflowJob)
 
 		if q.Error != nil {
 			if errors.Is(q.Error, gorm.ErrRecordNotFound) {
@@ -305,7 +305,7 @@ func (s *sqlDatabase) CreateOrUpdateJob(ctx context.Context, job params.Job) (pa
 			searchField = "scale_set_job_id = ?"
 			searchVal = job.ScaleSetJobID
 		}
-		q := tx.Preload("Instance").Where(searchField, searchVal).First(&workflowJob)
+		q := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Preload("Instance").Where(searchField, searchVal).First(&workflowJob)
 
 		if q.Error != nil {
 			if !errors.Is(q.Error, gorm.ErrRecordNotFound) {

--- a/database/sql/migrations/0002_lower_indexes.go
+++ b/database/sql/migrations/0002_lower_indexes.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func init() {
+	// Convert the case-insensitive indexes from column-level COLLATE NOCASE to
+	// functional LOWER(col) indexes, matching what the models now declare. Fresh
+	// installs build these via InitSchema/AutoMigrate, so this migration only runs
+	// on existing SQLite databases.
+	//
+	// The queries now issue LOWER(col) = LOWER(?), which the old NOCASE/bare-column
+	// indexes can't serve, so lookups would fall back to full scans. Recreating the
+	// unique indexes is safe on existing data: NOCASE and LOWER() both fold ASCII,
+	// so rows unique under the old index stay unique under the new one.
+	//
+	// github_endpoints is the exception: its case-insensitivity lives on the
+	// PRIMARY KEY's NOCASE collation, which SQLite can't ALTER without a table
+	// rebuild, so we leave the PK and only add the functional unique index.
+	Register(&gormigrate.Migration{
+		ID: "0002_lower_indexes",
+		Migrate: func(tx *gorm.DB) error {
+			stmts := []string{
+				"DROP INDEX IF EXISTS idx_owner_nocase",
+				"CREATE UNIQUE INDEX idx_owner_nocase ON repositories(LOWER(owner),LOWER(name),LOWER(endpoint_name))",
+
+				"DROP INDEX IF EXISTS idx_org_name_nocase",
+				"CREATE INDEX idx_org_name_nocase ON organizations(LOWER(name),LOWER(endpoint_name))",
+
+				"DROP INDEX IF EXISTS idx_ent_name_nocase",
+				"CREATE INDEX idx_ent_name_nocase ON enterprises(LOWER(name),LOWER(endpoint_name))",
+
+				"DROP INDEX IF EXISTS idx_github_credentials",
+				"CREATE UNIQUE INDEX idx_github_credentials ON github_credentials(LOWER(name),user_id)",
+
+				"DROP INDEX IF EXISTS idx_gitea_credentials",
+				"CREATE UNIQUE INDEX idx_gitea_credentials ON gitea_credentials(LOWER(name),user_id)",
+
+				// PK stays NOCASE; just add the functional unique index.
+				"DROP INDEX IF EXISTS idx_endpoint_name_nocase",
+				"CREATE UNIQUE INDEX idx_endpoint_name_nocase ON github_endpoints(LOWER(name))",
+			}
+			for _, q := range stmts {
+				if err := tx.Exec(q).Error; err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/database/sql/models.go
+++ b/database/sql/models.go
@@ -79,7 +79,7 @@ type ControllerInfo struct {
 	// CACertBundle holds a certificate bundle meant to validate the certificate
 	// used by GARM itself. This can be just the root certificate that can validate
 	// the GARM TLS certificate, a chain or multiple root CAs.
-	CACertBundle []byte `gorm:"type:longblob"`
+	CACertBundle []byte
 }
 
 type Tag struct {
@@ -100,7 +100,7 @@ type Template struct {
 	Description string              `gorm:"type:text"`
 	OSType      commonParams.OSType `gorm:"type:varchar(32);index:idx_tpl_os_type"`
 	ForgeType   params.EndpointType `gorm:"type:varchar(32);index:idx_tpl_forge_type"`
-	Data        []byte              `gorm:"type:longblob"`
+	Data        []byte
 
 	ScaleSets []ScaleSet `gorm:"foreignKey:TemplateID"`
 	Pools     []Pool     `gorm:"foreignKey:TemplateID"`
@@ -235,8 +235,8 @@ type Repository struct {
 	PoolManagerRunning       bool
 	PoolManagerFailureReason string
 
-	Owner            string `gorm:"index:idx_owner_nocase,unique,collate:nocase"`
-	Name             string `gorm:"index:idx_owner_nocase,unique,collate:nocase"`
+	Owner            string `gorm:"index:idx_owner_nocase,unique,expression:LOWER(owner)"`
+	Name             string `gorm:"index:idx_owner_nocase,unique,expression:LOWER(name)"`
 	WebhookSecret    []byte
 	Pools            []Pool                  `gorm:"foreignKey:RepoID"`
 	ScaleSets        []ScaleSet              `gorm:"foreignKey:RepoID"`
@@ -244,7 +244,7 @@ type Repository struct {
 	PoolBalancerType params.PoolBalancerType `gorm:"type:varchar(64)"`
 	AgentMode        bool                    `gorm:"index:repo_agent_idx"`
 
-	EndpointName *string        `gorm:"index:idx_owner_nocase,unique,collate:nocase"`
+	EndpointName *string        `gorm:"index:idx_owner_nocase,unique,expression:LOWER(endpoint_name)"`
 	Endpoint     GithubEndpoint `gorm:"foreignKey:EndpointName;constraint:OnDelete:SET NULL"`
 
 	Events []RepositoryEvent `gorm:"foreignKey:RepoID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
@@ -272,7 +272,7 @@ type Organization struct {
 	PoolManagerRunning       bool
 	PoolManagerFailureReason string
 
-	Name             string `gorm:"index:idx_org_name_nocase,collate:nocase"`
+	Name             string `gorm:"index:idx_org_name_nocase,expression:LOWER(name)"`
 	WebhookSecret    []byte
 	Pools            []Pool                  `gorm:"foreignKey:OrgID"`
 	ScaleSet         []ScaleSet              `gorm:"foreignKey:OrgID"`
@@ -280,7 +280,7 @@ type Organization struct {
 	PoolBalancerType params.PoolBalancerType `gorm:"type:varchar(64)"`
 	AgentMode        bool                    `gorm:"index:org_agent_idx"`
 
-	EndpointName *string        `gorm:"index:idx_org_name_nocase,collate:nocase"`
+	EndpointName *string        `gorm:"index:idx_org_name_nocase,expression:LOWER(endpoint_name)"`
 	Endpoint     GithubEndpoint `gorm:"foreignKey:EndpointName;constraint:OnDelete:SET NULL"`
 
 	Events []OrganizationEvent `gorm:"foreignKey:OrgID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
@@ -306,7 +306,7 @@ type Enterprise struct {
 	PoolManagerRunning       bool
 	PoolManagerFailureReason string
 
-	Name             string `gorm:"index:idx_ent_name_nocase,collate:nocase"`
+	Name             string `gorm:"index:idx_ent_name_nocase,expression:LOWER(name)"`
 	WebhookSecret    []byte
 	Pools            []Pool                  `gorm:"foreignKey:EnterpriseID"`
 	ScaleSet         []ScaleSet              `gorm:"foreignKey:EnterpriseID"`
@@ -314,7 +314,7 @@ type Enterprise struct {
 	PoolBalancerType params.PoolBalancerType `gorm:"type:varchar(64)"`
 	AgentMode        bool                    `gorm:"index:enterprise_agent_idx"`
 
-	EndpointName *string        `gorm:"index:idx_ent_name_nocase,collate:nocase"`
+	EndpointName *string        `gorm:"index:idx_ent_name_nocase,expression:LOWER(endpoint_name)"`
 	Endpoint     GithubEndpoint `gorm:"foreignKey:EndpointName;constraint:OnDelete:SET NULL"`
 
 	Events []EnterpriseEvent `gorm:"foreignKey:EnterpriseID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE;"`
@@ -357,10 +357,10 @@ type Instance struct {
 	Heartbeat         time.Time
 	CallbackURL       string
 	MetadataURL       string
-	ProviderFault     []byte `gorm:"type:longblob"`
+	ProviderFault     []byte
 	CreateAttempt     int
 	TokenFetched      bool
-	JitConfiguration  []byte `gorm:"type:longblob"`
+	JitConfiguration  []byte
 	GitHubRunnerGroup string
 	AditionalLabels   datatypes.JSON
 	Capabilities      datatypes.JSON
@@ -461,32 +461,32 @@ type WorkflowJob struct {
 }
 
 type GithubEndpoint struct {
-	Name      string `gorm:"type:varchar(64) collate nocase;primary_key;"`
+	Name      string `gorm:"type:varchar(64);primary_key;uniqueIndex:idx_endpoint_name_nocase,expression:LOWER(name)"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt gorm.DeletedAt `gorm:"index"`
 
 	EndpointType             params.EndpointType `gorm:"index:idx_endpoint_type"`
-	ToolsMetadataURL         string              `gorm:"type:text collate nocase"`
+	ToolsMetadataURL         string              `gorm:"type:text"`
 	UseInternalToolsMetadata bool
 
 	Description   string `gorm:"type:text"`
-	APIBaseURL    string `gorm:"type:text collate nocase"`
-	UploadBaseURL string `gorm:"type:text collate nocase"`
-	BaseURL       string `gorm:"type:text collate nocase"`
-	CACertBundle  []byte `gorm:"type:longblob"`
+	APIBaseURL    string `gorm:"type:text"`
+	UploadBaseURL string `gorm:"type:text"`
+	BaseURL       string `gorm:"type:text"`
+	CACertBundle  []byte
 }
 
 type GithubCredentials struct {
 	gorm.Model
 
-	Name   string     `gorm:"index:idx_github_credentials,unique;type:varchar(64) collate nocase"`
+	Name   string     `gorm:"index:idx_github_credentials,unique,expression:LOWER(name);type:varchar(64)"`
 	UserID *uuid.UUID `gorm:"index:idx_github_credentials,unique"`
 	User   User       `gorm:"foreignKey:UserID"`
 
 	Description string               `gorm:"type:text"`
 	AuthType    params.ForgeAuthType `gorm:"index"`
-	Payload     []byte               `gorm:"type:longblob"`
+	Payload     []byte
 
 	Endpoint     GithubEndpoint `gorm:"foreignKey:EndpointName"`
 	EndpointName *string        `gorm:"index"`
@@ -507,13 +507,13 @@ func (g GithubCredentials) GetID() uint {
 type GiteaCredentials struct {
 	gorm.Model
 
-	Name   string     `gorm:"index:idx_gitea_credentials,unique;type:varchar(64) collate nocase"`
+	Name   string     `gorm:"index:idx_gitea_credentials,unique,expression:LOWER(name);type:varchar(64)"`
 	UserID *uuid.UUID `gorm:"index:idx_gitea_credentials,unique"`
 	User   User       `gorm:"foreignKey:UserID"`
 
 	Description string               `gorm:"type:text"`
 	AuthType    params.ForgeAuthType `gorm:"index"`
-	Payload     []byte               `gorm:"type:longblob"`
+	Payload     []byte
 
 	Endpoint     GithubEndpoint `gorm:"foreignKey:EndpointName"`
 	EndpointName *string        `gorm:"index"`

--- a/database/sql/organizations.go
+++ b/database/sql/organizations.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm-provider-common/util"
@@ -161,7 +162,7 @@ func (s *sqlDatabase) UpdateOrganization(ctx context.Context, orgID string, para
 	var org Organization
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
 		var err error
-		org, err = s.getOrgByID(ctx, tx, orgID, "Endpoint")
+		org, err = s.getOrgByID(ctx, tx.Clauses(clause.Locking{Strength: "UPDATE"}), orgID, "Endpoint")
 		if err != nil {
 			return fmt.Errorf("error fetching org: %w", err)
 		}
@@ -282,7 +283,7 @@ func (s *sqlDatabase) getOrgByID(_ context.Context, db *gorm.DB, id string, prel
 func (s *sqlDatabase) getOrg(_ context.Context, name, endpointName string) (Organization, error) {
 	var org Organization
 
-	q := s.conn.Where("name = ? COLLATE NOCASE and endpoint_name = ? COLLATE NOCASE", name, endpointName).
+	q := s.conn.Where("LOWER(name) = LOWER(?) and LOWER(endpoint_name) = LOWER(?)", name, endpointName).
 		Preload("Credentials").
 		Preload("GiteaCredentials").
 		Preload("Credentials.Endpoint").

--- a/database/sql/organizations_test.go
+++ b/database/sql/organizations_test.go
@@ -338,7 +338,7 @@ func (s *OrgTestSuite) TestGetOrganizationNotFound() {
 
 func (s *OrgTestSuite) TestGetOrganizationDBDecryptingErr() {
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE (name = ? COLLATE NOCASE and endpoint_name = ? COLLATE NOCASE) AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `organizations` WHERE (LOWER(name) = LOWER(?) and LOWER(endpoint_name) = LOWER(?)) AND `organizations`.`deleted_at` IS NULL ORDER BY `organizations`.`id` LIMIT ?")).
 		WithArgs(s.Fixtures.Orgs[0].Name, s.Fixtures.Orgs[0].Endpoint.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow(s.Fixtures.Orgs[0].Name))
 
@@ -514,7 +514,7 @@ func (s *OrgTestSuite) TestUpdateOrganizationDBEncryptErr() {
 			AddRow(s.Fixtures.Orgs[0].Endpoint.Name, s.Fixtures.Orgs[0].Endpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -548,7 +548,7 @@ func (s *OrgTestSuite) TestUpdateOrganizationDBSaveErr() {
 			AddRow(s.Fixtures.Orgs[0].Endpoint.Name, s.Fixtures.Orgs[0].Endpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -583,7 +583,7 @@ func (s *OrgTestSuite) TestUpdateOrganizationDBDecryptingErr() {
 			AddRow(s.Fixtures.Orgs[0].Endpoint.Name, s.Fixtures.Orgs[0].Endpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -682,7 +682,7 @@ func (s *OrgTestSuite) TestCreateOrganizationPoolDBFetchTagErr() {
 		WithArgs(s.Fixtures.Orgs[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnError(fmt.Errorf("mocked fetching tag error"))
 
 	entity, err := s.Fixtures.Orgs[0].GetEntity()
@@ -703,7 +703,7 @@ func (s *OrgTestSuite) TestCreateOrganizationPoolDBAddingPoolErr() {
 		WithArgs(s.Fixtures.Orgs[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).
@@ -731,7 +731,7 @@ func (s *OrgTestSuite) TestCreateOrganizationPoolDBSaveTagErr() {
 		WithArgs(s.Fixtures.Orgs[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).
@@ -762,7 +762,7 @@ func (s *OrgTestSuite) TestCreateOrganizationPoolDBFetchPoolErr() {
 		WithArgs(s.Fixtures.Orgs[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Orgs[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).

--- a/database/sql/pools.go
+++ b/database/sql/pools.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/database/common"
@@ -219,14 +221,19 @@ func (s *sqlDatabase) findPoolByTags(id string, poolType params.ForgeEntityType,
 		return nil, fmt.Errorf("invalid poolType: %v", poolType)
 	}
 
+	lowerTags := make([]string, len(tags))
+	for i, t := range tags {
+		lowerTags[i] = strings.ToLower(t)
+	}
+
 	var pools []Pool
-	where := fmt.Sprintf("tags.name COLLATE NOCASE in ? and %s = ? and enabled = true", fieldName)
+	where := fmt.Sprintf("LOWER(tags.name) in ? and %s = ? and enabled = true", fieldName)
 	q := s.conn.Joins("JOIN pool_tags on pool_tags.pool_id=pools.id").
 		Joins("JOIN tags on tags.id=pool_tags.tag_id").
 		Group("pools.id").
 		Preload("Tags").
 		Having("count(1) = ?", len(tags)).
-		Where(where, tags, u).
+		Where(where, lowerTags, u).
 		Order("priority desc").
 		Find(&pools)
 
@@ -410,7 +417,7 @@ func (s *sqlDatabase) UpdateEntityPool(ctx context.Context, entity params.ForgeE
 		}
 	}()
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		pool, err := s.getEntityPool(tx, entity.EntityType, entity.ID, poolID, "Tags", "Instances")
+		pool, err := s.getEntityPool(tx.Clauses(clause.Locking{Strength: "UPDATE"}), entity.EntityType, entity.ID, poolID, "Tags", "Instances")
 		if err != nil {
 			return fmt.Errorf("error fetching pool: %w", err)
 		}

--- a/database/sql/repositories.go
+++ b/database/sql/repositories.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm-provider-common/util"
@@ -163,7 +164,7 @@ func (s *sqlDatabase) UpdateRepository(ctx context.Context, repoID string, param
 	var repo Repository
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
 		var err error
-		repo, err = s.getRepoByID(ctx, tx, repoID, "Endpoint")
+		repo, err = s.getRepoByID(ctx, tx.Clauses(clause.Locking{Strength: "UPDATE"}), repoID, "Endpoint")
 		if err != nil {
 			return fmt.Errorf("error fetching repo: %w", err)
 		}
@@ -260,7 +261,7 @@ func (s *sqlDatabase) GetRepositoryByID(ctx context.Context, repoID string) (par
 func (s *sqlDatabase) getRepo(_ context.Context, owner, name, endpointName string) (Repository, error) {
 	var repo Repository
 
-	q := s.conn.Where("name = ? COLLATE NOCASE and owner = ? COLLATE NOCASE and endpoint_name = ? COLLATE NOCASE", name, owner, endpointName).
+	q := s.conn.Where("LOWER(name) = LOWER(?) and LOWER(owner) = LOWER(?) and LOWER(endpoint_name) = LOWER(?)", name, owner, endpointName).
 		Preload("Credentials").
 		Preload("Credentials.Endpoint").
 		Preload("GiteaCredentials").

--- a/database/sql/repositories_test.go
+++ b/database/sql/repositories_test.go
@@ -366,11 +366,11 @@ func (s *RepoTestSuite) TestGetRepositoryNotFound() {
 
 func (s *RepoTestSuite) TestGetRepositoryDBDecryptingErr() {
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `repositories` WHERE (name = ? COLLATE NOCASE and owner = ? COLLATE NOCASE and endpoint_name = ? COLLATE NOCASE) AND `repositories`.`deleted_at` IS NULL ORDER BY `repositories`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `repositories` WHERE (LOWER(name) = LOWER(?) and LOWER(owner) = LOWER(?) and LOWER(endpoint_name) = LOWER(?)) AND `repositories`.`deleted_at` IS NULL ORDER BY `repositories`.`id` LIMIT ?")).
 		WithArgs(s.Fixtures.Repos[0].Name, s.Fixtures.Repos[0].Owner, s.Fixtures.Repos[0].Endpoint.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"name", "owner"}).AddRow(s.Fixtures.Repos[0].Name, s.Fixtures.Repos[0].Owner))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `repositories` WHERE (name = ? COLLATE NOCASE and owner = ? COLLATE NOCASE and endpoint_name = ? COLLATE NOCASE) AND `repositories`.`deleted_at` IS NULL ORDER BY `repositories`.`id`,`repositories`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `repositories` WHERE (LOWER(name) = LOWER(?) and LOWER(owner) = LOWER(?) and LOWER(endpoint_name) = LOWER(?)) AND `repositories`.`deleted_at` IS NULL ORDER BY `repositories`.`id`,`repositories`.`id` LIMIT ?")).
 		WithArgs(s.Fixtures.Repos[0].Name, s.Fixtures.Repos[0].Owner, s.Fixtures.Repos[0].Endpoint.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"name", "owner"}).AddRow(s.Fixtures.Repos[0].Name, s.Fixtures.Repos[0].Owner))
 
@@ -586,7 +586,7 @@ func (s *RepoTestSuite) TestUpdateRepositoryDBEncryptErr() {
 			AddRow(s.githubEndpoint.Name, s.githubEndpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -618,7 +618,7 @@ func (s *RepoTestSuite) TestUpdateRepositoryDBSaveErr() {
 			AddRow(s.githubEndpoint.Name, s.githubEndpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -654,7 +654,7 @@ func (s *RepoTestSuite) TestUpdateRepositoryDBDecryptingErr() {
 			AddRow(s.githubEndpoint.Name, s.githubEndpoint.EndpointType))
 	// Expect credentials fetch
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND name = ? AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `github_credentials` WHERE user_id = ? AND LOWER(name) = LOWER(?) AND `github_credentials`.`deleted_at` IS NULL ORDER BY `github_credentials`.`id` LIMIT ?")).
 		WithArgs(s.adminUserID, s.secondaryTestCreds.Name, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "endpoint_name"}).
 			AddRow(s.secondaryTestCreds.ID, s.secondaryTestCreds.Endpoint.Name))
@@ -752,7 +752,7 @@ func (s *RepoTestSuite) TestCreateRepositoryPoolDBFetchTagErr() {
 		WithArgs(s.Fixtures.Repos[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Repos[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnError(fmt.Errorf("mocked fetching tag error"))
 
 	entity, err := s.Fixtures.Repos[0].GetEntity()
@@ -774,7 +774,7 @@ func (s *RepoTestSuite) TestCreateRepositoryPoolDBAddingPoolErr() {
 		WithArgs(s.Fixtures.Repos[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Repos[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).
@@ -803,7 +803,7 @@ func (s *RepoTestSuite) TestCreateRepositoryPoolDBSaveTagErr() {
 		WithArgs(s.Fixtures.Repos[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Repos[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).
@@ -834,7 +834,7 @@ func (s *RepoTestSuite) TestCreateRepositoryPoolDBFetchPoolErr() {
 		WithArgs(s.Fixtures.Repos[0].ID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(s.Fixtures.Repos[0].ID))
 	s.Fixtures.SQLMock.
-		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE name = ? COLLATE NOCASE AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
+		ExpectQuery(regexp.QuoteMeta("SELECT * FROM `tags` WHERE LOWER(name) = LOWER(?) AND `tags`.`deleted_at` IS NULL ORDER BY `tags`.`id` LIMIT ?")).
 		WillReturnRows(sqlmock.NewRows([]string{"linux"}))
 	s.Fixtures.SQLMock.
 		ExpectExec(regexp.QuoteMeta("INSERT INTO `tags`")).

--- a/database/sql/scalesets.go
+++ b/database/sql/scalesets.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/database/common"
@@ -218,7 +219,7 @@ func (s *sqlDatabase) UpdateEntityScaleSet(ctx context.Context, entity params.Fo
 		}
 	}()
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		scaleSet, err := s.getEntityScaleSet(tx, entity.EntityType, entity.ID, scaleSetID, "Instances", "Tags")
+		scaleSet, err := s.getEntityScaleSet(tx.Clauses(clause.Locking{Strength: "UPDATE"}), entity.EntityType, entity.ID, scaleSetID, "Instances", "Tags")
 		if err != nil {
 			return fmt.Errorf("error fetching scale set: %w", err)
 		}
@@ -432,7 +433,7 @@ func (s *sqlDatabase) DeleteScaleSetByID(_ context.Context, scaleSetID uint) (er
 		}
 	}()
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		dbSet, err := s.getScaleSetByID(tx, scaleSetID, "Instances", "Enterprise", "Organization", "Repository")
+		dbSet, err := s.getScaleSetByID(tx.Clauses(clause.Locking{Strength: "UPDATE"}), scaleSetID, "Instances", "Enterprise", "Organization", "Repository")
 		if err != nil {
 			return fmt.Errorf("error fetching scale set: %w", err)
 		}
@@ -465,7 +466,7 @@ func (s *sqlDatabase) SetScaleSetLastMessageID(_ context.Context, scaleSetID uin
 		}
 	}()
 	if err := s.conn.Transaction(func(tx *gorm.DB) error {
-		dbSet, err := s.getScaleSetByID(tx, scaleSetID, "Instances", "Enterprise", "Organization", "Repository")
+		dbSet, err := s.getScaleSetByID(tx.Clauses(clause.Locking{Strength: "UPDATE"}), scaleSetID, "Instances", "Enterprise", "Organization", "Repository")
 		if err != nil {
 			return fmt.Errorf("error fetching scale set: %w", err)
 		}
@@ -502,7 +503,7 @@ func (s *sqlDatabase) SetScaleSetDesiredRunnerCount(_ context.Context, scaleSetI
 		}
 	}()
 	if err := s.conn.Transaction(func(tx *gorm.DB) error {
-		dbSet, err := s.getScaleSetByID(tx, scaleSetID, "Instances", "Enterprise", "Organization", "Repository")
+		dbSet, err := s.getScaleSetByID(tx.Clauses(clause.Locking{Strength: "UPDATE"}), scaleSetID, "Instances", "Enterprise", "Organization", "Repository")
 		if err != nil {
 			return fmt.Errorf("error fetching scale set: %w", err)
 		}

--- a/database/sql/sql.go
+++ b/database/sql/sql.go
@@ -12,6 +12,11 @@
 //    License for the specific language governing permissions and limitations
 //    under the License.
 
+// Concurrency invariant: read-modify-write transactions in this package take a
+// row lock via SELECT ... FOR UPDATE (clause.Locking{Strength: "UPDATE"}) to
+// serialize concurrent updates of the same row and prevent lost updates. On a
+// single-writer backend (SQLite) the lock is effectively a no-op, but it is
+// load-bearing on any backend that permits concurrent writers — do not remove it.
 package sql
 
 import (

--- a/database/sql/templates.go
+++ b/database/sql/templates.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	commonParams "github.com/cloudbase/garm-provider-common/params"
@@ -45,7 +46,7 @@ func (s *sqlDatabase) ListTemplates(ctx context.Context, osType *commonParams.OS
 	}
 
 	if partialName != nil {
-		q = q.Where("name like ? COLLATE NOCASE", fmt.Sprintf("%%%s%%", *partialName))
+		q = q.Where("LOWER(name) LIKE LOWER(?)", fmt.Sprintf("%%%s%%", *partialName))
 	}
 
 	if forgeType != nil {
@@ -196,7 +197,7 @@ func (s *sqlDatabase) UpdateTemplate(ctx context.Context, id uint, param params.
 	}()
 	var tpl Template
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		tpl, err = s.getTemplate(ctx, tx, id)
+		tpl, err = s.getTemplate(ctx, tx.Clauses(clause.Locking{Strength: "UPDATE"}), id)
 		if err != nil {
 			return fmt.Errorf("failed to get template: %w", err)
 		}
@@ -252,7 +253,7 @@ func (s *sqlDatabase) DeleteTemplate(ctx context.Context, id uint) (err error) {
 		}
 	}()
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		tpl, err := s.getTemplate(ctx, tx, id, "Pools", "ScaleSets")
+		tpl, err := s.getTemplate(ctx, tx.Clauses(clause.Locking{Strength: "UPDATE"}), id, "Pools", "ScaleSets")
 		if err != nil {
 			return fmt.Errorf("failed to get template: %w", err)
 		}

--- a/database/sql/users.go
+++ b/database/sql/users.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm-provider-common/util"
@@ -122,7 +123,7 @@ func (s *sqlDatabase) UpdateUser(_ context.Context, user string, param params.Up
 	var err error
 	var dbUser User
 	err = s.conn.Transaction(func(tx *gorm.DB) error {
-		dbUser, err = s.getUserByUsernameOrEmail(tx, user)
+		dbUser, err = s.getUserByUsernameOrEmail(tx.Clauses(clause.Locking{Strength: "UPDATE"}), user)
 		if err != nil {
 			return fmt.Errorf("error fetching user: %w", err)
 		}

--- a/database/sql/util.go
+++ b/database/sql/util.go
@@ -559,7 +559,7 @@ func (s *sqlDatabase) sqlToParamsUser(user User) params.User {
 
 func (s *sqlDatabase) getOrCreateTag(tx *gorm.DB, tagName string) (Tag, error) {
 	var tag Tag
-	q := tx.Where("name = ? COLLATE NOCASE", tagName).First(&tag)
+	q := tx.Where("LOWER(name) = LOWER(?)", tagName).First(&tag)
 	if q.Error == nil {
 		return tag, nil
 	}


### PR DESCRIPTION
## What

Two backend-agnostic improvements to the GORM SQL layer:

1. **Case-insensitive lookups via `LOWER()` instead of `COLLATE NOCASE`.**
   `COLLATE NOCASE` is SQLite-specific. Replace it with `LOWER(col) = LOWER(?)`
   predicates and matching functional `LOWER(col)` indexes in the models, plus a
   migration (`0002_lower_indexes`) that converts the legacy NOCASE indexes on
   existing SQLite databases. Also drop the MySQL-specific `longblob` column-type
   tags.

2. **Row locking in read-modify-write transactions.**
   Add `SELECT ... FOR UPDATE` (`clause.Locking{Strength: "UPDATE"}`) to the
   transactions that read a row, mutate it in Go, and write it back, so concurrent
   updates of the same row are serialized and can't lose writes.

## Why

This improves portability of the existing SQL layer and is a prerequisite for adding a
concurrent backend such as PostgreSQL [#753].

On SQLite both changes are behavior-preserving: `LOWER()` and `NOCASE` both fold
ASCII, and the single-writer connection pool already serializes writes, so the
`FOR UPDATE` lock is effectively a no-op there. The value shows up on any backend
that permits concurrent writers, where the lock prevents lost-update races.

The `0002_lower_indexes` migration drops and recreates unique indexes on existing SQLite databases; this is safe because NOCASE and LOWER() both fold ASCII, so any row unique under the old index stays unique under the new one.

## Testing

- `go test -tags testing ./database/sql/... ./config/...` passes.
- sqlmock query expectations updated to the new `LOWER()` SQL.
- Verified on a fresh SQLite DB that the functional indexes are created and the
  planner uses them (e.g. `SEARCH organizations USING INDEX idx_org_name_nocase`).

## Out of scope

The file-object/blob storage layer (`file_store.go`, the `FileBlob` /
`FileObjectTag` models, and their migration) is deliberately not modified in
this PR because the layer is tied to SQLite specifics; its conversion is
handled in a follow-up PostgreSQL PR.