### PR TITLE
Retry failed gitea tools updates

### DIFF
--- a/workers/cache/tool_cache.go
+++ b/workers/cache/tool_cache.go
@@ -224,7 +224,7 @@ reset:
 			return
 		case <-ticker.C:
 			now := time.Now().UTC()
-			if !now.After(t.lastUpdate.Add(time.Duration(giteaToolsUpdateDeadline)*time.Minute)) || oldMetadataURL != metadataURL || oldUseInternal != useInternal {
+			if !now.After(t.lastUpdate.Add(time.Duration(giteaToolsUpdateDeadline)*time.Minute)) && oldMetadataURL == metadataURL && oldUseInternal == useInternal {
 				continue
 			}
 			ep, ok := cache.GetEndpoint(t.entity.Credentials.Endpoint.Name)


### PR DESCRIPTION
The giteaUpdateLoop skipped the update whenever metadataURL or useInternal differed from the last successful update, even if giteaToolsUpdateDeadline passed. When the initial fetch failed, this resulted in the tools never being fetched, as oldMetadataURL/oldUseInternal are only assigned after the first successful fetch.

The condition missed a proper application of De Morgan's law. The condition is right further up in the function where it isn't negated. The intended logic is "fetch when stale OR the URL changed OR the internal flag flipped".