### PR TITLE
ci: back postgres test data dir with tmpfs to avoid test timeout

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -95,11 +95,17 @@ jobs:
           POSTGRES_DB: garm
         ports:
           - 5432:5432
+        # Back the data directory with tmpfs (RAM). The test suite creates a
+        # fresh schema and runs the full migration for every test case, so the
+        # default disk-backed, fsync-on container makes the run slow enough to
+        # hit the test timeout. This database is ephemeral, so trading
+        # durability for speed is safe.
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --tmpfs /var/lib/postgresql/data
 
     steps:
       - name: Install dependencies


### PR DESCRIPTION
## What

Mount the PostgreSQL service container's data directory (`/var/lib/postgresql/data`) on `tmpfs` in the `Go Tests (PostgreSQL)` job.

```yaml
options: >-
  --health-cmd pg_isready
  --health-interval 10s
  --health-timeout 5s
  --health-retries 5
  --tmpfs /var/lib/postgresql/data
```

## Why

The `Go Tests (PostgreSQL)` job has been hitting the `go test` timeout and failing, unrelated to the PR under test:

```
panic: test timed out after 15m0s
	running tests:
		TestGithubTestSuite (1m59s)
FAIL	github.com/cloudbase/garm/database/sql	900.382s
```

The `database/sql` suite creates a fresh schema and runs the full migration for every test case (`OpenTestPostgresDB` -> `CREATE SCHEMA` -> `migrateDB`). On the default `postgres:16` service container that DDL is fsync'd to disk, and the goroutine dump confirms the suite was stuck server-side in `CreateTable` on IO wait.

GitHub Actions service containers can't pass server flags like `postgres -c fsync=off` (there's no `command` field), so the data directory is moved to `tmpfs` instead. This keeps all of Postgres's I/O in RAM, making fsync effectively free. The database is ephemeral and recreated for every job, so trading durability for speed has no downside here, and it mirrors the `fsync=off` config already used for local Postgres test runs.

Measured locally on the `database/sql` package with the same flags CI uses (`-race -parallel=4`): ~562s disk-backed vs ~60s on tmpfs (~9x faster), tests still passing.
