### PR TITLE
Add endpoint label to forge client ops

### DIFF
--- a/contrib/grafana/alerts/garm-alerts.yaml
+++ b/contrib/grafana/alerts/garm-alerts.yaml
@@ -51,14 +51,14 @@ groups:
 
       - alert: GarmForgeAPIErrorRate
         expr: |
-          sum(increase(garm_github_errors_total[15m]))
-            / clamp_min(sum(increase(garm_github_operations_total[15m])), 1) > 0.2
+          sum by (endpoint) (increase(garm_github_errors_total[15m]))
+            / clamp_min(sum by (endpoint) (increase(garm_github_operations_total[15m])), 1) > 0.2
         for: 10m
         labels:
           severity: warning
         annotations:
-          summary: "GARM forge API calls are failing"
-          description: "More than 20% of forge API calls failed over the last 15 minutes. Check credential validity (expired PAT?) and endpoint reachability; `sum by (operation) (increase(garm_github_errors_total[15m]))` names the failing operations."
+          summary: "GARM API calls to forge endpoint {{ $labels.endpoint }} are failing"
+          description: "More than 20% of API calls to forge endpoint {{ $labels.endpoint }} failed over the last 15 minutes. Check credential validity (expired PAT?) and endpoint reachability; `sum by (operation) (increase(garm_github_errors_total{endpoint=\"{{ $labels.endpoint }}\"}[15m]))` names the failing operations."
 
       - alert: GarmCredentialExpiringSoon
         expr: |

--- a/contrib/grafana/dashboards/garm-control-plane.json
+++ b/contrib/grafana/dashboards/garm-control-plane.json
@@ -601,8 +601,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation) (rate(garm_github_operations_total[$__rate_interval]))",
-          "legendFormat": "{{operation}}",
+          "expr": "sum by (endpoint, operation) (rate(garm_github_operations_total[$__rate_interval]))",
+          "legendFormat": "{{endpoint}} \u00b7 {{operation}}",
           "refId": "A"
         }
       ]
@@ -673,8 +673,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (operation) (rate(garm_github_errors_total[$__rate_interval]))",
-          "legendFormat": "{{operation}}",
+          "expr": "sum by (endpoint, operation) (rate(garm_github_errors_total[$__rate_interval]))",
+          "legendFormat": "{{endpoint}} \u00b7 {{operation}}",
           "refId": "A"
         }
       ]

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -231,8 +231,8 @@ A spike in `bootstrap_timeout` typically means a broken image, network or userda
 
 | Metric | Type | Labels |
 | -------- | ------ | -------- |
-| `garm_github_operations_total` | Counter | `operation`, `scope` |
-| `garm_github_errors_total` | Counter | `operation`, `scope` |
+| `garm_github_operations_total` | Counter | `operation`, `scope`, `endpoint` |
+| `garm_github_errors_total` | Counter | `operation`, `scope`, `endpoint` |
 | `garm_github_rate_limit_limit` | Gauge | `credential_name`, `credential_id`, `endpoint` |
 | `garm_github_rate_limit_remaining` | Gauge | `credential_name`, `credential_id`, `endpoint` |
 | `garm_github_rate_limit_used` | Gauge | `credential_name`, `credential_id`, `endpoint` |
@@ -240,6 +240,8 @@ A spike in `bootstrap_timeout` typically means a broken image, network or userda
 | `garm_github_token_expiration_timestamp` | Gauge | `credential_name`, `credential_id`, `endpoint` |
 
 The `scope` label is `Repository`, `Organization`, or `Enterprise`. The `operation` label takes one of the values listed below.
+
+Despite the `github` in their names (kept for backwards compatibility), these metrics cover **all** forge API traffic — GitHub, GHES, Gitea and Forgejo alike. The `endpoint` label carries the name of the endpoint the credential belongs to (for example `github.com` or the name you gave your Gitea endpoint), so error rates can be attributed to a specific forge: `sum by (endpoint) (rate(garm_github_errors_total[5m]))`.
 
 `garm_github_token_expiration_timestamp` records when a credential's token expires, as reported by the forge on API responses. It is only emitted for PAT credentials whose token has an expiration set; app credentials are excluded since their tokens rotate automatically. Alert on `(garm_github_token_expiration_timestamp - time()) < 14 * 24 * 3600` to rotate tokens before an expiry turns into a wall of API errors.
 
@@ -296,7 +298,7 @@ GARM's internal workers (caches, entity workers, scale set workers, the provider
 | `garm_watcher_notify_timeouts_total` | Counter | (none) |
 | `garm_watcher_consumer_queue_depth` | Gauge | `consumer` |
 
-`garm_watcher_events_total` counts every database change event published to the watcher — the change-feed heartbeat of the controller. The `entity_type` and `operation` labels match the values documented under [Database events](#database-events).
+`garm_watcher_events_total` counts every database change event published to the watcher (the change-feed heartbeat of the controller). The `entity_type` and `operation` labels match the values documented under [Database events](#database-events).
 
 `garm_watcher_notify_timeouts_total` counts change notifications that were **dropped** because the watcher could not accept them within the notify timeout. The database write itself succeeded, but downstream consumers never saw the event, so in-memory state may have diverged from the database. Any nonzero value is worth alerting on.
 

--- a/metrics/github.go
+++ b/metrics/github.go
@@ -21,15 +21,15 @@ var (
 		Namespace: metricsNamespace,
 		Subsystem: metricsGithubSubsystem,
 		Name:      "operations_total",
-		Help:      "Total number of github operation attempts",
-	}, []string{"operation", "scope"})
+		Help:      "Total number of forge (github, gitea) operation attempts",
+	}, []string{"operation", "scope", "endpoint"})
 
 	GithubOperationFailedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: metricsNamespace,
 		Subsystem: metricsGithubSubsystem,
 		Name:      "errors_total",
-		Help:      "Total number of failed github operation attempts",
-	}, []string{"operation", "scope"})
+		Help:      "Total number of failed forge (github, gitea) operation attempts",
+	}, []string{"operation", "scope", "endpoint"})
 
 	// GitHub rate limit metrics
 	GithubRateLimitLimit = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/util/github/client.go
+++ b/util/github/client.go
@@ -55,16 +55,10 @@ type githubClient struct {
 }
 
 func (g *githubClient) ListEntityHooks(ctx context.Context, opts *github.ListOptions) (ret []*github.Hook, response *github.Response, err error) {
-	metrics.GithubOperationCount.WithLabelValues(
-		"ListHooks",           // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("ListHooks")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"ListHooks",           // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("ListHooks")
 		}
 	}()
 	switch g.entity.EntityType {
@@ -85,16 +79,10 @@ func (g *githubClient) ListEntityHooks(ctx context.Context, opts *github.ListOpt
 }
 
 func (g *githubClient) GetEntityHook(ctx context.Context, id int64) (ret *github.Hook, err error) {
-	metrics.GithubOperationCount.WithLabelValues(
-		"GetHook",             // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("GetHook")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"GetHook",             // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("GetHook")
 		}
 	}()
 	var response *github.Response
@@ -117,16 +105,10 @@ func (g *githubClient) GetEntityHook(ctx context.Context, id int64) (ret *github
 }
 
 func (g *githubClient) createGithubEntityHook(ctx context.Context, hook *github.Hook) (ret *github.Hook, err error) {
-	metrics.GithubOperationCount.WithLabelValues(
-		"CreateHook",          // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("CreateHook")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"CreateHook",          // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("CreateHook")
 		}
 	}()
 	var response *github.Response
@@ -157,16 +139,10 @@ func (g *githubClient) CreateEntityHook(ctx context.Context, hook *github.Hook) 
 }
 
 func (g *githubClient) DeleteEntityHook(ctx context.Context, id int64) (ret *github.Response, err error) {
-	metrics.GithubOperationCount.WithLabelValues(
-		"DeleteHook",          // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("DeleteHook")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"DeleteHook",          // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("DeleteHook")
 		}
 	}()
 	switch g.entity.EntityType {
@@ -187,16 +163,10 @@ func (g *githubClient) DeleteEntityHook(ctx context.Context, id int64) (ret *git
 }
 
 func (g *githubClient) PingEntityHook(ctx context.Context, id int64) (ret *github.Response, err error) {
-	metrics.GithubOperationCount.WithLabelValues(
-		"PingHook",            // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("PingHook")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"PingHook",            // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("PingHook")
 		}
 	}()
 	switch g.entity.EntityType {
@@ -222,16 +192,10 @@ func (g *githubClient) ListEntityRunners(ctx context.Context, opts *github.ListR
 	var response *github.Response
 	var err error
 
-	metrics.GithubOperationCount.WithLabelValues(
-		"ListEntityRunners",   // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("ListEntityRunners")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"ListEntityRunners",   // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("ListEntityRunners")
 		}
 	}()
 
@@ -259,16 +223,10 @@ func (g *githubClient) ListEntityRunnerApplicationDownloads(ctx context.Context)
 	var response *github.Response
 	var err error
 
-	metrics.GithubOperationCount.WithLabelValues(
-		"ListEntityRunnerApplicationDownloads", // label: operation
-		g.entity.LabelScope(),                  // label: scope
-	).Inc()
+	g.recordOp("ListEntityRunnerApplicationDownloads")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"ListEntityRunnerApplicationDownloads", // label: operation
-				g.entity.LabelScope(),                  // label: scope
-			).Inc()
+			g.recordOpFailure("ListEntityRunnerApplicationDownloads")
 		}
 	}()
 
@@ -296,16 +254,10 @@ func (g *githubClient) GetWorkflowJobByID(ctx context.Context, owner, repo strin
 	var response *github.Response
 	var err error
 
-	metrics.GithubOperationCount.WithLabelValues(
-		"GetWorkflowJobByID",  // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("GetWorkflowJobByID")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"GetWorkflowJobByID",  // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("GetWorkflowJobByID")
 		}
 	}()
 
@@ -362,16 +314,10 @@ func (g *githubClient) RemoveEntityRunner(ctx context.Context, runnerID int64) e
 	var response *github.Response
 	var err error
 
-	metrics.GithubOperationCount.WithLabelValues(
-		"RemoveEntityRunner",  // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("RemoveEntityRunner")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"RemoveEntityRunner",  // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("RemoveEntityRunner")
 		}
 	}()
 
@@ -403,16 +349,10 @@ func (g *githubClient) CreateEntityRegistrationToken(ctx context.Context) (*gith
 	var response *github.Response
 	var err error
 
-	metrics.GithubOperationCount.WithLabelValues(
-		"CreateEntityRegistrationToken", // label: operation
-		g.entity.LabelScope(),           // label: scope
-	).Inc()
+	g.recordOp("CreateEntityRegistrationToken")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"CreateEntityRegistrationToken", // label: operation
-				g.entity.LabelScope(),           // label: scope
-			).Inc()
+			g.recordOpFailure("CreateEntityRegistrationToken")
 		}
 	}()
 
@@ -443,19 +383,13 @@ func (g *githubClient) getOrganizationRunnerGroupIDByName(ctx context.Context, e
 	}
 
 	for {
-		metrics.GithubOperationCount.WithLabelValues(
-			"ListOrganizationRunnerGroups", // label: operation
-			entity.LabelScope(),            // label: scope
-		).Inc()
+		g.recordOp("ListOrganizationRunnerGroups")
 		runnerGroups, ghResp, err := g.ListOrganizationRunnerGroups(ctx, entity.Owner, &opts)
 		if ghResp != nil {
 			g.recordLimits(ghResp.Rate)
 		}
 		if err := parseError(ghResp, err); err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"ListOrganizationRunnerGroups", // label: operation
-				entity.LabelScope(),            // label: scope
-			).Inc()
+			g.recordOpFailure("ListOrganizationRunnerGroups")
 			return 0, fmt.Errorf("error fetching runners: %w", err)
 		}
 
@@ -480,19 +414,13 @@ func (g *githubClient) getEnterpriseRunnerGroupIDByName(ctx context.Context, ent
 	}
 
 	for {
-		metrics.GithubOperationCount.WithLabelValues(
-			"ListRunnerGroups",  // label: operation
-			entity.LabelScope(), // label: scope
-		).Inc()
+		g.recordOp("ListRunnerGroups")
 		runnerGroups, ghResp, err := g.enterprise.ListRunnerGroups(ctx, entity.Owner, &opts)
 		if ghResp != nil {
 			g.recordLimits(ghResp.Rate)
 		}
 		if err := parseError(ghResp, err); err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"ListRunnerGroups",  // label: operation
-				entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("ListRunnerGroups")
 			return 0, fmt.Errorf("error fetching runners: %w", err)
 		}
 		for _, runnerGroup := range runnerGroups.RunnerGroups {
@@ -555,10 +483,7 @@ func (g *githubClient) GetEntityJITConfig(ctx context.Context, instance string, 
 		WorkFolder: github.Ptr("_work"),
 	}
 
-	metrics.GithubOperationCount.WithLabelValues(
-		"GetEntityJITConfig",  // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("GetEntityJITConfig")
 
 	var ret *github.JITRunnerConfig
 	var response *github.Response
@@ -575,10 +500,7 @@ func (g *githubClient) GetEntityJITConfig(ctx context.Context, instance string, 
 		g.recordLimits(response.Rate)
 	}
 	if err != nil {
-		metrics.GithubOperationFailedCount.WithLabelValues(
-			"GetEntityJITConfig",  // label: operation
-			g.entity.LabelScope(), // label: scope
-		).Inc()
+		g.recordOpFailure("GetEntityJITConfig")
 		return nil, nil, fmt.Errorf("failed to get JIT config: %w", parseError(response, err))
 	}
 
@@ -605,16 +527,10 @@ func (g *githubClient) GetEntityJITConfig(ctx context.Context, instance string, 
 }
 
 func (g *githubClient) RateLimit(ctx context.Context) (*github.RateLimits, error) {
-	metrics.GithubOperationCount.WithLabelValues(
-		"GetRateLimit",        // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("GetRateLimit")
 	limits, resp, err := g.rateLimit.Get(ctx)
 	if err != nil {
-		metrics.GithubOperationFailedCount.WithLabelValues(
-			"GetRateLimit",        // label: operation
-			g.entity.LabelScope(), // label: scope
-		).Inc()
+		g.recordOpFailure("GetRateLimit")
 	}
 	if err := parseError(resp, err); err != nil {
 		return nil, fmt.Errorf("getting rate limit: %w", err)
@@ -644,6 +560,33 @@ func (g *githubClient) LastRateLimit() (params.GithubRateLimit, bool) {
 	return g.limits, true
 }
 
+// endpointLabel returns the value used for the "endpoint" metrics label:
+// the name of the endpoint the client's credentials belong to, falling
+// back to the credentials base URL.
+func (g *githubClient) endpointLabel() string {
+	endpoint := g.entity.Credentials.Endpoint.Name
+	if endpoint == "" {
+		endpoint = g.entity.Credentials.BaseURL
+	}
+	return endpoint
+}
+
+func (g *githubClient) recordOp(operation string) {
+	metrics.GithubOperationCount.WithLabelValues(
+		operation,             // label: operation
+		g.entity.LabelScope(), // label: scope
+		g.endpointLabel(),     // label: endpoint
+	).Inc()
+}
+
+func (g *githubClient) recordOpFailure(operation string) {
+	metrics.GithubOperationFailedCount.WithLabelValues(
+		operation,             // label: operation
+		g.entity.LabelScope(), // label: scope
+		g.endpointLabel(),     // label: endpoint
+	).Inc()
+}
+
 func (g *githubClient) recordLimits(core github.Rate) {
 	// A zero limit means the forge did not send rate limit headers (Gitea,
 	// or GHES with rate limiting disabled). There is nothing to record, and
@@ -667,10 +610,7 @@ func (g *githubClient) recordLimits(core github.Rate) {
 	// Record Prometheus metrics
 	credID := fmt.Sprintf("%d", g.entity.Credentials.ID)
 	credName := g.entity.Credentials.Name
-	endpoint := g.entity.Credentials.Endpoint.Name
-	if endpoint == "" {
-		endpoint = g.entity.Credentials.BaseURL
-	}
+	endpoint := g.endpointLabel()
 
 	labels := map[string]string{
 		"credential_name": credName,
@@ -701,7 +641,8 @@ func NewRateLimitClient(ctx context.Context, credentials params.ForgeCredentials
 		return nil, fmt.Errorf("error fetching github client: %w", err)
 	}
 	cli := &rateLimitClient{
-		cli: ghClient,
+		cli:         ghClient,
+		credentials: credentials,
 	}
 
 	return cli, nil
@@ -711,19 +652,30 @@ func NewRateLimitClient(ctx context.Context, credentials params.ForgeCredentials
 // limits outside the context of any entity. Besides the limits themselves,
 // it surfaces the token expiration the forge reports on the response.
 type rateLimitClient struct {
-	cli *github.Client
+	cli         *github.Client
+	credentials params.ForgeCredentials
+}
+
+func (r *rateLimitClient) endpointLabel() string {
+	endpoint := r.credentials.Endpoint.Name
+	if endpoint == "" {
+		endpoint = r.credentials.BaseURL
+	}
+	return endpoint
 }
 
 func (r *rateLimitClient) RateLimit(ctx context.Context) (*github.RateLimits, time.Time, error) {
 	metrics.GithubOperationCount.WithLabelValues(
-		"GetRateLimit", // label: operation
-		"",             // label: scope
+		"GetRateLimit",    // label: operation
+		"",                // label: scope
+		r.endpointLabel(), // label: endpoint
 	).Inc()
 	limits, resp, err := r.cli.RateLimit.Get(ctx)
 	if err != nil {
 		metrics.GithubOperationFailedCount.WithLabelValues(
-			"GetRateLimit", // label: operation
-			"",             // label: scope
+			"GetRateLimit",    // label: operation
+			"",                // label: scope
+			r.endpointLabel(), // label: endpoint
 		).Inc()
 	}
 	if err := parseError(resp, err); err != nil {

--- a/util/github/gitea.go
+++ b/util/github/gitea.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-github/v84/github"
 
-	"github.com/cloudbase/garm/metrics"
 	"github.com/cloudbase/garm/params"
 )
 
@@ -221,16 +220,10 @@ func (g *githubClient) removeGiteaInstanceRunner(ctx context.Context, runnerID i
 }
 
 func (g *githubClient) createGiteaEntityHook(ctx context.Context, hook *github.Hook) (ret *github.Hook, err error) {
-	metrics.GithubOperationCount.WithLabelValues(
-		"CreateHook",          // label: operation
-		g.entity.LabelScope(), // label: scope
-	).Inc()
+	g.recordOp("CreateHook")
 	defer func() {
 		if err != nil {
-			metrics.GithubOperationFailedCount.WithLabelValues(
-				"CreateHook",          // label: operation
-				g.entity.LabelScope(), // label: scope
-			).Inc()
+			g.recordOpFailure("CreateHook")
 		}
 	}()
 	switch g.entity.EntityType {

--- a/util/github/scalesets/client.go
+++ b/util/github/scalesets/client.go
@@ -76,10 +76,20 @@ type ScaleSetClient struct {
 	mux sync.Mutex
 }
 
+func (s *ScaleSetClient) endpointLabel() string {
+	creds := s.ghCli.GetEntity().Credentials
+	endpoint := creds.Endpoint.Name
+	if endpoint == "" {
+		endpoint = creds.BaseURL
+	}
+	return endpoint
+}
+
 func (s *ScaleSetClient) recordOperation(operation string) {
 	metrics.GithubOperationCount.WithLabelValues(
 		operation,
 		s.ghCli.GetEntity().LabelScope(),
+		s.endpointLabel(),
 	).Inc()
 }
 
@@ -87,6 +97,7 @@ func (s *ScaleSetClient) recordFailedOperation(operation string) {
 	metrics.GithubOperationFailedCount.WithLabelValues(
 		operation,
 		s.ghCli.GetEntity().LabelScope(),
+		s.endpointLabel(),
 	).Inc()
 }
 


### PR DESCRIPTION
This change adds the endpoint name/base URL to the forge client ops.