### PR TITLE
Fix/type template data

### DIFF
--- a/cmd/garm-cli/cmd/templates.go
+++ b/cmd/garm-cli/cmd/templates.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 
@@ -101,7 +102,7 @@ var templateCreateCmd = &cobra.Command{
 		createTemplateReq.Body.ForgeType = forge
 		createTemplateReq.Body.OSType = osType
 		createTemplateReq.Body.Description = templateDescription
-		createTemplateReq.Body.Data = data
+		createTemplateReq.Body.Data = strfmt.Base64(data)
 
 		response, err := apiCli.Templates.CreateTemplate(createTemplateReq, authToken)
 		if err != nil {
@@ -156,7 +157,7 @@ var templateUpdateCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to read template file: %q", err)
 			}
-			updateReq.Body.Data = data
+			updateReq.Body.Data = strfmt.Base64(data)
 			changes = true
 		}
 		if !changes {
@@ -271,7 +272,7 @@ var templateDownloadCmd = &cobra.Command{
 			return fmt.Errorf("destination path already exists; will not overwrite")
 		}
 
-		if err := os.WriteFile(templatePath, response.Payload.Data, 0o600); err != nil {
+		if err := os.WriteFile(templatePath, []byte(response.Payload.Data), 0o600); err != nil {
 			return fmt.Errorf("failed to save file %s: %s", templatePath, err)
 		}
 		return nil
@@ -445,7 +446,7 @@ var templateEditCmd = &cobra.Command{
 		if saved && newContent != string(response.Payload.Data) {
 			updateReq := apiTemplates.NewUpdateTemplateParams()
 			updateReq.TemplateID = float64(response.Payload.ID)
-			updateReq.Body.Data = []byte(newContent)
+			updateReq.Body.Data = strfmt.Base64(newContent)
 
 			_, err = apiCli.Templates.UpdateTemplate(updateReq, authToken)
 			if err != nil {

--- a/database/sql/util.go
+++ b/database/sql/util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -1133,7 +1134,7 @@ func (s *sqlDatabase) sqlToParamTemplate(template Template) (params.Template, er
 		UpdatedAt:   template.UpdatedAt,
 		Name:        template.Name,
 		Description: template.Description,
-		Data:        data,
+		Data:        strfmt.Base64(data),
 		ForgeType:   template.ForgeType,
 		Owner:       owner,
 		OSType:      template.OSType,

--- a/params/params.go
+++ b/params/params.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/go-openapi/strfmt"
 	"github.com/google/go-github/v84/github"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
@@ -1489,7 +1490,7 @@ type Template struct {
 	Description string              `json:"description"`
 	OSType      commonParams.OSType `json:"os_type"`
 	ForgeType   EndpointType        `json:"forge_type,omitempty"`
-	Data        []byte              `json:"data"`
+	Data        strfmt.Base64       `json:"data"`
 	Owner       string              `json:"owner_id,omitempty"`
 }
 

--- a/params/requests.go
+++ b/params/requests.go
@@ -25,6 +25,7 @@ import (
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	commonParams "github.com/cloudbase/garm-provider-common/params"
 	commonUtil "github.com/cloudbase/garm-provider-common/util"
+	"github.com/go-openapi/strfmt"
 )
 
 const (
@@ -877,7 +878,7 @@ func (u UpdateGiteaCredentialsParams) Validate() error {
 type CreateTemplateParams struct {
 	Name        string              `json:"name"`
 	Description string              `json:"description"`
-	Data        []byte              `json:"data"`
+	Data        strfmt.Base64       `json:"data"`
 	OSType      commonParams.OSType `json:"os_type"`
 	ForgeType   EndpointType        `json:"forge_type,omitempty"`
 	IsSystem    bool                `json:"-"`
@@ -908,9 +909,9 @@ func (c *CreateTemplateParams) Validate() error {
 
 // swagger:model UpdateTemplateParams
 type UpdateTemplateParams struct {
-	Name        *string `json:"name"`
-	Description *string `json:"description"`
-	Data        []byte  `json:"data"`
+	Name        *string       `json:"name"`
+	Description *string       `json:"description"`
+	Data        strfmt.Base64 `json:"data"`
 }
 
 func (u *UpdateTemplateParams) Validate() error {

--- a/runner/metadata.go
+++ b/runner/metadata.go
@@ -461,7 +461,7 @@ func (r *Runner) GetRunnerInstallScript(ctx context.Context) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get template: %w", err)
 		}
-		tplBytes = template.Data
+		tplBytes = []byte(template.Data)
 	}
 
 	installScript, err := templates.RenderRunnerInstallScript(string(tplBytes), tplCtx)

--- a/runner/templates_test.go
+++ b/runner/templates_test.go
@@ -349,7 +349,7 @@ func (s *TemplateTestSuite) TestRestoreTemplateSpecific() {
 	updatedTemplate, err := s.Runner.GetTemplate(s.adminCtx, systemTemplate.ID)
 	s.Require().Nil(err)
 	s.Require().Equal(modifiedName, updatedTemplate.Name)
-	s.Require().Equal(modifiedData, updatedTemplate.Data)
+	s.Require().Equal(modifiedData, []byte(updatedTemplate.Data))
 
 	restoreParams := params.RestoreTemplateRequest{
 		Forge:      params.GithubEndpointType,
@@ -365,7 +365,7 @@ func (s *TemplateTestSuite) TestRestoreTemplateSpecific() {
 	// Name should be restored to the system default
 	s.Require().Equal("github_linux", restoredTemplate.Name)
 	// Data should be restored to original template content (not the modified content)
-	s.Require().NotEqual(modifiedData, restoredTemplate.Data)
+	s.Require().NotEqual(modifiedData, []byte(restoredTemplate.Data))
 	// Should match the original template data or be close to it (content from internal/templates)
 	s.Require().NotEmpty(restoredTemplate.Data)
 	// Verify it's still a system template

--- a/webapp/src/lib/api/generated/api.ts
+++ b/webapp/src/lib/api/generated/api.ts
@@ -772,10 +772,10 @@ export interface CreateScaleSetParams {
 export interface CreateTemplateParams {
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof CreateTemplateParams
      */
-    'data'?: Array<number>;
+    'data'?: string;
     /**
      * 
      * @type {string}
@@ -2913,10 +2913,10 @@ export interface Template {
     'created_at'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof Template
      */
-    'data'?: Array<number>;
+    'data'?: string;
     /**
      * 
      * @type {string}
@@ -3421,10 +3421,10 @@ export interface UpdateScaleSetParams {
 export interface UpdateTemplateParams {
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof UpdateTemplateParams
      */
-    'data'?: Array<number>;
+    'data'?: string;
     /**
      * 
      * @type {string}

--- a/webapp/swagger.yaml
+++ b/webapp/swagger.yaml
@@ -459,11 +459,9 @@ definitions:
     CreateTemplateParams:
         properties:
             data:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                type: string
                 x-go-name: Data
+                x-go-type: github.com/go-openapi/strfmt.Base64
             description:
                 type: string
                 x-go-name: Description
@@ -1898,11 +1896,9 @@ definitions:
                 type: string
                 x-go-name: CreatedAt
             data:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                type: string
                 x-go-name: Data
+                x-go-type: github.com/go-openapi/strfmt.Base64
             description:
                 type: string
                 x-go-name: Description
@@ -2188,11 +2184,9 @@ definitions:
     UpdateTemplateParams:
         properties:
             data:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                type: string
                 x-go-name: Data
+                x-go-type: github.com/go-openapi/strfmt.Base64
             description:
                 type: string
                 x-go-name: Description


### PR DESCRIPTION
This PR is intended to fix issue #796.

The `byte[]` data type for field `data` in the template causes the OpenAPI spec to record it as an array of uint8, when the returned response is a base64-encoded string.

This PR uses the `Base64` type of `github.com/go-openapi/strfmt` package to ensure the OpenAPI spec generated contains `string` as the datatype.

I have run `make generate` on the code.