### PR TITLE
fix(scalesets): remove debug print leaking auth token to stdout

### DIFF
--- a/util/github/scalesets/scalesets.go
+++ b/util/github/scalesets/scalesets.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/httputil"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/params"
@@ -108,10 +107,6 @@ func (s *ScaleSetClient) ListRunnerScaleSets(ctx context.Context) (_ *params.Run
 	req, err := s.newActionsRequest(ctx, http.MethodGet, scaleSetEndpoint, nil)
 	if err != nil {
 		return nil, err
-	}
-	data, err := httputil.DumpRequest(req, false)
-	if err == nil {
-		fmt.Println(string(data))
 	}
 	resp, err := s.Do(req)
 	if err != nil {


### PR DESCRIPTION
## What

`ListRunnerScaleSets` dumped its outgoing HTTP request to stdout, leaking the Actions service bearer token. Removes the leftover debug block (and the now-unused `httputil` import).

What it printed:

```
GET /_apis/runtime/runnerscalesets?api-version=6.0-preview HTTP/1.1
Host: <actions-service-host>
Authorization: Bearer <redacted>
Content-Type: application/json
```

## Why

It's leftover debug instrumentation that writes a credential to stdout via `fmt.Println` rather than the structured logger, and it's ungated. The method itself is left in place in case it's reused.