### PR TITLE
Fix swagger []byte definitions

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -340,6 +340,8 @@ type Instance struct {
 
 	// ProviderFault holds any error messages captured from the IaaS provider that is
 	// responsible for managing the lifecycle of the runner.
+	//
+	// swagger:strfmt byte
 	ProviderFault []byte `json:"provider_fault,omitempty"`
 
 	// StatusMessages is a list of status messages sent back by the runner as it sets itself
@@ -426,6 +428,8 @@ type BootstrapInstance struct {
 	// CACertBundle is a CA certificate bundle which will be sent to instances and which
 	// will tipically be installed as a system wide trusted root CA. by either cloud-init
 	// or whatever mechanism the provider will use to set up the runner.
+	//
+	// swagger:strfmt byte
 	CACertBundle []byte `json:"ca-cert-bundle,omitempty"`
 
 	// OSArch is the target OS CPU architecture of the runner.
@@ -1041,6 +1045,8 @@ type ControllerInfo struct {
 	// CACertBundle holds a certificate bundle meant to validate the certificate
 	// used by GARM itself. This can be just the root certificate that can validate
 	// the GARM TLS certificate, a chain or multiple root CAs.
+	//
+	// swagger:strfmt byte
 	CACertBundle []byte `json:"ca_cert_bundle,omitempty"`
 	// CachedGARMAgentReleaseFetchedAt is the timestamp when the release data was last fetched from GARMAgentReleasesURL
 	CachedGARMAgentReleaseFetchedAt *time.Time `json:"cached_garm_agent_release_fetched_at,omitempty"`
@@ -1107,14 +1113,15 @@ func (g GithubRateLimit) ResetAt() time.Time {
 
 // swagger:model ForgeCredentials
 type ForgeCredentials struct {
-	ID            uint          `json:"id,omitempty"`
-	Name          string        `json:"name,omitempty"`
-	Description   string        `json:"description,omitempty"`
-	APIBaseURL    string        `json:"api_base_url,omitempty"`
-	UploadBaseURL string        `json:"upload_base_url,omitempty"`
-	BaseURL       string        `json:"base_url,omitempty"`
-	CABundle      []byte        `json:"ca_bundle,omitempty"`
-	AuthType      ForgeAuthType `json:"auth-type,omitempty"`
+	ID            uint   `json:"id,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Description   string `json:"description,omitempty"`
+	APIBaseURL    string `json:"api_base_url,omitempty"`
+	UploadBaseURL string `json:"upload_base_url,omitempty"`
+	BaseURL       string `json:"base_url,omitempty"`
+	// swagger:strfmt byte
+	CABundle []byte        `json:"ca_bundle,omitempty"`
+	AuthType ForgeAuthType `json:"auth-type,omitempty"`
 
 	ForgeType EndpointType `json:"forge_type,omitempty"`
 
@@ -1449,11 +1456,12 @@ type ForgeEndpoints []ForgeEndpoint
 
 // swagger:model ForgeEndpoint
 type ForgeEndpoint struct {
-	Name                     string    `json:"name,omitempty"`
-	Description              string    `json:"description,omitempty"`
-	APIBaseURL               string    `json:"api_base_url,omitempty"`
-	UploadBaseURL            string    `json:"upload_base_url,omitempty"`
-	BaseURL                  string    `json:"base_url,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Description   string `json:"description,omitempty"`
+	APIBaseURL    string `json:"api_base_url,omitempty"`
+	UploadBaseURL string `json:"upload_base_url,omitempty"`
+	BaseURL       string `json:"base_url,omitempty"`
+	// swagger:strfmt byte
 	CACertBundle             []byte    `json:"ca_cert_bundle,omitempty"`
 	CreatedAt                time.Time `json:"created_at,omitempty"`
 	UpdatedAt                time.Time `json:"updated_at,omitempty"`
@@ -1489,8 +1497,9 @@ type Template struct {
 	Description string              `json:"description"`
 	OSType      commonParams.OSType `json:"os_type"`
 	ForgeType   EndpointType        `json:"forge_type,omitempty"`
-	Data        []byte              `json:"data"`
-	Owner       string              `json:"owner_id,omitempty"`
+	// swagger:strfmt byte
+	Data  []byte `json:"data"`
+	Owner string `json:"owner_id,omitempty"`
 }
 
 // used by swagger client generated code

--- a/params/requests.go
+++ b/params/requests.go
@@ -262,15 +262,16 @@ type UpdateInstanceParams struct {
 	// for this instance.
 	Addresses []commonParams.Address `json:"addresses,omitempty"`
 	// Status is the status of the instance inside the provider (eg: running, stopped, etc)
-	Status           commonParams.InstanceStatus `json:"status,omitempty"`
-	RunnerStatus     RunnerStatus                `json:"runner_status,omitempty"`
-	ProviderFault    []byte                      `json:"provider_fault,omitempty"`
-	Heartbeat        *time.Time                  `json:"heartbeat,omitempty"`
-	AgentID          int64                       `json:"-"`
-	CreateAttempt    int                         `json:"-"`
-	TokenFetched     *bool                       `json:"-"`
-	JitConfiguration map[string]string           `json:"-"`
-	Capabilities     *AgentCapabilities          `json:"-"`
+	Status       commonParams.InstanceStatus `json:"status,omitempty"`
+	RunnerStatus RunnerStatus                `json:"runner_status,omitempty"`
+	// swagger:strfmt byte
+	ProviderFault    []byte             `json:"provider_fault,omitempty"`
+	Heartbeat        *time.Time         `json:"heartbeat,omitempty"`
+	AgentID          int64              `json:"-"`
+	CreateAttempt    int                `json:"-"`
+	TokenFetched     *bool              `json:"-"`
+	JitConfiguration map[string]string  `json:"-"`
+	Capabilities     *AgentCapabilities `json:"-"`
 }
 
 type UpdateUserParams struct {
@@ -318,7 +319,8 @@ type CreateGithubEndpointParams struct {
 	APIBaseURL    string `json:"api_base_url,omitempty"`
 	UploadBaseURL string `json:"upload_base_url,omitempty"`
 	BaseURL       string `json:"base_url,omitempty"`
-	CACertBundle  []byte `json:"ca_cert_bundle,omitempty"`
+	// swagger:strfmt byte
+	CACertBundle []byte `json:"ca_cert_bundle,omitempty"`
 }
 
 func (c CreateGithubEndpointParams) Validate() error {
@@ -385,7 +387,8 @@ type UpdateGithubEndpointParams struct {
 	APIBaseURL    *string `json:"api_base_url,omitempty"`
 	UploadBaseURL *string `json:"upload_base_url,omitempty"`
 	BaseURL       *string `json:"base_url,omitempty"`
-	CACertBundle  []byte  `json:"ca_cert_bundle,omitempty"`
+	// swagger:strfmt byte
+	CACertBundle []byte `json:"ca_cert_bundle,omitempty"`
 }
 
 func (u UpdateGithubEndpointParams) Validate() error {
@@ -445,8 +448,9 @@ type GithubPAT struct {
 
 // swagger:model GithubApp
 type GithubApp struct {
-	AppID           int64  `json:"app_id,omitempty"`
-	InstallationID  int64  `json:"installation_id,omitempty"`
+	AppID          int64 `json:"app_id,omitempty"`
+	InstallationID int64 `json:"installation_id,omitempty"`
+	// swagger:strfmt byte
 	PrivateKeyBytes []byte `json:"private_key_bytes,omitempty"`
 }
 
@@ -553,8 +557,9 @@ type UpdateControllerParams struct {
 	GARMAgentReleasesURL *string `json:"garm_agent_releases_url,omitempty"`
 	SyncGARMAgentTools   *bool   `json:"enable_agent_tools_sync,omitempty"`
 	MinimumJobAgeBackoff *uint   `json:"minimum_job_age_backoff,omitempty"`
-	CACertBundle         []byte  `json:"ca_cert_bundle,omitempty"`
-	ClearCACertBundle    *bool   `json:"clear_ca_cert_bundle,omitempty"`
+	// swagger:strfmt byte
+	CACertBundle      []byte `json:"ca_cert_bundle,omitempty"`
+	ClearCACertBundle *bool  `json:"clear_ca_cert_bundle,omitempty"`
 }
 
 func (u UpdateControllerParams) Validate() error {
@@ -698,10 +703,11 @@ type UpdateScaleSetParams struct {
 
 // swagger:model CreateGiteaEndpointParams
 type CreateGiteaEndpointParams struct {
-	Name                     string `json:"name,omitempty"`
-	Description              string `json:"description,omitempty"`
-	APIBaseURL               string `json:"api_base_url,omitempty"`
-	BaseURL                  string `json:"base_url,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	APIBaseURL  string `json:"api_base_url,omitempty"`
+	BaseURL     string `json:"base_url,omitempty"`
+	// swagger:strfmt byte
 	CACertBundle             []byte `json:"ca_cert_bundle,omitempty"`
 	ToolsMetadataURL         string `json:"tools_metadata_url,omitempty"`
 	UseInternalToolsMetadata *bool  `json:"use_internal_tools_metadata,omitempty"`
@@ -764,12 +770,13 @@ func (c CreateGiteaEndpointParams) Validate() error {
 
 // swagger:model UpdateGiteaEndpointParams
 type UpdateGiteaEndpointParams struct {
-	Description              *string `json:"description,omitempty"`
-	APIBaseURL               *string `json:"api_base_url,omitempty"`
-	BaseURL                  *string `json:"base_url,omitempty"`
-	CACertBundle             []byte  `json:"ca_cert_bundle,omitempty"`
-	ToolsMetadataURL         string  `json:"tools_metadata_url,omitempty"`
-	UseInternalToolsMetadata *bool   `json:"use_internal_tools_metadata,omitempty"`
+	Description *string `json:"description,omitempty"`
+	APIBaseURL  *string `json:"api_base_url,omitempty"`
+	BaseURL     *string `json:"base_url,omitempty"`
+	// swagger:strfmt byte
+	CACertBundle             []byte `json:"ca_cert_bundle,omitempty"`
+	ToolsMetadataURL         string `json:"tools_metadata_url,omitempty"`
+	UseInternalToolsMetadata *bool  `json:"use_internal_tools_metadata,omitempty"`
 }
 
 func (u UpdateGiteaEndpointParams) Validate() error {
@@ -875,12 +882,13 @@ func (u UpdateGiteaCredentialsParams) Validate() error {
 
 // swagger:model CreateTemplateParams
 type CreateTemplateParams struct {
-	Name        string              `json:"name"`
-	Description string              `json:"description"`
-	Data        []byte              `json:"data"`
-	OSType      commonParams.OSType `json:"os_type"`
-	ForgeType   EndpointType        `json:"forge_type,omitempty"`
-	IsSystem    bool                `json:"-"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// swagger:strfmt byte
+	Data      []byte              `json:"data"`
+	OSType    commonParams.OSType `json:"os_type"`
+	ForgeType EndpointType        `json:"forge_type,omitempty"`
+	IsSystem  bool                `json:"-"`
 }
 
 func (c *CreateTemplateParams) Validate() error {
@@ -910,7 +918,8 @@ func (c *CreateTemplateParams) Validate() error {
 type UpdateTemplateParams struct {
 	Name        *string `json:"name"`
 	Description *string `json:"description"`
-	Data        []byte  `json:"data"`
+	// swagger:strfmt byte
+	Data []byte `json:"data"`
 }
 
 func (u *UpdateTemplateParams) Validate() error {

--- a/webapp/src/lib/api/generated/api.ts
+++ b/webapp/src/lib/api/generated/api.ts
@@ -88,10 +88,10 @@ export interface ControllerInfo {
     'agent_url'?: string;
     /**
      * CACertBundle holds a certificate bundle meant to validate the certificate used by GARM itself. This can be just the root certificate that can validate the GARM TLS certificate, a chain or multiple root CAs.
-     * @type {Array<number>}
+     * @type {string}
      * @memberof ControllerInfo
      */
-    'ca_cert_bundle'?: Array<number>;
+    'ca_cert_bundle'?: string;
     /**
      * CachedGARMAgentReleaseFetchedAt is the timestamp when the release data was last fetched from GARMAgentReleasesURL
      * @type {string}
@@ -339,10 +339,10 @@ export interface CreateGiteaEndpointParams {
     'base_url'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof CreateGiteaEndpointParams
      */
-    'ca_cert_bundle'?: Array<number>;
+    'ca_cert_bundle'?: string;
     /**
      * 
      * @type {string}
@@ -431,10 +431,10 @@ export interface CreateGithubEndpointParams {
     'base_url'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof CreateGithubEndpointParams
      */
-    'ca_cert_bundle'?: Array<number>;
+    'ca_cert_bundle'?: string;
     /**
      * 
      * @type {string}
@@ -772,10 +772,10 @@ export interface CreateScaleSetParams {
 export interface CreateTemplateParams {
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof CreateTemplateParams
      */
-    'data'?: Array<number>;
+    'data'?: string;
     /**
      * 
      * @type {string}
@@ -1114,10 +1114,10 @@ export interface ForgeCredentials {
     'base_url'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof ForgeCredentials
      */
-    'ca_bundle'?: Array<number>;
+    'ca_bundle'?: string;
     /**
      * 
      * @type {string}
@@ -1211,10 +1211,10 @@ export interface ForgeEndpoint {
     'base_url'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof ForgeEndpoint
      */
-    'ca_cert_bundle'?: Array<number>;
+    'ca_cert_bundle'?: string;
     /**
      * 
      * @type {string}
@@ -1576,10 +1576,10 @@ export interface GithubApp {
     'installation_id'?: number;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof GithubApp
      */
-    'private_key_bytes'?: Array<number>;
+    'private_key_bytes'?: string;
 }
 /**
  * 
@@ -1779,10 +1779,10 @@ export interface Instance {
     'pool_id'?: string;
     /**
      * ProviderFault holds any error messages captured from the IaaS provider that is responsible for managing the lifecycle of the runner.
-     * @type {Array<number>}
+     * @type {string}
      * @memberof Instance
      */
-    'provider_fault'?: Array<number>;
+    'provider_fault'?: string;
     /**
      * PeoviderID is the unique ID the provider associated with the compute instance. We use this to identify the instance in the provider.
      * @type {string}
@@ -2913,10 +2913,10 @@ export interface Template {
     'created_at'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof Template
      */
-    'data'?: Array<number>;
+    'data'?: string;
     /**
      * 
      * @type {string}
@@ -2974,10 +2974,10 @@ export interface UpdateControllerParams {
     'agent_url'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof UpdateControllerParams
      */
-    'ca_cert_bundle'?: Array<number>;
+    'ca_cert_bundle'?: string;
     /**
      * 
      * @type {string}
@@ -3122,10 +3122,10 @@ export interface UpdateGiteaEndpointParams {
     'base_url'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof UpdateGiteaEndpointParams
      */
-    'ca_cert_bundle'?: Array<number>;
+    'ca_cert_bundle'?: string;
     /**
      * 
      * @type {string}
@@ -3196,10 +3196,10 @@ export interface UpdateGithubEndpointParams {
     'base_url'?: string;
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof UpdateGithubEndpointParams
      */
-    'ca_cert_bundle'?: Array<number>;
+    'ca_cert_bundle'?: string;
     /**
      * 
      * @type {string}
@@ -3421,10 +3421,10 @@ export interface UpdateScaleSetParams {
 export interface UpdateTemplateParams {
     /**
      * 
-     * @type {Array<number>}
+     * @type {string}
      * @memberof UpdateTemplateParams
      */
-    'data'?: Array<number>;
+    'data'?: string;
     /**
      * 
      * @type {string}

--- a/webapp/swagger.yaml
+++ b/webapp/swagger.yaml
@@ -44,10 +44,8 @@ definitions:
                     CACertBundle holds a certificate bundle meant to validate the certificate
                     used by GARM itself. This can be just the root certificate that can validate
                     the GARM TLS certificate, a chain or multiple root CAs.
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: CACertBundle
             cached_garm_agent_release_fetched_at:
                 description: CachedGARMAgentReleaseFetchedAt is the timestamp when the release data was last fetched from GARMAgentReleasesURL
@@ -222,10 +220,8 @@ definitions:
                 type: string
                 x-go-name: BaseURL
             ca_cert_bundle:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: CACertBundle
             description:
                 type: string
@@ -269,10 +265,8 @@ definitions:
                 type: string
                 x-go-name: BaseURL
             ca_cert_bundle:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: CACertBundle
             description:
                 type: string
@@ -459,10 +453,8 @@ definitions:
     CreateTemplateParams:
         properties:
             data:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: Data
             description:
                 type: string
@@ -680,10 +672,8 @@ definitions:
                 type: string
                 x-go-name: BaseURL
             ca_bundle:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: CABundle
             created_at:
                 format: date-time
@@ -738,10 +728,8 @@ definitions:
                 type: string
                 x-go-name: BaseURL
             ca_cert_bundle:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: CACertBundle
             created_at:
                 format: date-time
@@ -966,10 +954,8 @@ definitions:
                 type: integer
                 x-go-name: InstallationID
             private_key_bytes:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: PrivateKeyBytes
         type: object
         x-go-package: github.com/cloudbase/garm/params
@@ -1108,10 +1094,8 @@ definitions:
                 description: |-
                     ProviderFault holds any error messages captured from the IaaS provider that is
                     responsible for managing the lifecycle of the runner.
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: ProviderFault
             provider_id:
                 description: |-
@@ -1898,10 +1882,8 @@ definitions:
                 type: string
                 x-go-name: CreatedAt
             data:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: Data
             description:
                 type: string
@@ -1938,10 +1920,8 @@ definitions:
                 type: string
                 x-go-name: AgentURL
             ca_cert_bundle:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: CACertBundle
             callback_url:
                 type: string
@@ -2018,10 +1998,8 @@ definitions:
                 type: string
                 x-go-name: BaseURL
             ca_cert_bundle:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: CACertBundle
             description:
                 type: string
@@ -2057,10 +2035,8 @@ definitions:
                 type: string
                 x-go-name: BaseURL
             ca_cert_bundle:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: CACertBundle
             description:
                 type: string
@@ -2188,10 +2164,8 @@ definitions:
     UpdateTemplateParams:
         properties:
             data:
-                items:
-                    format: uint8
-                    type: integer
-                type: array
+                format: byte
+                type: string
                 x-go-name: Data
             description:
                 type: string


### PR DESCRIPTION
Golang serializez byte arrays as base64 strings, but by default go-swagger generates specs for []byte types as uint8 arrays.

This change annotates most byte arrays as string represented byte arrays, which should fix the swagger definitions.


Supersedes: #801 
Fixes: #796