### PR TITLE
Safety improvements

### DIFF
--- a/apiserver/controllers/agent.go
+++ b/apiserver/controllers/agent.go
@@ -105,7 +105,7 @@ func (a *APIController) AgentShellHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	slog.InfoContext(ctx, "shell session created", "session_id", sessionID, "agent_name", agentName)
-	defer agent.RemoveClientSession(sessionID, false)
+	defer agent.RemoveClientSession(sessionID)
 
 	select {
 	case <-sess.Done():

--- a/workers/websocket/agent/agent.go
+++ b/workers/websocket/agent/agent.go
@@ -50,13 +50,12 @@ func NewAgent(ctx context.Context, conn *websocket.Conn, instance params.Instanc
 	)
 
 	return &Agent{
-		ctx:           ctx,
-		conn:          conn,
-		instance:      instance,
-		agentStore:    store,
-		done:          closed,
-		consumerID:    consumerID,
-		shellSessions: make(map[string]*ClientSession),
+		ctx:        ctx,
+		conn:       conn,
+		instance:   instance,
+		agentStore: store,
+		done:       closed,
+		consumerID: consumerID,
 	}, nil
 }
 
@@ -74,14 +73,20 @@ type Agent struct {
 	running atomic.Bool
 	done    chan struct{}
 
-	shellSessions map[string]*ClientSession
+	// shellSessions maps a session ID string to its *ClientSession.
+	// It is a sync.Map because it is read from the runner-driven agentReader
+	// goroutine (handleShell*) concurrently with writes from the admin's
+	// shell handler goroutine (CreateShellSession/RemoveClientSession). A plain
+	// map here would let a compromised runner trigger a fatal
+	// "concurrent map read and map write" and crash the controller.
+	shellSessions sync.Map
 }
 
 func (a *Agent) CreateShellSession(ctx context.Context, sessionID uuid.UUID, clientConn *websocket.Conn) (*ClientSession, error) {
 	a.mux.Lock()
 	defer a.mux.Unlock()
 
-	_, ok := a.shellSessions[sessionID.String()]
+	_, ok := a.shellSessions.Load(sessionID.String())
 	if ok {
 		return nil, runnerErrors.NewConflictError("session ID %q already in use", sessionID)
 	}
@@ -104,25 +109,23 @@ func (a *Agent) CreateShellSession(ctx context.Context, sessionID uuid.UUID, cli
 		sess.Stop()
 		return nil, fmt.Errorf("agent shell is disabled")
 	}
-	a.shellSessions[sessionID.String()] = sess
+	a.shellSessions.Store(sessionID.String(), sess)
 	return sess, nil
 }
 
-func (a *Agent) RemoveClientSession(sessionID uuid.UUID, safe bool) error {
-	if !safe {
-		a.mux.Lock()
-		defer a.mux.Unlock()
-	}
-	sess, ok := a.shellSessions[sessionID.String()]
+func (a *Agent) RemoveClientSession(sessionID uuid.UUID) error {
+	// LoadAndDelete atomically removes the session, so concurrent callers
+	// (e.g. the runner-driven handleShellExit and the shell handler's defer)
+	// don't double-stop it. sync.Map makes this safe without a.mux.
+	val, ok := a.shellSessions.LoadAndDelete(sessionID.String())
 	if !ok {
 		return nil
 	}
+	sess := val.(*ClientSession)
 
 	if err := sess.Stop(); err != nil {
 		return fmt.Errorf("failed to stop session")
 	}
-
-	delete(a.shellSessions, sessionID.String())
 	return nil
 }
 
@@ -172,10 +175,12 @@ func (a *Agent) Stop() error {
 		return nil
 	}
 	slog.InfoContext(a.ctx, "removing sessions")
-	for _, val := range a.shellSessions {
-		slog.InfoContext(a.ctx, "removing session", "session_id", val.sessionID)
-		a.RemoveClientSession(val.sessionID, true)
-	}
+	a.shellSessions.Range(func(_, val any) bool {
+		sess := val.(*ClientSession)
+		slog.InfoContext(a.ctx, "removing session", "session_id", sess.sessionID)
+		a.RemoveClientSession(sess.sessionID)
+		return true
+	})
 
 	a.running.Store(false)
 	slog.InfoContext(a.ctx, "sending websocket close message")
@@ -266,10 +271,11 @@ func (a *Agent) handleShellReady(agentMsg messaging.AgentMessage, raw []byte) er
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal shell ready message: %w", err)
 	}
-	session, ok := a.shellSessions[shellReady.ID()]
+	val, ok := a.shellSessions.Load(shellReady.ID())
 	if !ok {
 		return nil
 	}
+	session := val.(*ClientSession)
 	if err := session.Write(raw); err != nil {
 		return fmt.Errorf("failed to write message: %w", err)
 	}
@@ -281,11 +287,12 @@ func (a *Agent) handleShellExit(agentMsg messaging.AgentMessage) error {
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal shell exit message: %w", err)
 	}
-	session, ok := a.shellSessions[shellExit.ID()]
+	val, ok := a.shellSessions.Load(shellExit.ID())
 	if !ok {
 		return nil
 	}
-	if err := a.RemoveClientSession(session.sessionID, false); err != nil {
+	session := val.(*ClientSession)
+	if err := a.RemoveClientSession(session.sessionID); err != nil {
 		return fmt.Errorf("failed to remove session: %w", err)
 	}
 	return nil
@@ -296,10 +303,11 @@ func (a *Agent) handleShellData(agentMsg messaging.AgentMessage, raw []byte) err
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal shell data message: %w", err)
 	}
-	session, ok := a.shellSessions[shellData.ID()]
+	val, ok := a.shellSessions.Load(shellData.ID())
 	if !ok {
 		return nil
 	}
+	session := val.(*ClientSession)
 	if err := session.Write(raw); err != nil {
 		return fmt.Errorf("failed to write message: %w", err)
 	}

--- a/workers/websocket/agent/shell.go
+++ b/workers/websocket/agent/shell.go
@@ -149,13 +149,29 @@ func (c *ClientSession) clientReader() {
 		}
 
 		switch agentMsg.Type {
-		case messaging.MessageTypeClientShellClosed, messaging.MessageTypeShellData,
-			messaging.MessageTypeShellResize:
+		case messaging.MessageTypeClientShellClosed:
+			_, err = messaging.Unmarshal[messaging.ClientShellClosedMessage](agentMsg)
+			if err != nil {
+				slog.ErrorContext(c.ctx, "invalid client shell closed message", "error", err)
+				return
+			}
+		case messaging.MessageTypeShellData:
+			_, err = messaging.Unmarshal[messaging.ShellDataMessage](agentMsg)
+			if err != nil {
+				slog.ErrorContext(c.ctx, "invalid client shell data message", "error", err)
+				return
+			}
+		case messaging.MessageTypeShellResize:
+			_, err = messaging.Unmarshal[messaging.ShellResizeMessage](agentMsg)
+			if err != nil {
+				slog.ErrorContext(c.ctx, "invalid client shell resize message", "error", err)
+				return
+			}
 		default:
 			slog.ErrorContext(c.ctx, "invalid message type received from client", "message_type", agentMsg.Type)
 			return
 		}
-		if !bytes.Equal(agentMsg.Data[:16], c.sessionID[:]) {
+		if len(agentMsg.Data) < 16 || !bytes.Equal(agentMsg.Data[:16], c.sessionID[:]) {
 			slog.ErrorContext(c.ctx, "invalid session ID")
 			return
 		}


### PR DESCRIPTION
Use sync.Map for Agent{} shellSessions. This simplifies logic around mutating that map and makes sure we don't accidentally forget to lock a mutex before mutating the map. This seems to be the case in at least one function where the agent sends a payload back to the server.

There is also an aditional potential panic fixed in shell.go where we try to read the session ID by slicing the data array up to byte 16. This can lead to a panic as we try to read past the bounds of the array, crashing the garm daemon.