### PR TITLE
Allow the GARM agent to connect to GARM insecurely

### DIFF
--- a/cmd/garm-cli/cmd/controller.go
+++ b/cmd/garm-cli/cmd/controller.go
@@ -163,6 +163,9 @@ available upstream can be listed with "garm-cli controller tools list --online".
 		if cmd.Flags().Changed("enable-tools-sync") {
 			params.SyncGARMAgentTools = &enableToolsSync
 		}
+		if cmd.Flags().Changed("allow-insecure-agent") {
+			params.AllowInsecureGARMAgent = &allowInsecureAgent
+		}
 		if cmd.Flags().Changed("clear-ca-bundle") {
 			params.ClearCACertBundle = &clearCABundle
 		}
@@ -642,6 +645,7 @@ func renderControllerInfoTable(info params.ControllerInfo) string {
 		agentVersion = params.GARMAgentLatestVersion
 	}
 	t.AppendRow(table.Row{"GARM agent version", agentVersion})
+	t.AppendRow(table.Row{"Allow insecure agent", info.AllowInsecureGARMAgent})
 	t.AppendRow(table.Row{"Minimum Job Age Backoff", info.MinimumJobAgeBackoff})
 	t.AppendRow(table.Row{"Version", serverVersion})
 	if len(info.CACertBundle) > 0 {
@@ -667,6 +671,7 @@ func init() {
 	controllerUpdateCmd.Flags().StringVarP(&garmToolsReleasesURL, "garm-tools-url", "t", "", "The URL for the garm-agent releases page (ie. https://api.github.com/repos/cloudbase/garm-agent/releases)")
 	controllerUpdateCmd.Flags().StringVar(&garmAgentVersion, "garm-agent-version", "", "Pin the GARM agent version to use (a semver version like v0.1.0). Use \"latest\" to track the newest release.")
 	controllerUpdateCmd.Flags().BoolVarP(&enableToolsSync, "enable-tools-sync", "s", false, "Enable or disable automatic garm tools sync.")
+	controllerUpdateCmd.Flags().BoolVar(&allowInsecureAgent, "allow-insecure-agent", false, "Configure deployed garm-agents to connect to GARM over plain http/ws (force_insecure). The agent token is sent in plain text; meant for local development and testing only.")
 	controllerUpdateCmd.Flags().UintVarP(&minimumJobAgeBackoff, "minimum-job-age-backoff", "b", 0, "The minimum job age backoff for the controller")
 	controllerUpdateCmd.Flags().StringVar(&controllerCABundle, "ca-bundle", "", "A CA bundle that will be used by GARM and the runners to validate HTTPS connections.")
 	controllerUpdateCmd.Flags().BoolVar(&clearCABundle, "clear-ca-bundle", false, "Remove the currently configured CA bundle from the controller.")

--- a/cmd/garm-cli/cmd/init.go
+++ b/cmd/garm-cli/cmd/init.go
@@ -39,6 +39,7 @@ var (
 	garmToolsReleasesURL string
 	garmAgentVersion     string
 	enableToolsSync      bool
+	allowInsecureAgent   bool
 	minimumJobAgeBackoff uint
 	controllerCABundle   string
 	clearCABundle        bool

--- a/database/sql/controller.go
+++ b/database/sql/controller.go
@@ -78,6 +78,7 @@ func dbControllerToCommonController(dbInfo ControllerInfo) (params.ControllerInf
 		GARMAgentReleasesURL:            dbInfo.GARMAgentReleasesURL,
 		SyncGARMAgentTools:              dbInfo.SyncGARMAgentTools,
 		GARMAgentVersion:                dbInfo.GARMAgentVersion,
+		AllowInsecureGARMAgent:          dbInfo.AllowInsecureGARMAgent,
 		CachedGARMAgentReleaseFetchedAt: dbInfo.CachedGARMAgentReleaseFetchedAt,
 		CachedGARMAgentReleases:         dbInfo.CachedGARMAgentReleases,
 		CACertBundle:                    dbInfo.CACertBundle,
@@ -215,6 +216,10 @@ func controllerUpdates(info params.UpdateControllerParams, dbInfo ControllerInfo
 		if agentVersion != dbInfo.GARMAgentVersion {
 			updates["garm_agent_version"] = agentVersion
 		}
+	}
+
+	if info.AllowInsecureGARMAgent != nil && *info.AllowInsecureGARMAgent != dbInfo.AllowInsecureGARMAgent {
+		updates["allow_insecure_garm_agent"] = *info.AllowInsecureGARMAgent
 	}
 
 	if info.MinimumJobAgeBackoff != nil && *info.MinimumJobAgeBackoff != dbInfo.MinimumJobAgeBackoff {

--- a/database/sql/controller_test.go
+++ b/database/sql/controller_test.go
@@ -113,6 +113,36 @@ func (s *CtrlTestSuite) TestUpdateControllerGARMAgentVersion() {
 	s.Require().Equal("v2.0.0", info.GARMAgentVersion)
 }
 
+func (s *CtrlTestSuite) TestUpdateControllerAllowInsecureGARMAgent() {
+	_, err := s.Store.InitController()
+	s.Require().NoError(err)
+
+	// The flag defaults to off.
+	info, err := s.Store.ControllerInfo()
+	s.Require().NoError(err)
+	s.Require().False(info.AllowInsecureGARMAgent)
+
+	// Enabling it persists and round-trips through ControllerInfo.
+	allow := true
+	info, err = s.Store.UpdateController(params.UpdateControllerParams{AllowInsecureGARMAgent: &allow})
+	s.Require().NoError(err)
+	s.Require().True(info.AllowInsecureGARMAgent)
+	info, err = s.Store.ControllerInfo()
+	s.Require().NoError(err)
+	s.Require().True(info.AllowInsecureGARMAgent)
+
+	// A nil pointer leaves the stored value untouched.
+	info, err = s.Store.UpdateController(params.UpdateControllerParams{})
+	s.Require().NoError(err)
+	s.Require().True(info.AllowInsecureGARMAgent)
+
+	// It can be turned off again.
+	allow = false
+	info, err = s.Store.UpdateController(params.UpdateControllerParams{AllowInsecureGARMAgent: &allow})
+	s.Require().NoError(err)
+	s.Require().False(info.AllowInsecureGARMAgent)
+}
+
 func (s *CtrlTestSuite) TestControllerInfoResolvesCachedTools() {
 	_, err := s.Store.InitController()
 	s.Require().NoError(err)

--- a/database/sql/migrations/0005_allow_insecure_garm_agent.go
+++ b/database/sql/migrations/0005_allow_insecure_garm_agent.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package migrations
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// controllerInfo0005 is a minimal stub that only declares the new column:
+// whether deployed garm-agents are configured to connect to GARM over
+// plain http/ws (the agent's force_insecure setting).
+
+type controllerInfo0005 struct {
+	AllowInsecureGARMAgent bool
+}
+
+func (controllerInfo0005) TableName() string { return "controller_infos" }
+
+func init() {
+	Register(&gormigrate.Migration{
+		ID: "0005_allow_insecure_garm_agent",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&controllerInfo0005{})
+		},
+	})
+}

--- a/database/sql/models.go
+++ b/database/sql/models.go
@@ -81,6 +81,9 @@ type ControllerInfo struct {
 	CachedGARMAgentReleases datatypes.JSON
 	// CachedGARMAgentReleaseFetchedAt is the timestamp when the release index was last fetched
 	CachedGARMAgentReleaseFetchedAt *time.Time
+	// AllowInsecureGARMAgent tells GARM to configure the garm-agent (when used) to connect
+	// to the GARM API even when not using TLS.
+	AllowInsecureGARMAgent bool
 
 	// CACertBundle holds a certificate bundle meant to validate the certificate
 	// used by GARM itself. This can be just the root certificate that can validate

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -40,6 +40,9 @@ type InstallContext struct {
 	AgentURL         string
 	AgentToken       string
 	AgentShell       string // "true" or "false", used verbatim in TOML config
+	// ForceInsecureGARMAgent allows the agent to connect back to GARM even when
+	// TLS is not enabled in GARM itself.
+	ForceInsecureGARMAgent bool
 }
 
 func GetTemplateContent(osType commonParams.OSType, forge params.EndpointType) ([]byte, error) {

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package templates
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	commonParams "github.com/cloudbase/garm-provider-common/params"
+	"github.com/cloudbase/garm/params"
+)
+
+// TestInstallTemplatesRenderForceInsecure renders every default install
+// template and checks that the agent config only carries force_insecure when
+// the controller allows insecure agent connections. Agents older than v0.1.1
+// do not know the setting, so it must be absent unless explicitly enabled.
+func TestInstallTemplatesRenderForceInsecure(t *testing.T) {
+	for _, forge := range []params.EndpointType{params.GithubEndpointType, params.GiteaEndpointType} {
+		for _, osType := range []commonParams.OSType{commonParams.Linux, commonParams.Windows} {
+			t.Run(fmt.Sprintf("%s_%s", forge, osType), func(t *testing.T) {
+				content, err := GetTemplateContent(osType, forge)
+				if err != nil {
+					t.Fatalf("failed to get template content: %v", err)
+				}
+
+				tplCtx := InstallContext{
+					AgentMode:  true,
+					AgentURL:   "wss://garm.example.com/agent",
+					AgentToken: "secret",
+					AgentShell: "false",
+				}
+
+				rendered, err := RenderRunnerInstallScript(string(content), tplCtx)
+				if err != nil {
+					t.Fatalf("failed to render template: %v", err)
+				}
+				if strings.Contains(string(rendered), "force_insecure") {
+					t.Error("expected force_insecure to be absent when not allowed")
+				}
+
+				tplCtx.ForceInsecureGARMAgent = true
+				rendered, err = RenderRunnerInstallScript(string(content), tplCtx)
+				if err != nil {
+					t.Fatalf("failed to render template: %v", err)
+				}
+				if !strings.Contains(string(rendered), "force_insecure = true") {
+					t.Error("expected force_insecure = true in the agent config")
+				}
+				// The neighboring config keys must survive the conditional.
+				if !strings.Contains(string(rendered), "enable_shell = ") {
+					t.Error("expected enable_shell to remain in the agent config")
+				}
+			})
+		}
+	}
+}

--- a/internal/templates/userdata/gitea_linux_userdata.tmpl
+++ b/internal/templates/userdata/gitea_linux_userdata.tmpl
@@ -86,6 +86,9 @@ server_url = "$AGENT_URL"
 log_file = "/var/log/garm-agent/garm-agent.log"
 work_dir = "$RUN_HOME"
 enable_shell = $AGENT_SHELL
+{{- if .ForceInsecureGARMAgent }}
+force_insecure = true
+{{- end }}
 token = "$AGENT_TOKEN"
 runner_cmdline = ["$RUN_HOME/gitea-runner", "daemon", "--once"]
 state_db_path = "/etc/garm-agent/agent-state.db"

--- a/internal/templates/userdata/gitea_windows_userdata.tmpl
+++ b/internal/templates/userdata/gitea_windows_userdata.tmpl
@@ -430,6 +430,9 @@ server_url = "$agentURL"
 log_file = "C:/garm-agent/garm-agent.log"
 shell = "cmd.exe"
 enable_shell = $shellEnabled
+{{- if .ForceInsecureGARMAgent }}
+force_insecure = true
+{{- end }}
 work_dir = "C:/actions-runner/"
 token = "$agentToken"
 runner_cmdline = ["$runnerExecutable", "daemon", "--once"]

--- a/internal/templates/userdata/github_linux_userdata.tmpl
+++ b/internal/templates/userdata/github_linux_userdata.tmpl
@@ -95,6 +95,9 @@ server_url = "$AGENT_URL"
 log_file = "/var/log/garm-agent/garm-agent.log"
 work_dir = "$RUN_HOME"
 enable_shell = $AGENT_SHELL
+{{- if .ForceInsecureGARMAgent }}
+force_insecure = true
+{{- end }}
 token = "$AGENT_TOKEN"
 runner_cmdline = ["/bin/bash", "-C", "/home/runner/actions-runner/run.sh"]
 state_db_path = "/etc/garm-agent/agent-state.db"

--- a/internal/templates/userdata/github_windows_userdata.tmpl
+++ b/internal/templates/userdata/github_windows_userdata.tmpl
@@ -426,6 +426,9 @@ server_url = "$agentURL"
 log_file = "C:/garm-agent/garm-agent.log"
 shell = "cmd.exe"
 enable_shell = $shellEnabled
+{{- if .ForceInsecureGARMAgent }}
+force_insecure = true
+{{- end }}
 work_dir = "C:/actions-runner/"
 token = "$agentToken"
 runner_cmdline = ["C:\\Windows\\system32\\cmd.exe", "/C", "C:\\actions-runner\\run.cmd"]

--- a/params/params.go
+++ b/params/params.go
@@ -1152,6 +1152,11 @@ type ControllerInfo struct {
 	// SyncGARMAgentTools is enabled) downloaded, for operators who want to
 	// stick with a known good agent version.
 	GARMAgentVersion string `json:"garm_agent_version"`
+	// AllowInsecureGARMAgent configures deployed garm-agents with
+	// force_insecure enabled, permitting them to connect back to GARM over
+	// plain http/ws when GARM itself does not use TLS. The agent token is
+	// sent in plain text; meant for local development and testing only.
+	AllowInsecureGARMAgent bool `json:"allow_insecure_garm_agent"`
 	// MinimumJobAgeBackoff is the minimum time in seconds that a job must be in queued state
 	// before GARM will attempt to allocate a runner for it. When set to a non zero value,
 	// GARM will ignore the job until the job's age is greater than this value. When using

--- a/params/requests.go
+++ b/params/requests.go
@@ -593,8 +593,12 @@ type UpdateControllerParams struct {
 	// GARMAgentVersion pins the garm-agent version the controller uses. An
 	// empty string or "latest" tracks the newest release at
 	// GARMAgentReleasesURL; any other value must be a valid semver version.
-	GARMAgentVersion     *string `json:"garm_agent_version,omitempty"`
-	MinimumJobAgeBackoff *uint   `json:"minimum_job_age_backoff,omitempty"`
+	GARMAgentVersion *string `json:"garm_agent_version,omitempty"`
+	// AllowInsecureGARMAgent configures deployed garm-agents to connect to
+	// GARM over plain http/ws (the agent's force_insecure setting). Meant
+	// for local development and testing only.
+	AllowInsecureGARMAgent *bool `json:"allow_insecure_garm_agent,omitempty"`
+	MinimumJobAgeBackoff   *uint `json:"minimum_job_age_backoff,omitempty"`
 	// swagger:strfmt byte
 	CACertBundle      []byte `json:"ca_cert_bundle,omitempty"`
 	ClearCACertBundle *bool  `json:"clear_ca_cert_bundle,omitempty"`

--- a/runner/metadata.go
+++ b/runner/metadata.go
@@ -445,8 +445,10 @@ func (r *Runner) GetRunnerInstallScript(ctx context.Context) ([]byte, error) {
 				return nil, fmt.Errorf("failed to get agent token: %w", err)
 			}
 			tplCtx.AgentToken = agentToken
-			tplCtx.AgentURL = cache.ControllerInfo().AgentURL
+			controllerInfo := cache.ControllerInfo()
+			tplCtx.AgentURL = controllerInfo.AgentURL
 			tplCtx.AgentShell = fmt.Sprintf("%t", enableShell)
+			tplCtx.ForceInsecureGARMAgent = controllerInfo.AllowInsecureGARMAgent
 		} else {
 			slog.WarnContext(ctx, "agent mode enabled but no tools available",
 				"runner_name", instance.Name)

--- a/webapp/src/lib/api/generated/api.ts
+++ b/webapp/src/lib/api/generated/api.ts
@@ -87,6 +87,12 @@ export interface ControllerInfo {
      */
     'agent_url'?: string;
     /**
+     * AllowInsecureGARMAgent configures deployed garm-agents with force_insecure enabled, permitting them to connect back to GARM over plain http/ws when GARM itself does not use TLS. The agent token is sent in plain text; meant for local development and testing only.
+     * @type {boolean}
+     * @memberof ControllerInfo
+     */
+    'allow_insecure_garm_agent'?: boolean;
+    /**
      * CACertBundle holds a certificate bundle meant to validate the certificate used by GARM itself. This can be just the root certificate that can validate the GARM TLS certificate, a chain or multiple root CAs.
      * @type {string}
      * @memberof ControllerInfo
@@ -3198,6 +3204,12 @@ export interface UpdateControllerParams {
      * @memberof UpdateControllerParams
      */
     'agent_url'?: string;
+    /**
+     * AllowInsecureGARMAgent configures deployed garm-agents to connect to GARM over plain http/ws (the agent\'s force_insecure setting). Meant for local development and testing only.
+     * @type {boolean}
+     * @memberof UpdateControllerParams
+     */
+    'allow_insecure_garm_agent'?: boolean;
     /**
      * 
      * @type {string}

--- a/webapp/src/lib/components/ControllerInfoCard.svelte
+++ b/webapp/src/lib/components/ControllerInfoCard.svelte
@@ -44,6 +44,7 @@
 	let minimumJobAgeBackoff: number | null = null;
 	let garmAgentReleasesUrl = '';
 	let syncGarmAgentTools = false;
+	let allowInsecureAgent = false;
 	let caCertBundleBytes: number[] | null = null;
 	let caCertBundleFileName = '';
 	let clearCaCertBundle = false;
@@ -146,6 +147,7 @@
 		minimumJobAgeBackoff = controllerInfo.minimum_job_age_backoff || null;
 		garmAgentReleasesUrl = controllerInfo.garm_agent_releases_url || '';
 		syncGarmAgentTools = controllerInfo.enable_agent_tools_sync ?? false;
+		allowInsecureAgent = controllerInfo.allow_insecure_garm_agent ?? false;
 		caCertBundleBytes = null;
 		caCertBundleFileName = '';
 		clearCaCertBundle = false;
@@ -189,6 +191,7 @@
 			updateParams.garm_agent_version = effectiveAgentVersion;
 			// Always send the boolean value
 			updateParams.enable_agent_tools_sync = syncGarmAgentTools;
+			updateParams.allow_insecure_garm_agent = allowInsecureAgent;
 
 			if (clearCaCertBundle) {
 				updateParams.clear_ca_cert_bundle = true;
@@ -229,6 +232,7 @@
 		minimumJobAgeBackoff = null;
 		garmAgentReleasesUrl = '';
 		syncGarmAgentTools = false;
+		allowInsecureAgent = false;
 		caCertBundleBytes = null;
 		caCertBundleFileName = '';
 		clearCaCertBundle = false;
@@ -367,6 +371,30 @@
 								{#if controllerInfo.enable_agent_tools_sync}
 									<span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
 										Enabled
+									</span>
+								{:else}
+									<span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+										Disabled
+									</span>
+								{/if}
+							</div>
+						</div>
+
+						<!-- Insecure Agent Connections -->
+						<div>
+							<div class="flex items-center">
+								<div class="text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wide font-medium">Insecure Agent Connections</div>
+								<div class="ml-2">
+									<Tooltip
+										title="Insecure Agent Connections"
+										content="When allowed, deployed garm-agents are configured with force_insecure and may connect to GARM over plain http/ws. The agent token is sent in plain text. Meant for local development and testing only."
+									/>
+								</div>
+							</div>
+							<div class="mt-1 p-2 bg-gray-50 dark:bg-gray-700 rounded text-sm font-mono text-gray-600 dark:text-gray-300 min-h-[38px] flex items-center">
+								{#if controllerInfo.allow_insecure_garm_agent}
+									<span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+										Allowed
 									</span>
 								{:else}
 									<span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
@@ -774,6 +802,25 @@
 					</label>
 					<p class="mt-1 text-xs text-gray-500 dark:text-gray-400 ml-6">
 						Automatically synchronize garm-agent tools from the configured releases URL
+					</p>
+				</div>
+
+				<!-- Allow Insecure Agent Connections -->
+				<div>
+					<label class="flex items-center cursor-pointer">
+						<input
+							id="allowInsecureAgent"
+							type="checkbox"
+							bind:checked={allowInsecureAgent}
+							class="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded cursor-pointer"
+						/>
+						<span class="ml-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+							Allow Insecure Agent Connections
+						</span>
+					</label>
+					<p class="mt-1 text-xs text-amber-600 dark:text-amber-400 ml-6">
+						Configures deployed garm-agents to connect over plain http/ws (force_insecure). The
+						agent token is sent in plain text — meant for local development and testing only.
 					</p>
 				</div>
 

--- a/webapp/src/routes/page.integration.test.ts
+++ b/webapp/src/routes/page.integration.test.ts
@@ -482,6 +482,36 @@ describe('Dashboard Page Integration Tests', () => {
 			});
 		});
 
+		it('should send the insecure agent toggle when saving settings', async () => {
+			const { garmApi } = await import('$lib/api/client.js');
+			(garmApi.updateController as any).mockResolvedValueOnce({
+				...mockControllerInfo,
+				allow_insecure_garm_agent: true
+			});
+			render(DashboardPage);
+
+			await waitFor(() => {
+				expect(screen.getByText('Settings')).toBeInTheDocument();
+			});
+			await fireEvent.click(screen.getByText('Settings'));
+
+			const checkbox = await waitFor(() => {
+				const el = document.getElementById('allowInsecureAgent') as HTMLInputElement;
+				expect(el).toBeInTheDocument();
+				return el;
+			});
+			expect(checkbox.checked).toBe(false);
+			await fireEvent.click(checkbox);
+
+			await fireEvent.click(screen.getByText('Save Changes'));
+
+			await waitFor(() => {
+				expect(garmApi.updateController).toHaveBeenCalledWith(
+					expect.objectContaining({ allow_insecure_garm_agent: true })
+				);
+			});
+		});
+
 		it('should show the release notes of the selected version', async () => {
 			render(DashboardPage);
 

--- a/webapp/swagger.yaml
+++ b/webapp/swagger.yaml
@@ -39,6 +39,14 @@ definitions:
                     URL must be configured to allow websocket connections.
                 type: string
                 x-go-name: AgentURL
+            allow_insecure_garm_agent:
+                description: |-
+                    AllowInsecureGARMAgent configures deployed garm-agents with
+                    force_insecure enabled, permitting them to connect back to GARM over
+                    plain http/ws when GARM itself does not use TLS. The agent token is
+                    sent in plain text; meant for local development and testing only.
+                type: boolean
+                x-go-name: AllowInsecureGARMAgent
             ca_cert_bundle:
                 description: |-
                     CACertBundle holds a certificate bundle meant to validate the certificate
@@ -2087,6 +2095,13 @@ definitions:
             agent_url:
                 type: string
                 x-go-name: AgentURL
+            allow_insecure_garm_agent:
+                description: |-
+                    AllowInsecureGARMAgent configures deployed garm-agents to connect to
+                    GARM over plain http/ws (the agent's force_insecure setting). Meant
+                    for local development and testing only.
+                type: boolean
+                x-go-name: AllowInsecureGARMAgent
             ca_cert_bundle:
                 format: byte
                 type: string


### PR DESCRIPTION
This is mostly for testing and as a temporary stopgap for environments that need time to transition GARM to TLS.

The change surfaces the force_insecure option added in the garm-agent v0.1.1.