### PR TITLE
scaleset: reap timed-out runners stuck in failed status

### DIFF
--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -395,8 +395,8 @@ func (w *Worker) reapTimedOutRunners(runners map[string]params.RunnerReference) 
 			continue
 		}
 
-		if runner.RunnerStatus != params.RunnerPending && runner.RunnerStatus != params.RunnerInstalling {
-			slog.DebugContext(w.ctx, "runner is not pending or installing; skipping", "runner_name", runner.Name)
+		if runner.RunnerStatus != params.RunnerPending && runner.RunnerStatus != params.RunnerInstalling && runner.RunnerStatus != params.RunnerFailed {
+			slog.DebugContext(w.ctx, "runner is not pending, installing or failed; skipping", "runner_name", runner.Name)
 			continue
 		}
 		if ghRunner, ok := runners[runner.Name]; !ok || ghRunner.GetStatus() == params.RunnerOffline {


### PR DESCRIPTION
`reapTimedOutRunners` only considered runners in `pending`/`installing` `RunnerStatus` as eligible for reaping. A runner whose agent reports a failure (`RunnerStatus` set to `failed` via `AddInstanceStatusMessage`) was never `pending`/`installing` again, and would never register as idle/active in GitHub either, so it was permanently excluded from this check and leaked forever (the instance never transitioned to `pending_delete`).

This change allows `RunnerFailed` through the same eligibility check. Downstream logic still requires the runner be missing from GitHub or reported offline there before reaping, unchanged.