### PR TITLE
Fix extra specs nil pointer deref

### DIFF
--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -270,7 +270,7 @@ func (r *basePoolManager) persistJobToDB(ctx context.Context, jobParams params.J
 			"is_new_job", isNewJob,
 			"job_action", jobParams.Action,
 		)
-		return fmt.Errorf("job %d should not be recorded", jobParams.WorkflowJobID)
+		return fmt.Errorf("job %d should not be recorded: %w", jobParams.WorkflowJobID, runnerErrors.ErrUnprocessable)
 	}
 
 	slog.DebugContext(

--- a/util/util.go
+++ b/util/util.go
@@ -139,6 +139,12 @@ func MaybeAddWrapperToExtraSpecs(ctx context.Context, param commonParams.Bootstr
 			return param
 		}
 	}
+	if data == nil {
+		// Unmarshal returned nil. An explicit `null` was probably passed.
+		// Any other valid json would either fail to unmarshal or unmarshal
+		// into an actual map we can use.
+		return param
+	}
 
 	if _, ok := data["runner_install_template"]; ok {
 		// User has already set a runner install template override. Do not touch.


### PR DESCRIPTION
When pools have extra specs set explicitly to `null`, the variable we unmarshal into, if the type is nullable, will become null. In this case a ma[string]any{}, even if it was previously initialized to a non-null value, will become null. Any attempt to assign it it will cause a panic.

Guard against that case.

Fixes: #787