### PR TITLE
scaleset: allow updating disable_update on existing scale sets

### DIFF
--- a/database/sql/scalesets.go
+++ b/database/sql/scalesets.go
@@ -360,6 +360,10 @@ func (s *sqlDatabase) updateScaleSet(tx *gorm.DB, scaleSet ScaleSet, param param
 		updates["name"] = param.Name
 	}
 
+	if param.DisableUpdate != nil && *param.DisableUpdate != scaleSet.DisableUpdate {
+		updates["disable_update"] = *param.DisableUpdate
+	}
+
 	if param.GitHubRunnerGroup != nil && *param.GitHubRunnerGroup != "" && *param.GitHubRunnerGroup != scaleSet.GitHubRunnerGroup {
 		updates["git_hub_runner_group"] = *param.GitHubRunnerGroup
 		incrementGeneration = true

--- a/params/requests.go
+++ b/params/requests.go
@@ -738,6 +738,7 @@ type UpdateScaleSetParams struct {
 	RunnerPrefix
 
 	Name                   string              `json:"name,omitempty"`
+	DisableUpdate          *bool               `json:"disable_update,omitempty"`
 	Enabled                *bool               `json:"enabled,omitempty"`
 	MaxRunners             *uint               `json:"max_runners,omitempty"`
 	MinIdleRunners         *uint               `json:"min_idle_runners,omitempty"`

--- a/webapp/swagger.yaml
+++ b/webapp/swagger.yaml
@@ -2454,6 +2454,9 @@ definitions:
         x-go-package: github.com/cloudbase/garm/params
     UpdateScaleSetParams:
         properties:
+            disable_update:
+                type: boolean
+                x-go-name: DisableUpdate
             enable_shell:
                 type: boolean
                 x-go-name: EnableShell


### PR DESCRIPTION
`DisableUpdate` could only be set when a scale set was created. The update path in the runner layer already propagates a changed `DisableUpdate` to GitHub via `UpdateRunnerScaleSet` — only the API param and the DB update mapping were missing, so there was no way to actually trigger it.

This adds `disable_update` to `UpdateScaleSetParams` and maps it in the DB update path, allowing runner self-updates to be toggled on existing scale sets without recreating them.