### PR TITLE
Add PAT expiration metrics and alerts

### DIFF
--- a/contrib/grafana/alerts/garm-alerts.yaml
+++ b/contrib/grafana/alerts/garm-alerts.yaml
@@ -49,6 +49,26 @@ groups:
           summary: "Scale set {{ $labels.id }} listener is stale"
           description: "No successful long-poll cycle in over 5 minutes. This scale set has silently stopped receiving scaling signals from GitHub."
 
+      - alert: GarmForgeAPIErrorRate
+        expr: |
+          sum(increase(garm_github_errors_total[15m]))
+            / clamp_min(sum(increase(garm_github_operations_total[15m])), 1) > 0.2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GARM forge API calls are failing"
+          description: "More than 20% of forge API calls failed over the last 15 minutes. Check credential validity (expired PAT?) and endpoint reachability; `sum by (operation) (increase(garm_github_errors_total[15m]))` names the failing operations."
+
+      - alert: GarmCredentialExpiringSoon
+        expr: |
+          (garm_github_token_expiration_timestamp - time()) < 14 * 24 * 3600
+        labels:
+          severity: warning
+        annotations:
+          summary: "Credential {{ $labels.credential_name }} expires soon"
+          description: "The token for {{ $labels.credential_name }} on {{ $labels.endpoint }} expires in less than 14 days (or has already expired). Rotate it before API calls start failing."
+
       - alert: GarmRateLimitNearExhaustion
         expr: |
           garm_github_rate_limit_remaining

--- a/contrib/grafana/dashboards/garm-control-plane.json
+++ b/contrib/grafana/dashboards/garm-control-plane.json
@@ -969,6 +969,121 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 314,
+      "type": "table",
+      "title": "Credential token expiry",
+      "description": "Time until each credential's token expires, as reported by the forge. Only PATs with an expiration set appear here; app credentials rotate automatically. Rotate anything yellow or red before API calls start failing.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 604800
+              },
+              {
+                "color": "green",
+                "value": 2592000
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Time until expiry"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false
+        },
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Time until expiry"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "garm_github_token_expiration_timestamp - time()",
+          "legendFormat": "{{credential_name}}",
+          "refId": "A",
+          "format": "table",
+          "instant": true,
+          "range": false
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "credential_id": true
+            },
+            "renameByName": {}
+          }
+        }
+      ]
     }
   ]
 }

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -237,8 +237,11 @@ A spike in `bootstrap_timeout` typically means a broken image, network or userda
 | `garm_github_rate_limit_remaining` | Gauge | `credential_name`, `credential_id`, `endpoint` |
 | `garm_github_rate_limit_used` | Gauge | `credential_name`, `credential_id`, `endpoint` |
 | `garm_github_rate_limit_reset_timestamp` | Gauge | `credential_name`, `credential_id`, `endpoint` |
+| `garm_github_token_expiration_timestamp` | Gauge | `credential_name`, `credential_id`, `endpoint` |
 
 The `scope` label is `Repository`, `Organization`, or `Enterprise`. The `operation` label takes one of the values listed below.
+
+`garm_github_token_expiration_timestamp` records when a credential's token expires, as reported by the forge on API responses. It is only emitted for PAT credentials whose token has an expiration set; app credentials are excluded since their tokens rotate automatically. Alert on `(garm_github_token_expiration_timestamp - time()) < 14 * 24 * 3600` to rotate tokens before an expiry turns into a wall of API errors.
 
 **GitHub client operations** (hooks, runners, registration tokens):
 

--- a/metrics/github.go
+++ b/metrics/github.go
@@ -59,4 +59,16 @@ var (
 		Name:      "rate_limit_reset_timestamp",
 		Help:      "Unix timestamp when the rate limit resets",
 	}, []string{"credential_name", "credential_id", "endpoint"})
+
+	// GithubTokenExpirationTimestamp records when a credential's token
+	// expires, as reported by the forge. PATs created without an expiration
+	// and forges that do not report one emit no series; app credentials are
+	// excluded since their tokens rotate automatically. Alert on this before
+	// the expiry turns into a wall of API errors.
+	GithubTokenExpirationTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsGithubSubsystem,
+		Name:      "token_expiration_timestamp",
+		Help:      "Unix timestamp when the credential's token expires, if reported by the forge",
+	}, []string{"credential_name", "credential_id", "endpoint"})
 )

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -84,6 +84,7 @@ func RegisterMetrics() error {
 		GithubRateLimitRemaining,
 		GithubRateLimitUsed,
 		GithubRateLimitResetTimestamp,
+		GithubTokenExpirationTimestamp,
 		JobStatus,
 		// webhook metrics
 		WebhooksReceived,

--- a/runner/common/mocks/RateLimitClient.go
+++ b/runner/common/mocks/RateLimitClient.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	context "context"
+	time "time"
 
 	github "github.com/google/go-github/v84/github"
 	mock "github.com/stretchr/testify/mock"
@@ -23,7 +24,7 @@ func (_m *RateLimitClient) EXPECT() *RateLimitClient_Expecter {
 }
 
 // RateLimit provides a mock function with given fields: ctx
-func (_m *RateLimitClient) RateLimit(ctx context.Context) (*github.RateLimits, error) {
+func (_m *RateLimitClient) RateLimit(ctx context.Context) (*github.RateLimits, time.Time, error) {
 	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
@@ -31,8 +32,9 @@ func (_m *RateLimitClient) RateLimit(ctx context.Context) (*github.RateLimits, e
 	}
 
 	var r0 *github.RateLimits
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (*github.RateLimits, error)); ok {
+	var r1 time.Time
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context) (*github.RateLimits, time.Time, error)); ok {
 		return rf(ctx)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context) *github.RateLimits); ok {
@@ -43,13 +45,21 @@ func (_m *RateLimitClient) RateLimit(ctx context.Context) (*github.RateLimits, e
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context) time.Time); ok {
 		r1 = rf(ctx)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(time.Time)
+		}
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = rf(ctx)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // RateLimitClient_RateLimit_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RateLimit'
@@ -70,12 +80,12 @@ func (_c *RateLimitClient_RateLimit_Call) Run(run func(ctx context.Context)) *Ra
 	return _c
 }
 
-func (_c *RateLimitClient_RateLimit_Call) Return(_a0 *github.RateLimits, _a1 error) *RateLimitClient_RateLimit_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *RateLimitClient_RateLimit_Call) Return(_a0 *github.RateLimits, _a1 time.Time, _a2 error) *RateLimitClient_RateLimit_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *RateLimitClient_RateLimit_Call) RunAndReturn(run func(context.Context) (*github.RateLimits, error)) *RateLimitClient_RateLimit_Call {
+func (_c *RateLimitClient_RateLimit_Call) RunAndReturn(run func(context.Context) (*github.RateLimits, time.Time, error)) *RateLimitClient_RateLimit_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/runner/common/util.go
+++ b/runner/common/util.go
@@ -17,6 +17,7 @@ package common
 import (
 	"context"
 	"net/url"
+	"time"
 
 	"github.com/google/go-github/v84/github"
 
@@ -44,7 +45,12 @@ type GithubEntityOperations interface {
 }
 
 type RateLimitClient interface {
-	RateLimit(ctx context.Context) (*github.RateLimits, error)
+	// RateLimit returns the current rate limits for the credential the
+	// client was created with. The returned time is the token expiration
+	// reported by the forge on the response; it is the zero value when the
+	// token was created without an expiration or the forge does not report
+	// one.
+	RateLimit(ctx context.Context) (*github.RateLimits, time.Time, error)
 }
 
 // GithubClient that describes the minimum list of functions we need to interact with github.

--- a/util/github/client.go
+++ b/util/github/client.go
@@ -573,6 +573,10 @@ func (g *githubClient) GetEntityJITConfig(ctx context.Context, instance string, 
 }
 
 func (g *githubClient) RateLimit(ctx context.Context) (*github.RateLimits, error) {
+	metrics.GithubOperationCount.WithLabelValues(
+		"GetRateLimit",        // label: operation
+		g.entity.LabelScope(), // label: scope
+	).Inc()
 	limits, resp, err := g.rateLimit.Get(ctx)
 	if err != nil {
 		metrics.GithubOperationFailedCount.WithLabelValues(
@@ -639,12 +643,41 @@ func NewRateLimitClient(ctx context.Context, credentials params.ForgeCredentials
 	if err != nil {
 		return nil, fmt.Errorf("error fetching github client: %w", err)
 	}
-	cli := &githubClient{
-		rateLimit: ghClient.RateLimit,
-		cli:       ghClient,
+	cli := &rateLimitClient{
+		cli: ghClient,
 	}
 
 	return cli, nil
+}
+
+// rateLimitClient is a minimal, credential-scoped client used to query rate
+// limits outside the context of any entity. Besides the limits themselves,
+// it surfaces the token expiration the forge reports on the response.
+type rateLimitClient struct {
+	cli *github.Client
+}
+
+func (r *rateLimitClient) RateLimit(ctx context.Context) (*github.RateLimits, time.Time, error) {
+	metrics.GithubOperationCount.WithLabelValues(
+		"GetRateLimit", // label: operation
+		"",             // label: scope
+	).Inc()
+	limits, resp, err := r.cli.RateLimit.Get(ctx)
+	if err != nil {
+		metrics.GithubOperationFailedCount.WithLabelValues(
+			"GetRateLimit", // label: operation
+			"",             // label: scope
+		).Inc()
+	}
+	if err := parseError(resp, err); err != nil {
+		return nil, time.Time{}, fmt.Errorf("getting rate limit: %w", err)
+	}
+
+	var tokenExpiration time.Time
+	if resp != nil {
+		tokenExpiration = resp.TokenExpiration.Time
+	}
+	return limits, tokenExpiration, nil
 }
 
 func withGiteaURLs(client *github.Client, apiBaseURL string) (*github.Client, error) {

--- a/workers/cache/cache.go
+++ b/workers/cache/cache.go
@@ -639,7 +639,7 @@ func (w *Worker) rateLimitLoop() {
 					slog.With(slog.Any("error", err)).ErrorContext(w.ctx, "failed to create rate limit client")
 					continue
 				}
-				rateLimit, err := rateCli.RateLimit(w.ctx)
+				rateLimit, tokenExpiration, err := rateCli.RateLimit(w.ctx)
 				if err != nil {
 					slog.With(slog.Any("error", err)).ErrorContext(w.ctx, "failed to get rate limit")
 					continue
@@ -672,6 +672,13 @@ func (w *Worker) rateLimitLoop() {
 					metrics.GithubRateLimitRemaining.With(labels).Set(float64(core.Remaining))
 					metrics.GithubRateLimitUsed.With(labels).Set(float64(core.Used))
 					metrics.GithubRateLimitResetTimestamp.With(labels).Set(float64(core.Reset.Unix()))
+
+					// Only PATs have a meaningful expiration to alert on.
+					// App credentials rotate their tokens automatically, so
+					// an expiration there is expected and not actionable.
+					if creds.AuthType == params.ForgeAuthTypePAT && !tokenExpiration.IsZero() {
+						metrics.GithubTokenExpirationTimestamp.With(labels).Set(float64(tokenExpiration.Unix()))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Extend the rate limit client to report PAT expiration time. Add metrics that records that expiration time and add an alert that triggers when a PAT will expire in 14 days or less.

Also, add alert for forge API errors.