### PR TITLE
Bug and stability fixes

### DIFF
--- a/database/watcher/consumer.go
+++ b/database/watcher/consumer.go
@@ -18,15 +18,28 @@ import (
 	"context"
 	"log/slog"
 	"sync"
-	"time"
 
 	"github.com/cloudbase/garm/database/common"
 )
 
+// queueWarnThreshold is the consumer queue depth at which we start warning
+// that a consumer is not keeping up. Events are never dropped. The queue
+// grows until the consumer drains it, so sustained growth indicates a wedged
+// consumer and deserves a loud signal.
+const queueWarnThreshold = 1024
+
 type consumer struct {
+	// messages is the channel returned by Watch(). It is fed exclusively by
+	// the dispatch goroutine, which also closes it on exit.
 	messages chan common.ChangePayload
-	filters  []common.PayloadFilterFunc
-	id       string
+	// in hands accepted payloads from Send to the dispatch goroutine. It is
+	// buffered so the producer completes with a plain copy in the common
+	// case, without waiting for the dispatch goroutine to be scheduled. The
+	// dispatch loop drains it into an unbounded queue, so a full buffer only
+	// ever means a brief wait for the dispatcher and never a drop.
+	in      chan common.ChangePayload
+	filters []common.PayloadFilterFunc
+	id      string
 
 	mux    sync.Mutex
 	closed bool
@@ -50,9 +63,10 @@ func (w *consumer) Close() {
 	if w.closed {
 		return
 	}
-	close(w.messages)
-	close(w.quit)
 	w.closed = true
+	// The dispatch goroutine closes w.messages on its way out. Closing it
+	// here would race a concurrent dispatch send.
+	close(w.quit)
 }
 
 func (w *consumer) IsClosed() bool {
@@ -61,38 +75,68 @@ func (w *consumer) IsClosed() bool {
 	return w.closed
 }
 
+// Send delivers a payload to this consumer. Delivery is in call order, never
+// blocks beyond a goroutine handoff and never drops. The payload is either
+// filtered out, accepted into the dispatch queue, or the consumer is closed.
 func (w *consumer) Send(payload common.ChangePayload) {
 	w.mux.Lock()
-	defer w.mux.Unlock()
-
 	if w.closed {
+		w.mux.Unlock()
 		return
 	}
+	filters := w.filters
+	w.mux.Unlock()
 
-	if len(w.filters) > 0 {
-		shouldSend := true
-		for _, filter := range w.filters {
+	if len(filters) > 0 {
+		for _, filter := range filters {
 			if !filter(payload) {
-				shouldSend = false
-				break
+				return
 			}
-		}
-
-		if !shouldSend {
-			return
 		}
 	}
 
-	timer := time.NewTimer(1 * time.Second)
-	defer timer.Stop()
-	slog.DebugContext(w.ctx, "sending payload")
 	select {
+	case w.in <- payload:
 	case <-w.quit:
-		slog.DebugContext(w.ctx, "consumer is closed")
 	case <-w.ctx.Done():
-		slog.DebugContext(w.ctx, "consumer is closed")
-	case <-timer.C:
-		slog.DebugContext(w.ctx, "timeout trying to send payload", "payload", payload)
-	case w.messages <- payload:
+	}
+}
+
+// dispatch owns delivery to the messages channel. It accepts payloads from
+// Send into an in-memory FIFO queue and feeds them to messages one at a
+// time, so a slow consumer only grows its own queue and can never block a
+// producer or another consumer. It closes messages on exit.
+func (w *consumer) dispatch() {
+	defer close(w.messages)
+
+	var queue []common.ChangePayload
+	for {
+		if len(queue) == 0 {
+			select {
+			case payload := <-w.in:
+				queue = append(queue, payload)
+			case <-w.quit:
+				return
+			case <-w.ctx.Done():
+				return
+			}
+			continue
+		}
+
+		select {
+		case payload := <-w.in:
+			queue = append(queue, payload)
+			if len(queue)%queueWarnThreshold == 0 {
+				slog.WarnContext(
+					w.ctx, "consumer is not keeping up with events",
+					"consumer_id", w.id, "queue_depth", len(queue))
+			}
+		case w.messages <- queue[0]:
+			queue = queue[1:]
+		case <-w.quit:
+			return
+		case <-w.ctx.Done():
+			return
+		}
 	}
 }

--- a/database/watcher/watcher.go
+++ b/database/watcher/watcher.go
@@ -85,7 +85,7 @@ func (w *watcher) RegisterProducer(ctx context.Context, id string) (common.Produ
 		return nil, fmt.Errorf("producer_id %s: %w", id, common.ErrProducerAlreadyRegistered)
 	}
 	p := &producer{
-		id:       id,
+		id: id,
 		// Buffer writes so a burst of DB updates doesn't trip Notify()'s
 		// 1 second timeout while serviceProducer waits on consumers to
 		// accept the previous event.
@@ -121,6 +121,10 @@ func (w *watcher) serviceProducer(prod *producer) {
 			slog.InfoContext(w.ctx, "closing producer")
 			return
 		case payload := <-prod.messages:
+			// Send each message in parallel to all consumers. Worst case,
+			// if any future implementation of the consumer will add a timeout,
+			// we will only ever wait for the amount of time of the timeout for
+			// all consumers, regardless of how many.
 			w.mux.Lock()
 			wg := sync.WaitGroup{}
 			for _, c := range w.consumers {
@@ -128,8 +132,8 @@ func (w *watcher) serviceProducer(prod *producer) {
 					c.Send(payload)
 				})
 			}
-			w.mux.Unlock()
 			wg.Wait()
+			w.mux.Unlock()
 		}
 	}
 }
@@ -141,18 +145,17 @@ func (w *watcher) RegisterConsumer(ctx context.Context, id string, filters ...co
 		return nil, common.ErrConsumerAlreadyRegistered
 	}
 	c := &consumer{
-		// Buffer enough events to ride out a consumer that is momentarily
-		// busy. Send() drops the payload after a 1 second timeout, so an
-		// unbuffered channel turns any processing hiccup into a lost event;
-		// with a buffer, a consumer must fall this many events behind and
-		// stay blocked for a full second before anything is dropped.
+		// Buffering the channels here helps with latency. The current
+		// implementation is non blocking.
 		messages: make(chan common.ChangePayload, 128),
+		in:       make(chan common.ChangePayload, 128),
 		filters:  filters,
 		quit:     make(chan struct{}),
 		id:       id,
 		ctx:      ctx,
 	}
 	w.consumers[id] = c
+	go c.dispatch()
 	go w.serviceConsumer(c)
 	return c, nil
 }

--- a/database/watcher/watcher.go
+++ b/database/watcher/watcher.go
@@ -119,10 +119,14 @@ func (w *watcher) serviceProducer(prod *producer) {
 			return
 		case payload := <-prod.messages:
 			w.mux.Lock()
+			wg := sync.WaitGroup{}
 			for _, c := range w.consumers {
-				go c.Send(payload)
+				wg.Go(func() {
+					c.Send(payload)
+				})
 			}
 			w.mux.Unlock()
+			wg.Wait()
 		}
 	}
 }

--- a/database/watcher/watcher.go
+++ b/database/watcher/watcher.go
@@ -86,7 +86,10 @@ func (w *watcher) RegisterProducer(ctx context.Context, id string) (common.Produ
 	}
 	p := &producer{
 		id:       id,
-		messages: make(chan common.ChangePayload, 1),
+		// Buffer writes so a burst of DB updates doesn't trip Notify()'s
+		// 1 second timeout while serviceProducer waits on consumers to
+		// accept the previous event.
+		messages: make(chan common.ChangePayload, 128),
 		quit:     make(chan struct{}),
 		ctx:      ctx,
 	}
@@ -138,7 +141,12 @@ func (w *watcher) RegisterConsumer(ctx context.Context, id string, filters ...co
 		return nil, common.ErrConsumerAlreadyRegistered
 	}
 	c := &consumer{
-		messages: make(chan common.ChangePayload, 1),
+		// Buffer enough events to ride out a consumer that is momentarily
+		// busy. Send() drops the payload after a 1 second timeout, so an
+		// unbuffered channel turns any processing hiccup into a lost event;
+		// with a buffer, a consumer must fall this many events behind and
+		// stay blocked for a full second before anything is dropped.
+		messages: make(chan common.ChangePayload, 128),
 		filters:  filters,
 		quit:     make(chan struct{}),
 		id:       id,

--- a/database/watcher/watcher_test.go
+++ b/database/watcher/watcher_test.go
@@ -1459,6 +1459,70 @@ func (s *WatcherTestSuite) TestWithInstanceStatusFilter() {
 	s.Require().Equal(payload, *receivedPayload)
 }
 
+func (s *WatcherTestSuite) TestBlockedConsumerDoesNotBlockWatcher() {
+	producer, err := watcher.RegisterProducer(s.ctx, "test-producer")
+	s.Require().NoError(err)
+	s.Require().NotNil(producer)
+
+	// This consumer is deliberately wedged: nothing reads from its Watch()
+	// channel until the flood below is over.
+	blocked, err := watcher.RegisterConsumer(
+		s.ctx, "test-blocked-consumer",
+		watcher.WithEntityTypeFilter(common.ControllerEntityType),
+		watcher.WithOperationTypeFilter(common.UpdateOperation))
+	s.Require().NoError(err)
+	s.Require().NotNil(blocked)
+
+	healthy, err := watcher.RegisterConsumer(
+		s.ctx, "test-healthy-consumer",
+		watcher.WithEntityTypeFilter(common.ControllerEntityType),
+		watcher.WithOperationTypeFilter(common.UpdateOperation))
+	s.Require().NoError(err)
+	s.Require().NotNil(healthy)
+	consumeEvents(healthy)
+
+	// Send more events than the producer buffer, the consumer hand-off
+	// buffer and the messages buffer combined can absorb, so delivery to the
+	// wedged consumer must spill into its dispatch queue.
+	const eventCount = 1000
+
+	expected := make([]common.ChangePayload, eventCount)
+	for i := range eventCount {
+		expected[i] = common.ChangePayload{
+			EntityType: common.ControllerEntityType,
+			Operation:  common.UpdateOperation,
+			Payload:    fmt.Sprintf("event-%d", i),
+		}
+	}
+
+	// The producer must never be throttled by the wedged consumer. With a
+	// blocking dispatch design, a full consumer buffer costs up to 1 second
+	// per event, so a flood this size would take many minutes; enqueue-based
+	// dispatch completes in milliseconds. The generous bound only guards
+	// against regressions, not scheduling jitter.
+	start := time.Now()
+	for i := range eventCount {
+		s.Require().NoError(producer.Notify(expected[i]))
+	}
+	s.Require().Less(time.Since(start), 10*time.Second, "producer was throttled by a blocked consumer")
+
+	// The healthy consumer receives every event, in emission order, while
+	// the other consumer is still wedged.
+	for i := range eventCount {
+		received := waitForPayload(healthy.Watch(), 1*time.Second)
+		s.Require().NotNil(received, "healthy consumer did not receive event %d", i)
+		s.Require().Equal(expected[i], *received)
+	}
+
+	// The wedged consumer lost nothing: once it starts reading, every event
+	// is there, in order.
+	for i := range eventCount {
+		received := waitForPayload(blocked.Watch(), 1*time.Second)
+		s.Require().NotNil(received, "blocked consumer lost event %d", i)
+		s.Require().Equal(expected[i], *received)
+	}
+}
+
 func TestWatcherTestSuite(t *testing.T) {
 	// Watcher tests
 	watcherSuite := &WatcherTestSuite{

--- a/locking/locking.go
+++ b/locking/locking.go
@@ -33,7 +33,12 @@ func TryLock(key, identifier string) (ok bool) {
 
 	_, filename, line, _ := runtime.Caller(1)
 	slog.Debug("attempting to try lock", "key", key, "identifier", identifier, "caller", fmt.Sprintf("%s:%d", filename, line))
-	defer slog.Debug("try lock returned", "key", key, "identifier", identifier, "locked", ok, "caller", fmt.Sprintf("%s:%d", filename, line))
+	// The deferred log must be a closure: deferring slog.Debug directly
+	// evaluates its arguments at defer time, which would always log the
+	// zero value of ok instead of the actual result.
+	defer func() {
+		slog.Debug("try lock returned", "key", key, "identifier", identifier, "locked", ok, "caller", fmt.Sprintf("%s:%d", filename, line))
+	}()
 
 	ok = locker.TryLock(key, identifier)
 	return ok

--- a/runner/agent.go
+++ b/runner/agent.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -9,6 +10,7 @@ import (
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	commonParams "github.com/cloudbase/garm-provider-common/params"
 	"github.com/cloudbase/garm/auth"
+	garmErrors "github.com/cloudbase/garm/internal/errors"
 	"github.com/cloudbase/garm/params"
 )
 
@@ -60,7 +62,18 @@ func (r *Runner) SetInstanceToPendingDelete(ctx context.Context) error {
 		Status: commonParams.InstancePendingDelete,
 	}
 
-	if _, err := r.store.ForceUpdateInstance(r.ctx, instance.ID, updateParams); err != nil {
+	// Currently, the only place this is called from is the agent websocket
+	// worker. So when an agent notices that the runner finished, it sends a
+	// status update back to GARM, letting it know that the runner can be reaped.
+	// But if a runner is already being deleted, there is no reason to forcefully
+	// transition it to pending_delete.
+	//
+	// Force transitions should be done only for recovery cases.
+	if _, err := r.store.UpdateInstance(r.ctx, instance.ID, updateParams); err != nil {
+		var te *runnerErrors.InstanceTransitionError
+		if errors.As(err, &te) && garmErrors.InstanceIsBeingDeleted(te.From) {
+			return nil
+		}
 		return fmt.Errorf("failed to set instance to pending_delete: %w", err)
 	}
 	return nil

--- a/runner/pool/pool.go
+++ b/runner/pool/pool.go
@@ -124,14 +124,15 @@ func NewEntityPoolManager(ctx context.Context, entity params.ForgeEntity, instan
 		controllerInfo:      controllerInfo,
 		instanceTokenGetter: instanceTokenGetter,
 
-		store:       store,
-		providers:   providers,
-		quit:        make(chan struct{}),
-		jobs:        make(map[int64]params.Job),
-		checkedJobs: make(map[int64]time.Time),
-		wg:          wg,
-		backoff:     backoff,
-		consumer:    consumer,
+		store:          store,
+		providers:      providers,
+		quit:           make(chan struct{}),
+		jobs:           make(map[int64]params.Job),
+		checkedJobs:    make(map[int64]time.Time),
+		clientUpdateCh: make(chan struct{}, 1),
+		wg:             wg,
+		backoff:        backoff,
+		consumer:       consumer,
 	}
 	return repo, nil
 }
@@ -153,6 +154,11 @@ type basePoolManager struct {
 	tools       []commonParams.RunnerApplicationDownload
 	quit        chan struct{}
 	checkedJobs map[int64]time.Time
+
+	// clientUpdateCh signals clientUpdaterLoop to rebuild the forge client
+	// after a credentials change. Capacity 1; the rebuild reads the newest
+	// entity state when it runs, so triggers coalesce.
+	clientUpdateCh chan struct{}
 
 	managerIsRunning   bool
 	managerErrorReason string
@@ -1902,6 +1908,7 @@ func (r *basePoolManager) Start() error {
 	}()
 
 	go r.runWatcher()
+	go r.clientUpdaterLoop()
 	go func() {
 		select {
 		case <-r.quit:

--- a/runner/pool/watcher.go
+++ b/runner/pool/watcher.go
@@ -15,7 +15,9 @@
 package pool
 
 import (
+	"context"
 	"log/slog"
+	"time"
 
 	runnerErrors "github.com/cloudbase/garm-provider-common/errors"
 	"github.com/cloudbase/garm/database/common"
@@ -23,6 +25,12 @@ import (
 	runnerCommon "github.com/cloudbase/garm/runner/common"
 	ghClient "github.com/cloudbase/garm/util/github"
 )
+
+// clientCreateTimeout bounds the creation of a new forge client after a
+// credentials change. Creating a client issues a RateLimit probe (and, for
+// github apps, may fetch an installation token); without a deadline a stalled
+// forge endpoint would hang the rebuild indefinitely.
+const clientCreateTimeout = 30 * time.Second
 
 // entityGetter is implemented by all github entities (repositories, organizations and enterprises)
 type entityGetter interface {
@@ -37,17 +45,63 @@ func (r *basePoolManager) handleControllerUpdateEvent(controllerInfo params.Cont
 	r.controllerInfo = controllerInfo
 }
 
-func (r *basePoolManager) getClientOrStub() runnerCommon.GithubClient {
-	var err error
+// triggerClientUpdate queues a forge client rebuild for clientUpdaterLoop
+// without blocking the caller. The channel carries no payload — the rebuild
+// snapshots r.entity when it runs — so a full channel already guarantees a
+// future rebuild will see the newest credentials.
+func (r *basePoolManager) triggerClientUpdate() {
+	select {
+	case r.clientUpdateCh <- struct{}{}:
+	default:
+	}
+}
+
+// clientUpdaterLoop is the only goroutine that rebuilds the forge client.
+// Client creation involves network I/O and must never run on the watcher
+// drain goroutine or under r.mux: a stalled forge endpoint would park event
+// processing (and, via the watcher fan-out, global event dispatch) for the
+// duration of the call.
+func (r *basePoolManager) clientUpdaterLoop() {
+	for {
+		select {
+		case <-r.quit:
+			return
+		case <-r.ctx.Done():
+			return
+		case <-r.clientUpdateCh:
+			r.updateClient()
+		}
+	}
+}
+
+// updateClient rebuilds the forge client from the current entity credentials
+// and refreshes the cached tools. If a newer credentials update lands while a
+// rebuild is in flight, its queued trigger makes the loop run again with the
+// fresh state, so a stale install is always overwritten.
+func (r *basePoolManager) updateClient() {
+	r.mux.Lock()
+	entity := r.entity
+	r.mux.Unlock()
+
+	ctx, cancel := context.WithTimeout(r.ctx, clientCreateTimeout)
+	defer cancel()
+
 	var ghc runnerCommon.GithubClient
-	ghc, err = ghClient.Client(r.ctx, r.entity)
+	ghc, err := ghClient.Client(ctx, entity)
 	if err != nil {
 		slog.WarnContext(r.ctx, "failed to create github client", "error", err)
 		ghc = &stubGithubClient{
 			err: runnerErrors.NewUnauthorizedError("failed to create github client; please update credentials"),
 		}
 	}
-	return ghc
+
+	r.mux.Lock()
+	r.ghcli = ghc
+	r.mux.Unlock()
+
+	if err := r.updateTools(); err != nil {
+		slog.ErrorContext(r.ctx, "failed to update tools", "error", err)
+	}
 }
 
 func (r *basePoolManager) handleEntityUpdate(entity params.ForgeEntity, operation common.OperationType) {
@@ -69,16 +123,6 @@ func (r *basePoolManager) handleEntityUpdate(entity params.ForgeEntity, operatio
 	}
 
 	credentialsUpdate := r.entity.Credentials.GetID() != entity.Credentials.GetID()
-	defer func() {
-		slog.DebugContext(r.ctx, "deferred tools update", "credentials_update", credentialsUpdate)
-		if !credentialsUpdate {
-			return
-		}
-		slog.DebugContext(r.ctx, "updating tools", "entity", entity.ID)
-		if err := r.updateTools(); err != nil {
-			slog.ErrorContext(r.ctx, "failed to update tools", "error", err)
-		}
-	}()
 
 	slog.DebugContext(r.ctx, "updating entity", "entity", entity.ID)
 	r.mux.Lock()
@@ -90,8 +134,8 @@ func (r *basePoolManager) handleEntityUpdate(entity params.ForgeEntity, operatio
 			filters := composeWatcherFilters(r.entity)
 			r.consumer.SetFilters(filters)
 		}
-		slog.DebugContext(r.ctx, "credentials update", "entity", entity.ID)
-		r.ghcli = r.getClientOrStub()
+		slog.DebugContext(r.ctx, "credentials update; queueing client rebuild", "entity", entity.ID)
+		r.triggerClientUpdate()
 	}
 	r.mux.Unlock()
 	slog.DebugContext(r.ctx, "lock released", "entity", entity.ID)
@@ -109,27 +153,16 @@ func (r *basePoolManager) handleCredentialsUpdate(credentials params.ForgeCreden
 	// test-repo. This function would handle situations where "org_pat" is updated.
 	// If "test-repo" is updated with new credentials, that event is handled above in
 	// handleEntityUpdate.
-	shouldUpdateTools := r.entity.Credentials.GetID() == credentials.GetID()
-	defer func() {
-		if !shouldUpdateTools {
-			return
-		}
-		slog.DebugContext(r.ctx, "deferred tools update", "credentials_id", credentials.GetID())
-		if err := r.updateTools(); err != nil {
-			slog.ErrorContext(r.ctx, "failed to update tools", "error", err)
-		}
-	}()
-
 	r.mux.Lock()
-	if !shouldUpdateTools {
+	if r.entity.Credentials.GetID() != credentials.GetID() {
 		slog.InfoContext(r.ctx, "credential ID mismatch; stale event?", "credentials_id", credentials.GetID())
 		r.mux.Unlock()
 		return
 	}
 
-	slog.DebugContext(r.ctx, "updating credentials", "credentials_id", credentials.GetID())
+	slog.DebugContext(r.ctx, "updating credentials; queueing client rebuild", "credentials_id", credentials.GetID())
 	r.entity.Credentials = credentials
-	r.ghcli = r.getClientOrStub()
+	r.triggerClientUpdate()
 	r.mux.Unlock()
 }
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -1040,7 +1040,7 @@ func (r *Runner) DispatchWorkflowJob(hookTargetType, signature string, forgeType
 	}
 
 	if err := poolManager.HandleWorkflowJob(job); err != nil {
-		slog.ErrorContext(r.ctx, "failed to handle workflow job", "error", err)
+		slog.WarnContext(r.ctx, "failed to handle workflow job", "error", err)
 		return fmt.Errorf("error handling workflow job: %w", err)
 	}
 

--- a/util/github/client.go
+++ b/util/github/client.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v84/github"
 
@@ -707,13 +708,23 @@ func Client(ctx context.Context, entity params.ForgeEntity) (common.GithubClient
 		entity:         entity,
 	}
 
-	limits, err := cli.RateLimit(ctx)
-	if err == nil && limits != nil {
-		core := limits.GetCore()
-		if core != nil {
-			cli.recordLimits(*core)
+	// The rate limit probe is advisory. It must not block construction. An
+	// unreachable forge would stall every caller for the full dial timeout
+	// (30s), and at startup pool managers are constructed serially, so one
+	// dead endpoint would hold up tools for every entity. Probe in the
+	// background, detached from the caller's context lifetime (callers may
+	// cancel right after construction) but bounded by its own deadline.
+	go func() {
+		probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		limits, err := cli.RateLimit(probeCtx)
+		if err == nil && limits != nil {
+			core := limits.GetCore()
+			if core != nil {
+				cli.recordLimits(*core)
+			}
 		}
-	}
+	}()
 
 	return cli, nil
 }

--- a/util/github/scalesets/client.go
+++ b/util/github/scalesets/client.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/google/go-github/v84/github"
 
@@ -28,16 +29,39 @@ import (
 	"github.com/cloudbase/garm/runner/common"
 )
 
+// requestTimeout bounds every scale set API call except the message queue
+// long poll. Without it, a stalled endpoint hangs the request
+// forever. Some call sites (like listener teardown) cannot rely on their
+// context for cancellation.
+const requestTimeout = 60 * time.Second
+
+// longPollRequestTimeout bounds a single message queue long poll. The broker
+// holds the request open for up to ~50 seconds before returning an empty
+// response, so this must stay comfortably above that; it only exists so a
+// black-holed connection cannot hold a poll open forever. GitHub's own
+// runner polls the same broker with a 100 second client timeout.
+const longPollRequestTimeout = 100 * time.Second
+
 func NewClient(cli common.GithubClient) (*ScaleSetClient, error) {
+	// Use separate clients for regular API calls against the scaleset API
+	// and the scaleset long poll message queue. The long poll is held open
+	// by the broker for up to ~50 seconds by design, so it cannot share the
+	// tighter timeout every other call gets.
 	return &ScaleSetClient{
-		ghCli:      cli,
-		httpClient: &http.Client{},
+		ghCli: cli,
+		httpClient: &http.Client{
+			Timeout: requestTimeout,
+		},
+		longPollClient: &http.Client{
+			Timeout: longPollRequestTimeout,
+		},
 	}, nil
 }
 
 type ScaleSetClient struct {
-	ghCli      common.GithubClient
-	httpClient *http.Client
+	ghCli          common.GithubClient
+	httpClient     *http.Client
+	longPollClient *http.Client
 
 	// scale sets are aparently available through the same security
 	// contex that a normal runner would use. We connect to the same
@@ -82,11 +106,23 @@ func (s *ScaleSetClient) GetGithubClient() (common.GithubClient, error) {
 }
 
 func (s *ScaleSetClient) Do(req *http.Request) (*http.Response, error) {
-	if s.httpClient == nil {
+	return s.doWithClient(s.httpClient, req)
+}
+
+// DoLongPoll dispatches a request through the long poll client, whose
+// timeout accommodates the broker holding the request open for up to ~50
+// seconds. Use it only for requests that legitimately block server side
+// (the message queue long poll).
+func (s *ScaleSetClient) DoLongPoll(req *http.Request) (*http.Response, error) {
+	return s.doWithClient(s.longPollClient, req)
+}
+
+func (s *ScaleSetClient) doWithClient(client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
 		return nil, fmt.Errorf("http client is not initialized")
 	}
 
-	resp, err := s.httpClient.Do(req) //nolint:gosec // G704 - URL is constructed from GitHub API endpoints
+	resp, err := client.Do(req) //nolint:gosec // G704 - URL is constructed from GitHub API endpoints
 	if err != nil {
 		return nil, fmt.Errorf("failed to dispatch HTTP request: %w", err)
 	}

--- a/util/github/scalesets/message_sessions.go
+++ b/util/github/scalesets/message_sessions.go
@@ -198,7 +198,10 @@ func (m *MessageSession) GetMessage(ctx context.Context, lastMessageID int64, ma
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", m.session.MessageQueueAccessToken))
 	req.Header.Set(maxCapacityHeader, fmt.Sprintf("%d", maxCapacity))
 
-	resp, err := m.ssCli.Do(req)
+	// This is a long poll: the broker holds the request open until a message
+	// arrives or it times the poll out server side, so it must bypass the
+	// bounded client.
+	resp, err := m.ssCli.DoLongPoll(req)
 	if err != nil {
 		return params.RunnerScaleSetMessage{}, fmt.Errorf("request to %s failed: %w", req.URL.String(), err)
 	}

--- a/util/github/scalesets/scalesets.go
+++ b/util/github/scalesets/scalesets.go
@@ -212,8 +212,7 @@ func (s *ScaleSetClient) DeleteRunnerScaleSet(ctx context.Context, runnerScaleSe
 		return err
 	}
 
-	client := &http.Client{}
-	resp, err := client.Do(req) //nolint:gosec // G704 - URL is constructed from GitHub API endpoints
+	resp, err := s.Do(req)
 	if err != nil {
 		return err
 	}

--- a/websocket/client.go
+++ b/websocket/client.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -93,7 +94,7 @@ type Client struct {
 
 	messageHandler HandleWebsocketMessage
 
-	running bool
+	running atomic.Bool
 	done    chan struct{}
 }
 
@@ -102,19 +103,20 @@ func (c *Client) ID() string {
 }
 
 func (c *Client) Stop() {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-
-	if !c.running {
+	if !c.running.CompareAndSwap(true, false) {
 		return
 	}
 
-	c.running = false
 	c.consumer.Close()
+	close(c.done)
+	// Best effort close frame. The peer may already be gone and writeMessage
+	// may block until the write deadline expires, so this must not run under
+	// any lock that Write() needs.
+	// NOTE: c.send is intentionally never closed. Write() checks running
+	// without holding a lock, so closing the channel here could panic a
+	// concurrent send. clientWriter exits via c.done instead.
 	c.writeMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	c.conn.Close()
-	close(c.send)
-	close(c.done)
 }
 
 func (c *Client) Done() <-chan struct{} {
@@ -128,10 +130,10 @@ func (c *Client) SetMessageHandler(handler HandleWebsocketMessage) {
 }
 
 func (c *Client) Start() error {
-	c.mux.Lock()
-	defer c.mux.Unlock()
+	if !c.running.CompareAndSwap(false, true) {
+		return nil
+	}
 
-	c.running = true
 	c.send = make(chan []byte, clientSendBuffer)
 	c.done = make(chan struct{})
 
@@ -143,10 +145,7 @@ func (c *Client) Start() error {
 }
 
 func (c *Client) Write(msg []byte) (int, error) {
-	c.mux.Lock()
-	defer c.mux.Unlock()
-
-	if !c.running {
+	if !c.running.Load() {
 		return 0, fmt.Errorf("websocket client is stopped")
 	}
 
@@ -227,17 +226,10 @@ func (c *Client) clientWriter() {
 	}()
 	for {
 		select {
-		case message, ok := <-c.send:
-			if !ok {
-				// The hub closed the channel.
-				if err := c.writeMessage(websocket.CloseMessage, []byte{}); err != nil {
-					if IsErrorOfInterest(err) {
-						slog.With(slog.Any("error", err)).Error("failed to write message")
-					}
-				}
-				return
-			}
-
+		case <-c.done:
+			// Stop() sends the close frame; nothing more to do here.
+			return
+		case message := <-c.send:
 			if err := c.writeMessage(websocket.TextMessage, message); err != nil {
 				if IsErrorOfInterest(err) {
 					slog.With(slog.Any("error", err)).Error("error sending message")

--- a/workers/cache/garm_agent.go
+++ b/workers/cache/garm_agent.go
@@ -504,24 +504,27 @@ func (g *garmToolsSync) downloadAssetToTempFile(asset garmUtil.GitHubReleaseAsse
 
 // triggerReconcile queues a reconcile for reconcileLoop without ever
 // blocking the caller. If a trigger is already queued, it is replaced so the
-// newest controller info wins; the reconcile that eventually runs always
-// sees the latest requested state.
+// newest controller info wins. Every select has a default, so this is
+// non-blocking by construction, regardless of how many goroutines call it.
 func (g *garmToolsSync) triggerReconcile(ctrlInfo params.ControllerInfo) {
-	for {
-		select {
-		case g.reconcileCh <- ctrlInfo:
-			return
-		default:
-		}
-		// Channel full: evict the stale queued trigger and retry. The loop
-		// handles reconcileLoop consuming the queued value between our evict
-		// and our send.
-		select {
-		case <-g.reconcileCh:
-		default:
-			// previous stale message was already consumed by the reconcile
-			// loop, after we checked in the previous select.
-		}
+	select {
+	case g.reconcileCh <- ctrlInfo:
+		return
+	default:
+	}
+	// Channel full: evict the stale queued trigger and try once more.
+	select {
+	case <-g.reconcileCh:
+	default:
+		// The queued trigger was already consumed by the reconcile loop
+		// after our first send failed.
+	}
+	select {
+	case g.reconcileCh <- ctrlInfo:
+	default:
+		// Another trigger was queued between our evict and this send. That
+		// can only happen with a concurrent caller; a reconcile will run
+		// either way, and the hourly tick covers any state it missed.
 	}
 }
 

--- a/workers/cache/garm_agent.go
+++ b/workers/cache/garm_agent.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -36,13 +37,37 @@ import (
 // releaseIndexTTL is how long a cached release index is considered fresh.
 const releaseIndexTTL = 24 * time.Hour
 
+// indexFetchTimeout bounds the entire fetch of a release index or single
+// release document. These are small JSON payloads; anything taking longer
+// than this is a stuck endpoint.
+const indexFetchTimeout = 60 * time.Second
+
+// syncHTTPClient is used for all release index fetches and asset downloads.
+// There is deliberately no overall client timeout — asset downloads can be
+// large, but connection establishment, TLS and time-to-first-response-byte
+// are all bounded so a dead endpoint cannot hang a request indefinitely.
+var syncHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+	},
+}
+
 // fetchURL retrieves the body of a URL, bounded by the request context.
 func fetchURL(ctx context.Context, uri string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, indexFetchTimeout)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %s: %w", uri, err)
 	}
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- the releases URL is an operator-configured controller setting
+	resp, err := syncHTTPClient.Do(req) // #nosec G704 -- the releases URL is an operator-configured controller setting
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch URL %s: %w", uri, err)
 	}
@@ -100,6 +125,12 @@ type garmToolsSync struct {
 	consumerID       string
 	consumer         common.Consumer
 
+	// reconcileCh feeds reconcileLoop, the only goroutine that runs
+	// reconcile. Capacity 1 with latest-wins semantics: a trigger arriving
+	// while a reconcile is in flight replaces any queued one, so bursts
+	// coalesce into a single run with the newest controller info.
+	reconcileCh chan params.ControllerInfo
+
 	mux     sync.Mutex
 	running bool
 	quit    chan struct{}
@@ -115,6 +146,7 @@ func newGARMToolsSync(ctx context.Context, store common.Store, garmToolsManager 
 		store:            store,
 		consumerID:       consumerID,
 		garmToolsManager: garmToolsManager,
+		reconcileCh:      make(chan params.ControllerInfo, 1),
 		quit:             make(chan struct{}),
 	}
 }
@@ -139,6 +171,7 @@ func (g *garmToolsSync) Start() error {
 	g.running = true
 	g.quit = make(chan struct{})
 	go g.loop()
+	go g.reconcileLoop()
 	return nil
 }
 
@@ -441,7 +474,7 @@ func (g *garmToolsSync) downloadAssetToTempFile(asset garmUtil.GitHubReleaseAsse
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for asset %s: %w", asset.Name, err)
 	}
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- asset URLs come from the operator-configured releases endpoint
+	resp, err := syncHTTPClient.Do(req) // #nosec G704 -- asset URLs come from the operator-configured releases endpoint
 	if err != nil {
 		return nil, fmt.Errorf("failed to download asset %s: %w", asset.Name, err)
 	}
@@ -469,6 +502,48 @@ func (g *garmToolsSync) downloadAssetToTempFile(asset garmUtil.GitHubReleaseAsse
 	return tmpFile, nil
 }
 
+// triggerReconcile queues a reconcile for reconcileLoop without ever
+// blocking the caller. If a trigger is already queued, it is replaced so the
+// newest controller info wins; the reconcile that eventually runs always
+// sees the latest requested state.
+func (g *garmToolsSync) triggerReconcile(ctrlInfo params.ControllerInfo) {
+	for {
+		select {
+		case g.reconcileCh <- ctrlInfo:
+			return
+		default:
+		}
+		// Channel full: evict the stale queued trigger and retry. The loop
+		// handles reconcileLoop consuming the queued value between our evict
+		// and our send.
+		select {
+		case <-g.reconcileCh:
+		default:
+			// previous stale message was already consumed by the reconcile
+			// loop, after we checked in the previous select.
+		}
+	}
+}
+
+// reconcileLoop is the only goroutine that runs reconcile. Reconciliation
+// involves network fetches and asset downloads which can take a long time;
+// running it here keeps loop() draining the watcher consumer, and a single
+// runner guarantees no two reconciles overlap.
+func (g *garmToolsSync) reconcileLoop() {
+	for {
+		select {
+		case <-g.quit:
+			return
+		case <-g.ctx.Done():
+			return
+		case ctrlInfo := <-g.reconcileCh:
+			if err := g.reconcile(ctrlInfo); err != nil {
+				slog.ErrorContext(g.ctx, "failed to sync GARM agent tools", "error", err)
+			}
+		}
+	}
+}
+
 func (g *garmToolsSync) loop() {
 	defer g.Stop()
 
@@ -490,14 +565,10 @@ func (g *garmToolsSync) loop() {
 			return
 		case <-initialSync.C:
 			// Initial sync after startup delay (fires once)
-			if err := g.reconcile(garmCache.ControllerInfo()); err != nil {
-				slog.ErrorContext(g.ctx, "failed initial sync of GARM agent tools", "error", err)
-			}
+			g.triggerReconcile(garmCache.ControllerInfo())
 			initialSync.Stop()
 		case <-ticker.C:
-			if err := g.reconcile(garmCache.ControllerInfo()); err != nil {
-				slog.ErrorContext(g.ctx, "failed to sync GARM agent tools", "error", err)
-			}
+			g.triggerReconcile(garmCache.ControllerInfo())
 		case event, ok := <-g.consumer.Watch():
 			if !ok {
 				slog.InfoContext(g.ctx, "consumer channel closed")
@@ -512,10 +583,10 @@ func (g *garmToolsSync) loop() {
 	}
 }
 
-// handleControllerUpdate reconciles after controller info changes. It runs
-// even when tools sync is disabled: the cached release index feeds the
-// metadata service (which serves upstream URLs when sync is off), so changes
-// to the releases URL or the pinned version must be reflected in it.
+// handleControllerUpdate queues a reconcile after controller info changes.
+// It runs even when tools sync is disabled: the cached release index feeds
+// the metadata service (which serves upstream URLs when sync is off), so
+// changes to the releases URL or the pinned version must be reflected in it.
 // Reconciliation converges to a no-op when everything already matches.
 //
 // The event payload is used directly rather than the in-memory cache: the
@@ -527,7 +598,5 @@ func (g *garmToolsSync) handleControllerUpdate(event common.ChangePayload) {
 		slog.WarnContext(g.ctx, "invalid payload type for controller update event")
 		return
 	}
-	if err := g.reconcile(ctrlInfo); err != nil {
-		slog.ErrorContext(g.ctx, "failed to sync GARM agent tools after controller update", "error", err)
-	}
+	g.triggerReconcile(ctrlInfo)
 }

--- a/workers/entity/controller.go
+++ b/workers/entity/controller.go
@@ -229,7 +229,11 @@ func (c *Controller) loop() {
 	defer c.Stop()
 	for {
 		select {
-		case payload := <-c.consumer.Watch():
+		case payload, ok := <-c.consumer.Watch():
+			if !ok {
+				slog.InfoContext(c.ctx, "consumer channel closed")
+				return
+			}
 			slog.DebugContext(c.ctx, "received payload, queuing for processing")
 			select {
 			case c.eventQueue.In() <- payload:

--- a/workers/entity/worker.go
+++ b/workers/entity/worker.go
@@ -179,6 +179,7 @@ func (w *Worker) consolidateRunnerState() error {
 	}
 	// Client is scoped to the current entity. Only runners in a repo/org/enterprise
 	// will be listed.
+	listedAt := time.Now()
 	runners, err := scaleSetCli.ListAllRunners(w.ctx)
 	if err != nil {
 		return fmt.Errorf("listing runners: %w", err)
@@ -201,7 +202,7 @@ func (w *Worker) consolidateRunnerState() error {
 	g, ctx := errgroup.WithContext(w.ctx)
 	g.Go(func() error {
 		slog.DebugContext(ctx, "consolidating scale set runners", "entity", w.Entity.String(), "runners", runners)
-		if err := w.scaleSetController.ConsolidateRunnerState(byScaleSetID); err != nil {
+		if err := w.scaleSetController.ConsolidateRunnerState(listedAt, byScaleSetID); err != nil {
 			return fmt.Errorf("consolidating runners for scale set: %w", err)
 		}
 		return nil

--- a/workers/entity/worker.go
+++ b/workers/entity/worker.go
@@ -261,7 +261,11 @@ func (w *Worker) loop() {
 	defer w.Stop()
 	for {
 		select {
-		case payload := <-w.consumer.Watch():
+		case payload, ok := <-w.consumer.Watch():
+			if !ok {
+				slog.InfoContext(w.ctx, "consumer channel closed")
+				return
+			}
 			slog.DebugContext(w.ctx, "received payload, queuing for processing")
 			select {
 			case w.eventQueue.In() <- payload:

--- a/workers/provider/instance_manager.go
+++ b/workers/provider/instance_manager.go
@@ -275,7 +275,7 @@ func (i *instanceManager) handleCreateInstanceInProvider(instance params.Instanc
 		}
 	}
 
-	updated, err := i.helper.updateArgsFromProviderInstance(instance.Name, providerInstance)
+	updated, err := i.helper.persistProviderInstanceState(instance.Name, providerInstance)
 	if err != nil {
 		return fmt.Errorf("updating instance args: %w", err)
 	}

--- a/workers/provider/instance_manager.go
+++ b/workers/provider/instance_manager.go
@@ -26,6 +26,7 @@ import (
 	commonParams "github.com/cloudbase/garm-provider-common/params"
 	"github.com/cloudbase/garm/cache"
 	dbCommon "github.com/cloudbase/garm/database/common"
+	garmErrors "github.com/cloudbase/garm/internal/errors"
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
 	garmUtil "github.com/cloudbase/garm/util"
@@ -364,10 +365,20 @@ func (i *instanceManager) consolidateState() error {
 		}
 	case commonParams.InstanceRunning:
 		// Nothing to do. The provider finished creating the instance.
-	case commonParams.InstancePendingDelete, commonParams.InstancePendingForceDelete:
+	case commonParams.InstancePendingDelete, commonParams.InstancePendingForceDelete, commonParams.InstanceDeleting:
 		// Remove or force remove the runner. When force remove is specified, we ignore
 		// IaaS errors.
-		if instance.Status == commonParams.InstancePendingDelete {
+		//
+		// InstanceDeleting is an interrupted delete. Restarts are recovered
+		// by the scale set worker on startup (deleting is moved back to
+		// pending_delete), but the manager can strand its own cached state
+		// here at runtime: a pass that errors out after setting deleting but
+		// before recording the outcome (the deleted write or the
+		// pending_delete requeue fails transiently) leaves the cached status
+		// at deleting with no further event to move it. Providers report a
+		// missing instance as success, so re-driving the delete is safe.
+		forced := instance.Status == commonParams.InstancePendingForceDelete
+		if !forced {
 			// invoke backoff sleep. We only do this for non forced removals,
 			// as force delete will always return, regardless of whether or not
 			// the remove operation succeeded in the provider. A user may decide
@@ -378,7 +389,6 @@ func (i *instanceManager) consolidateState() error {
 			}
 		}
 
-		prevStatus := instance.Status
 		if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstanceDeleting, nil, true); err != nil {
 			if errors.Is(err, runnerErrors.ErrNotFound) {
 				return nil
@@ -387,8 +397,8 @@ func (i *instanceManager) consolidateState() error {
 		}
 
 		if err := i.handleDeleteInstanceInProvider(instance); err != nil {
-			slog.ErrorContext(i.ctx, "deleting instance in provider", "error", err, "forced", prevStatus == commonParams.InstancePendingForceDelete)
-			if prevStatus == commonParams.InstancePendingDelete {
+			slog.ErrorContext(i.ctx, "deleting instance in provider", "error", err, "forced", forced)
+			if !forced {
 				i.incrementBackOff()
 				if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstancePendingDelete, []byte(err.Error()), true); err != nil {
 					return fmt.Errorf("setting instance status to error: %w", err)
@@ -398,7 +408,19 @@ func (i *instanceManager) consolidateState() error {
 			}
 		}
 		if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstanceDeleted, nil, false); err != nil {
-			if !errors.Is(err, runnerErrors.ErrNotFound) {
+			var te *runnerErrors.InstanceTransitionError
+			switch {
+			case errors.Is(err, runnerErrors.ErrNotFound):
+				// The record is already gone.
+			case errors.As(err, &te) && garmErrors.InstanceIsBeingDeleted(te.From):
+				// The row moved elsewhere on the deletion lane while the
+				// provider delete ran. The provider resource is confirmed
+				// gone at this point, so force the terminal state instead of
+				// re-driving a delete against nothing.
+				if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstanceDeleted, nil, true); err != nil && !errors.Is(err, runnerErrors.ErrNotFound) {
+					return fmt.Errorf("setting instance status to deleted: %w", err)
+				}
+			default:
 				return fmt.Errorf("setting instance status to deleted: %w", err)
 			}
 		}

--- a/workers/provider/instance_manager.go
+++ b/workers/provider/instance_manager.go
@@ -72,9 +72,16 @@ type instanceManager struct {
 	deleteBackoff time.Duration
 
 	updates chan dbCommon.ChangePayload
-	mux     sync.Mutex
-	running atomic.Bool
-	quit    chan struct{}
+	// mux guards i.instance. It must only be held for short reads and writes,
+	// never across provider calls.
+	mux sync.Mutex
+	// consolidateMux serializes consolidateState() invocations. Provider
+	// operations can take minutes and cannot be canceled once started, so
+	// consolidation works on a snapshot of the instance while updates continue
+	// to land on i.instance under mux.
+	consolidateMux sync.Mutex
+	running        atomic.Bool
+	quit           chan struct{}
 }
 
 func (i *instanceManager) Start() error {
@@ -272,7 +279,16 @@ func (i *instanceManager) handleCreateInstanceInProvider(instance params.Instanc
 	if err != nil {
 		return fmt.Errorf("updating instance args: %w", err)
 	}
-	i.instance = updated
+
+	// A newer update (like a user requested force delete) may have landed on
+	// i.instance while the provider call was in flight. Overwriting it would
+	// revert state that no future event will re-deliver, so only store the
+	// result of our own DB write if the cached instance is not newer.
+	i.mux.Lock()
+	if !i.instance.UpdatedAt.After(updated.UpdatedAt) {
+		i.instance = updated
+	}
+	i.mux.Unlock()
 
 	return nil
 }
@@ -319,22 +335,30 @@ func (i *instanceManager) handleDeleteInstanceInProvider(instance params.Instanc
 }
 
 func (i *instanceManager) consolidateState() error {
-	i.mux.Lock()
-	defer i.mux.Unlock()
+	i.consolidateMux.Lock()
+	defer i.consolidateMux.Unlock()
 
 	if !i.running.Load() {
 		return nil
 	}
 
-	switch i.instance.Status {
+	// Work on a snapshot of the instance. Provider operations can take a long
+	// time and cannot be canceled once started, and holding i.mux for the
+	// duration of this function would block handleUpdate(). Updates land on
+	// i.instance while we run; the next consolidation acts on the new state.
+	i.mux.Lock()
+	instance := i.instance
+	i.mux.Unlock()
+
+	switch instance.Status {
 	case commonParams.InstancePendingCreate:
 		// kick off the creation process
-		if err := i.helper.SetInstanceStatus(i.instance.Name, commonParams.InstanceCreating, nil, false); err != nil {
+		if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstanceCreating, nil, false); err != nil {
 			return fmt.Errorf("setting instance status to creating: %w", err)
 		}
-		if err := i.handleCreateInstanceInProvider(i.instance); err != nil {
+		if err := i.handleCreateInstanceInProvider(instance); err != nil {
 			slog.ErrorContext(i.ctx, "creating instance in provider", "error", err)
-			if err := i.helper.SetInstanceStatus(i.instance.Name, commonParams.InstanceError, []byte(err.Error()), true); err != nil {
+			if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstanceError, []byte(err.Error()), true); err != nil {
 				return fmt.Errorf("setting instance status to error: %w", err)
 			}
 		}
@@ -343,7 +367,7 @@ func (i *instanceManager) consolidateState() error {
 	case commonParams.InstancePendingDelete, commonParams.InstancePendingForceDelete:
 		// Remove or force remove the runner. When force remove is specified, we ignore
 		// IaaS errors.
-		if i.instance.Status == commonParams.InstancePendingDelete {
+		if instance.Status == commonParams.InstancePendingDelete {
 			// invoke backoff sleep. We only do this for non forced removals,
 			// as force delete will always return, regardless of whether or not
 			// the remove operation succeeded in the provider. A user may decide
@@ -354,26 +378,26 @@ func (i *instanceManager) consolidateState() error {
 			}
 		}
 
-		prevStatus := i.instance.Status
-		if err := i.helper.SetInstanceStatus(i.instance.Name, commonParams.InstanceDeleting, nil, true); err != nil {
+		prevStatus := instance.Status
+		if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstanceDeleting, nil, true); err != nil {
 			if errors.Is(err, runnerErrors.ErrNotFound) {
 				return nil
 			}
 			return fmt.Errorf("setting instance status to deleting: %w", err)
 		}
 
-		if err := i.handleDeleteInstanceInProvider(i.instance); err != nil {
-			slog.ErrorContext(i.ctx, "deleting instance in provider", "error", err, "forced", i.instance.Status == commonParams.InstancePendingForceDelete)
+		if err := i.handleDeleteInstanceInProvider(instance); err != nil {
+			slog.ErrorContext(i.ctx, "deleting instance in provider", "error", err, "forced", prevStatus == commonParams.InstancePendingForceDelete)
 			if prevStatus == commonParams.InstancePendingDelete {
 				i.incrementBackOff()
-				if err := i.helper.SetInstanceStatus(i.instance.Name, commonParams.InstancePendingDelete, []byte(err.Error()), true); err != nil {
+				if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstancePendingDelete, []byte(err.Error()), true); err != nil {
 					return fmt.Errorf("setting instance status to error: %w", err)
 				}
 
 				return fmt.Errorf("error removing instance. Will retry: %w", err)
 			}
 		}
-		if err := i.helper.SetInstanceStatus(i.instance.Name, commonParams.InstanceDeleted, nil, false); err != nil {
+		if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstanceDeleted, nil, false); err != nil {
 			if !errors.Is(err, runnerErrors.ErrNotFound) {
 				return fmt.Errorf("setting instance status to deleted: %w", err)
 			}
@@ -382,7 +406,7 @@ func (i *instanceManager) consolidateState() error {
 	case commonParams.InstanceError:
 		// Instance is in error state. We wait for next status or potentially retry
 		// spawning the instance with a backoff timer.
-		if err := i.helper.SetInstanceStatus(i.instance.Name, commonParams.InstancePendingDelete, nil, true); err != nil {
+		if err := i.helper.SetInstanceStatus(instance.Name, commonParams.InstancePendingDelete, nil, true); err != nil {
 			return fmt.Errorf("setting instance status to error: %w", err)
 		}
 	case commonParams.InstanceDeleted:

--- a/workers/provider/provider.go
+++ b/workers/provider/provider.go
@@ -357,7 +357,11 @@ func (p *Provider) loop() {
 	defer p.Stop()
 	for {
 		select {
-		case payload := <-p.consumer.Watch():
+		case payload, ok := <-p.consumer.Watch():
+			if !ok {
+				slog.InfoContext(p.ctx, "consumer channel closed")
+				return
+			}
 			slog.DebugContext(p.ctx, "received payload, queuing for processing")
 			select {
 			case p.eventQueue.In() <- payload:

--- a/workers/provider/provider_helper.go
+++ b/workers/provider/provider_helper.go
@@ -24,12 +24,15 @@ import (
 type providerHelper interface {
 	SetInstanceStatus(instanceName string, status commonParams.InstanceStatus, providerFault []byte, force bool) error
 	InstanceTokenGetter() auth.InstanceTokenGetter
-	updateArgsFromProviderInstance(instanceName string, providerInstance commonParams.ProviderInstance) (params.Instance, error)
+	persistProviderInstanceState(instanceName string, providerInstance commonParams.ProviderInstance) (params.Instance, error)
 	GetControllerInfo() (params.ControllerInfo, error)
 	GetGithubEntity(entity params.ForgeEntity) (params.ForgeEntity, error)
 }
 
-func (p *Provider) updateArgsFromProviderInstance(instanceName string, providerInstance commonParams.ProviderInstance) (params.Instance, error) {
+// persistProviderInstanceState commits the provider-reported state of an
+// instance (provider ID, addresses, OS info, status) to the store and returns
+// the full post-commit instance as re-read from the database.
+func (p *Provider) persistProviderInstanceState(instanceName string, providerInstance commonParams.ProviderInstance) (params.Instance, error) {
 	updateParams := params.UpdateInstanceParams{
 		ProviderID:    providerInstance.ProviderID,
 		OSName:        providerInstance.OSName,

--- a/workers/scaleset/controller.go
+++ b/workers/scaleset/controller.go
@@ -194,7 +194,7 @@ func (c *Controller) Stop() error {
 // The scale set worker will then need to cross check the existing runners in Github with the sate
 // in the database. Any inconsistencies will be reconciliated. This cleans up any manually removed
 // runners in either github or the providers.
-func (c *Controller) ConsolidateRunnerState(byScaleSetID map[int][]params.RunnerReference) error {
+func (c *Controller) ConsolidateRunnerState(listedAt time.Time, byScaleSetID map[int][]params.RunnerReference) error {
 	g, ctx := errgroup.WithContext(c.ctx)
 	c.ScaleSets.Range(func(_, value any) bool {
 		set := value.(*scaleSet)
@@ -204,7 +204,7 @@ func (c *Controller) ConsolidateRunnerState(byScaleSetID map[int][]params.Runner
 		runners := byScaleSetID[set.scaleSet.ScaleSetID]
 		g.Go(func() error {
 			slog.DebugContext(ctx, "consolidating runners for scale set", "scale_set_id", set.scaleSet.ScaleSetID, "runners", runners)
-			if err := set.worker.consolidateRunnerState(runners); err != nil {
+			if err := set.worker.consolidateRunnerState(listedAt, runners); err != nil {
 				return fmt.Errorf("consolidating runners for scale set %d: %w", set.scaleSet.ScaleSetID, err)
 			}
 			return nil

--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cloudbase/garm/params"
 	"github.com/cloudbase/garm/runner/common"
 	garmUtil "github.com/cloudbase/garm/util"
+	workersCommon "github.com/cloudbase/garm/workers/common"
 )
 
 func NewWorker(ctx context.Context, store dbCommon.Store, scaleSet params.ScaleSet, provider common.Provider) (*Worker, error) {
@@ -86,6 +87,13 @@ type Worker struct {
 	legacyPoolIDDrained bool
 
 	consumer dbCommon.Consumer
+
+	// eventQueue decouples the watcher consumer from event handling. The
+	// drain loop forwards events into it without blocking, and a single
+	// Process goroutine applies them strictly in delivery order — handlers
+	// mutate w.runners, so out-of-order application would leave stale or
+	// ghost entries.
+	eventQueue *workersCommon.UnboundedChan[dbCommon.ChangePayload]
 
 	listener *scaleSetListener
 
@@ -338,8 +346,10 @@ func (w *Worker) Start() (err error) {
 	w.consumer = consumer
 	w.running = true
 	w.quit = make(chan struct{})
+	w.eventQueue = workersCommon.NewUnboundedChan[dbCommon.ChangePayload](w.ctx, w.quit)
 
 	slog.DebugContext(w.ctx, "starting scale set worker loops", "scale_set", w.consumerID)
+	go w.eventQueue.Process(w.handleEvent)
 	go w.loop()
 	go w.keepListenerAlive()
 	go w.handleAutoScale()
@@ -781,7 +791,16 @@ func (w *Worker) loop() {
 				slog.InfoContext(w.ctx, "consumer channel closed")
 				return
 			}
-			go w.handleEvent(event)
+			// Forward to the serialized event queue. The queue router always
+			// accepts, so this cannot block the watcher drain; events are
+			// then applied in order by the Process goroutine.
+			select {
+			case w.eventQueue.In() <- event:
+			case <-w.quit:
+				return
+			case <-w.ctx.Done():
+				return
+			}
 		case <-w.ctx.Done():
 			slog.DebugContext(w.ctx, "context done")
 			return
@@ -974,7 +993,20 @@ func (w *Worker) handleScaleDown() {
 		slog.ErrorContext(w.ctx, "error getting scale set client", "error", err)
 		return
 	}
+	// Runners already on their way out satisfy part of the delta before any
+	// new victim is picked. Counting them during the removal loop instead
+	// would make the outcome depend on map iteration order: an idle runner
+	// could be removed while a runner already being deleted would have
+	// covered the delta.
 	removed := 0
+	for _, runner := range w.runners {
+		switch runner.Status {
+		case commonParams.InstancePendingDelete, commonParams.InstancePendingForceDelete,
+			commonParams.InstanceDeleting:
+			removed++
+		}
+	}
+
 	for _, runner := range w.runners {
 		slog.InfoContext(w.ctx, "considering runners for removal", "delta", delta, "removed", removed)
 		if removed >= delta {
@@ -982,9 +1014,14 @@ func (w *Worker) handleScaleDown() {
 		}
 		switch runner.Status {
 		case commonParams.InstanceRunning:
-			switch runner.RunnerStatus {
-			case params.RunnerTerminated, params.RunnerActive:
-				slog.DebugContext(w.ctx, "runner is not in a valid state; skipping", "runner_name", runner.Name, "runner_status", runner.RunnerStatus)
+			if runner.RunnerStatus != params.RunnerIdle {
+				// Scale down removes idle capacity, nothing else. A runner
+				// that is still bootstrapping (pending/installing) is moments
+				// away from being useful and will be picked up as idle on a
+				// later pass if the delta persists; stuck bootstraps are the
+				// reaper's job. Active and terminated runners are not
+				// removable capacity at all.
+				slog.DebugContext(w.ctx, "runner is not idle; skipping", "runner_name", runner.Name, "runner_status", runner.RunnerStatus)
 				continue
 			}
 			locked := locking.TryLock(runner.Name, w.consumerID)
@@ -1038,8 +1075,12 @@ func (w *Worker) handleScaleDown() {
 			locking.Unlock(runner.Name, false)
 			removed++
 		case commonParams.InstancePendingDelete, commonParams.InstancePendingForceDelete,
-			commonParams.InstanceDeleting, commonParams.InstanceDeleted:
-			removed++
+			commonParams.InstanceDeleting:
+			// Already counted against the delta before the loop.
+			continue
+		case commonParams.InstanceDeleted:
+			// Provider resource is gone and the record is excluded from
+			// runnerCount(); it is not part of the delta.
 			continue
 		default:
 			slog.WarnContext(w.ctx, "runner is not in a valid state; skipping", "runner_name", runner.Name, "runner_status", runner.Status)
@@ -1058,8 +1099,20 @@ func (w *Worker) targetRunners() int {
 	return int(targetRunners)
 }
 
+// runnerCount returns the number of runners that still occupy capacity in
+// the provider. Runners on their way out (pending_delete, deleting) are
+// still physically present in the IaaS, so they count; only runners whose
+// provider resource is confirmed gone (deleted) are excluded — those records
+// merely await database cleanup.
 func (w *Worker) runnerCount() int {
-	return len(w.runners)
+	count := 0
+	for _, runner := range w.runners {
+		if runner.Status == commonParams.InstanceDeleted {
+			continue
+		}
+		count++
+	}
+	return count
 }
 
 func (w *Worker) handleAutoScale() {

--- a/workers/scaleset/scaleset.go
+++ b/workers/scaleset/scaleset.go
@@ -459,7 +459,7 @@ func (w *Worker) reapTimedOutRunners(runners map[string]params.RunnerReference) 
 	return unlockFn, nil
 }
 
-func (w *Worker) consolidateRunnerState(runners []params.RunnerReference) error {
+func (w *Worker) consolidateRunnerState(listedAt time.Time, runners []params.RunnerReference) error {
 	w.mux.Lock()
 	defer w.mux.Unlock()
 
@@ -519,6 +519,14 @@ func (w *Worker) consolidateRunnerState(runners []params.RunnerReference) error 
 		}
 
 		if _, ok := ghRunnersByName[name]; !ok {
+			// The github listing is a snapshot taken before this function ran.
+			// A runner registered around or after that moment is absent from it
+			// by construction, not because it's gone. Don't judge a runner
+			// younger than the evidence. A future pass will see it.
+			if runner.CreatedAt.After(listedAt.Add(-time.Minute)) {
+				slog.DebugContext(w.ctx, "runner is newer than the github runner listing; skipping", "runner_name", name)
+				continue
+			}
 			if ok := locking.TryLock(name, w.consumerID); !ok {
 				slog.DebugContext(w.ctx, "runner is locked; skipping", "runner_name", name)
 				continue
@@ -532,6 +540,16 @@ func (w *Worker) consolidateRunnerState(runners []params.RunnerReference) error 
 			// as the transition commits. Cross-worker coordination is done by the
 			// status state machine, not by these locks.
 			defer locking.Unlock(name, false)
+
+			// Aditional guard against accidentally removing a runner that has picked
+			// up a job, but that got past our safety checks (ex: GH api didn't return it
+			// when we listed)
+			if err := scaleSetCli.RemoveRunner(w.ctx, runner.AgentID); err != nil {
+				if !errors.Is(err, runnerErrors.ErrNotFound) {
+					slog.ErrorContext(w.ctx, "error removing runner from github; skipping", "runner_name", name, "error", err)
+					continue
+				}
+			}
 
 			slog.InfoContext(w.ctx, "runner does not exist in github; removing from provider", "runner_name", name)
 			instance, err := w.setRunnerDBStatus(runner.Name, commonParams.InstancePendingDelete)

--- a/workers/scaleset/scaleset_listener.go
+++ b/workers/scaleset/scaleset_listener.go
@@ -73,8 +73,10 @@ func (l *scaleSetListener) Start() error {
 		return nil
 	}
 
-	listenCtx, listenCancelFunc := context.WithCancel(context.Background())
-	listenCtx = garmUtil.CopySlogValuesToNewCtx(l.ctx, listenCtx)
+	// Deriving from the worker context keeps the slog values and means the
+	// long poll dies with the worker; the cancel func still allows stopping
+	// the listener independently, for restarts without a worker restart.
+	listenCtx, listenCancelFunc := context.WithCancel(l.ctx)
 	listenCtx = garmUtil.WithSlogContext(
 		listenCtx,
 		slog.Any("session_listener", l.scaleSetHelper.GetScaleSet().ID),
@@ -255,6 +257,9 @@ func (l *scaleSetListener) loop() {
 			return
 		default:
 			slog.DebugContext(l.ctx, "getting message", "last_message_id", l.lastMessageID, "max_runners", l.scaleSetHelper.GetScaleSet().MaxRunners)
+			// Each poll attempt is bounded by the long poll client's own
+			// timeout, sized for the broker's ~50s hold; the context only
+			// needs to carry cancellation.
 			msg, err := l.messageSession.GetMessage(
 				l.listenerCtx, l.lastMessageID, l.scaleSetHelper.GetScaleSet().MaxRunners)
 			if err != nil {

--- a/workers/websocket/agent/agent.go
+++ b/workers/websocket/agent/agent.go
@@ -168,12 +168,25 @@ func (a *Agent) Start() error {
 }
 
 func (a *Agent) Stop() error {
-	a.mux.Lock()
-	defer a.mux.Unlock()
-
-	if !a.running.Load() {
+	if !a.running.CompareAndSwap(true, false) {
 		return nil
 	}
+
+	// Detach from the event pipeline first: closing the consumer removes it
+	// from the watcher's dispatch fan-out immediately, and closing a.done
+	// makes loop() exit so it stops contending for a.mux. Both are fast and
+	// must happen before the slow peer writes below, otherwise a dead client
+	// could keep this consumer in the fan-out (stalling global dispatch) for
+	// the duration of the teardown.
+	if a.consumer != nil {
+		a.consumer.Close()
+	}
+	close(a.done)
+
+	// The remaining teardown performs websocket writes that can each block up
+	// to the write deadline against a dead peer. It deliberately holds no
+	// mutex: loop() is already exiting, and nothing else may be stalled behind
+	// these writes.
 	slog.InfoContext(a.ctx, "removing sessions")
 	a.shellSessions.Range(func(_, val any) bool {
 		sess := val.(*ClientSession)
@@ -182,13 +195,10 @@ func (a *Agent) Stop() error {
 		return true
 	})
 
-	a.running.Store(false)
 	slog.InfoContext(a.ctx, "sending websocket close message")
 	a.writeMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	slog.InfoContext(a.ctx, "closing connection")
 	a.conn.Close()
-	slog.InfoContext(a.ctx, "closing done channel")
-	close(a.done)
 	return nil
 }
 
@@ -277,9 +287,24 @@ func (a *Agent) handleShellReady(agentMsg messaging.AgentMessage, raw []byte) er
 	}
 	session := val.(*ClientSession)
 	if err := session.Write(raw); err != nil {
+		a.dropDeadSession(session, err)
 		return fmt.Errorf("failed to write message: %w", err)
 	}
 	return nil
+}
+
+// dropDeadSession tears down a shell session whose client is unreachable.
+// Keeping it around would stall every subsequent write to that client on the
+// 10s write deadline; the user can open a new shell to reconnect. The client
+// connection already has a write error recorded, so the close frames sent by
+// RemoveClientSession return immediately rather than blocking.
+func (a *Agent) dropDeadSession(session *ClientSession, cause error) {
+	slog.WarnContext(a.ctx, "dropping unreachable shell session",
+		"session_id", session.sessionID, "error", cause)
+	if err := a.RemoveClientSession(session.sessionID); err != nil {
+		slog.ErrorContext(a.ctx, "failed to remove dead shell session",
+			"session_id", session.sessionID, "error", err)
+	}
 }
 
 func (a *Agent) handleShellExit(agentMsg messaging.AgentMessage) error {
@@ -309,6 +334,7 @@ func (a *Agent) handleShellData(agentMsg messaging.AgentMessage, raw []byte) err
 	}
 	session := val.(*ClientSession)
 	if err := session.Write(raw); err != nil {
+		a.dropDeadSession(session, err)
 		return fmt.Errorf("failed to write message: %w", err)
 	}
 	return nil
@@ -391,7 +417,11 @@ func (a *Agent) loop() {
 			return
 		case <-a.done:
 			return
-		case payload := <-a.consumer.Watch():
+		case payload, ok := <-a.consumer.Watch():
+			if !ok {
+				// Consumer was closed (Stop closes it). Exit the loop.
+				return
+			}
 			instance, ok := payload.Payload.(params.Instance)
 			if !ok {
 				continue


### PR DESCRIPTION
This PR addresses a bunch of issues in the scaleset workers, HTTP clients, database watcher and a few other places. Overall the changes include:

* Serialize watcher events both during the emission and the consumption of the events. We should never parallelize messages we send or receive from a channel unless they are completely independent from one another.
* The watcher consumers and producers must be non blocking.
* all HTTP clients should have proper timeouts to prevent situations where one HTTP call hangs everything 

These changes (some inspired from some of the PRs) should fix issues recently reported in:

  * https://github.com/cloudbase/garm/pull/855
  * https://github.com/cloudbase/garm/pull/850
  * https://github.com/cloudbase/garm/pull/823
  * https://github.com/cloudbase/garm/issues/860
  * https://github.com/cloudbase/garm/issues/854
  * https://github.com/cloudbase/garm/issues/834